### PR TITLE
Add show command and GET /api/memories for reading single memories

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -24,6 +24,7 @@ func init() {
 	rootCmd.AddCommand(importCmd)
 	rootCmd.AddCommand(dedupCmd)
 	rootCmd.AddCommand(rememberCmd)
+	rootCmd.AddCommand(showCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(timelineCmd)
 	rootCmd.AddCommand(installServiceCmd)

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -65,9 +65,7 @@ func runShow(cmd *cobra.Command, args []string) error {
 	data, getErr := client.Get("/api/memories?" + params.Encode())
 
 	// hooks.Client.Get returns (body, err) for non-2xx responses so callers can
-	// inspect the JSON error. Try to parse a clean error from the body first;
-	// fall back to the raw transport error if the body isn't a structured
-	// response.
+	// inspect the JSON error.
 	var resp struct {
 		URI      string `json:"uri"`
 		Category string `json:"category"`
@@ -76,14 +74,23 @@ func runShow(cmd *cobra.Command, args []string) error {
 		Detail   string `json:"detail"`
 		Error    string `json:"error"`
 	}
-	if len(data) > 0 {
-		_ = json.Unmarshal(data, &resp)
-	}
+
 	if getErr != nil {
-		if resp.Error != "" {
-			return fmt.Errorf("%s", resp.Error)
+		// Error path: best-effort parse for a clean server-side message, fall
+		// back to the raw transport error if the body isn't structured JSON.
+		if len(data) > 0 {
+			if jsonErr := json.Unmarshal(data, &resp); jsonErr == nil && resp.Error != "" {
+				return fmt.Errorf("%s", resp.Error)
+			}
 		}
 		return fmt.Errorf("show: %w", getErr)
+	}
+
+	// Success path: a bad decode means the server returned something
+	// unexpected (HTML from a proxy, a partial response, etc.) — fail fast
+	// rather than printing empty fields.
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("parse response: %w", err)
 	}
 	if resp.Error != "" {
 		return fmt.Errorf("%s", resp.Error)

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -62,11 +62,12 @@ func runShow(cmd *cobra.Command, args []string) error {
 
 	params := url.Values{}
 	params.Set("uri", uri)
-	data, err := client.Get("/api/memories?" + params.Encode())
-	if err != nil {
-		return fmt.Errorf("show: %w", err)
-	}
+	data, getErr := client.Get("/api/memories?" + params.Encode())
 
+	// hooks.Client.Get returns (body, err) for non-2xx responses so callers can
+	// inspect the JSON error. Try to parse a clean error from the body first;
+	// fall back to the raw transport error if the body isn't a structured
+	// response.
 	var resp struct {
 		URI      string `json:"uri"`
 		Category string `json:"category"`
@@ -75,8 +76,14 @@ func runShow(cmd *cobra.Command, args []string) error {
 		Detail   string `json:"detail"`
 		Error    string `json:"error"`
 	}
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return fmt.Errorf("parse response: %w", err)
+	if len(data) > 0 {
+		_ = json.Unmarshal(data, &resp)
+	}
+	if getErr != nil {
+		if resp.Error != "" {
+			return fmt.Errorf("%s", resp.Error)
+		}
+		return fmt.Errorf("show: %w", getErr)
 	}
 	if resp.Error != "" {
 		return fmt.Errorf("%s", resp.Error)

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -1,0 +1,140 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/lazypower/continuity/internal/hooks"
+	"github.com/spf13/cobra"
+)
+
+var (
+	showLayer string
+	showJSON  bool
+)
+
+var showCmd = &cobra.Command{
+	Use:     "show <uri>",
+	Aliases: []string{"get", "cat"},
+	Short:   "Show a single memory's full content",
+	Long: `Fetch a memory by URI and print its summary (L0), body (L1), and detail (L2).
+Requires a running server (continuity serve).
+
+Use this to read a memory's full body before updating it in place, so
+appends don't clobber unseen content.
+
+Examples:
+  continuity show mem://user/preferences/devbox
+  continuity show mem://user/preferences/devbox --layer body
+  continuity show mem://user/preferences/devbox --json
+
+You can also omit the mem:// prefix; it will be added automatically.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runShow,
+}
+
+func init() {
+	showCmd.Flags().StringVar(&showLayer, "layer", "all", "Which tier to print: summary, body, detail, or all")
+	showCmd.Flags().BoolVar(&showJSON, "json", false, "Emit machine-readable JSON")
+}
+
+func runShow(cmd *cobra.Command, args []string) error {
+	uri := strings.TrimSpace(args[0])
+	if uri == "" {
+		return fmt.Errorf("uri is required")
+	}
+	if !strings.HasPrefix(uri, "mem://") {
+		uri = "mem://" + strings.TrimPrefix(uri, "/")
+	}
+
+	switch showLayer {
+	case "all", "summary", "body", "detail":
+	default:
+		return fmt.Errorf("invalid --layer %q (valid: all, summary, body, detail)", showLayer)
+	}
+
+	client := hooks.NewClient()
+	if !client.Healthy() {
+		return fmt.Errorf("continuity server is not running — start it with: continuity serve")
+	}
+
+	params := url.Values{}
+	params.Set("uri", uri)
+	data, err := client.Get("/api/memories?" + params.Encode())
+	if err != nil {
+		return fmt.Errorf("show: %w", err)
+	}
+
+	var resp struct {
+		URI      string `json:"uri"`
+		Category string `json:"category"`
+		Summary  string `json:"summary"`
+		Body     string `json:"body"`
+		Detail   string `json:"detail"`
+		Error    string `json:"error"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+
+	if showJSON {
+		// Pretty-print what we got back — but filter by layer if requested.
+		out := map[string]any{"uri": resp.URI, "category": resp.Category}
+		switch showLayer {
+		case "summary":
+			out["summary"] = resp.Summary
+		case "body":
+			out["body"] = resp.Body
+		case "detail":
+			out["detail"] = resp.Detail
+		default:
+			out["summary"] = resp.Summary
+			out["body"] = resp.Body
+			out["detail"] = resp.Detail
+		}
+		enc, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal: %w", err)
+		}
+		fmt.Println(string(enc))
+		return nil
+	}
+
+	// Text output
+	switch showLayer {
+	case "summary":
+		fmt.Println(resp.Summary)
+	case "body":
+		fmt.Println(resp.Body)
+	case "detail":
+		if resp.Detail == "" {
+			fmt.Fprintln(cmd.ErrOrStderr(), "(no detail tier stored)")
+			return nil
+		}
+		fmt.Println(resp.Detail)
+	default:
+		fmt.Printf("%s [%s]\n", resp.URI, resp.Category)
+		fmt.Println()
+		fmt.Println("## Summary")
+		fmt.Println(resp.Summary)
+		fmt.Println()
+		fmt.Println("## Body")
+		if resp.Body == "" {
+			fmt.Println("(empty)")
+		} else {
+			fmt.Println(resp.Body)
+		}
+		if resp.Detail != "" {
+			fmt.Println()
+			fmt.Println("## Detail")
+			fmt.Println(resp.Detail)
+		}
+	}
+
+	return nil
+}

--- a/internal/cli/show_test.go
+++ b/internal/cli/show_test.go
@@ -44,13 +44,17 @@ func captureStdout(t *testing.T, fn func() error) (string, error) {
 	if err != nil {
 		t.Fatalf("pipe: %v", err)
 	}
+	defer r.Close()
+
 	orig := os.Stdout
 	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	defer w.Close()
 
 	runErr := fn()
 
+	// Close the write end before reading so io.ReadAll sees EOF.
 	w.Close()
-	os.Stdout = orig
 
 	out, _ := io.ReadAll(r)
 	return string(out), runErr
@@ -250,6 +254,11 @@ func TestShowNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+	// Assert we got the clean server-side error, not the raw transport wrap
+	// ("show: GET /api/memories?...: status 404: {...}").
+	if strings.Contains(err.Error(), "status 404") || strings.HasPrefix(err.Error(), "show: GET") {
+		t.Errorf("expected clean error message, got noisy transport wrap: %v", err)
 	}
 }
 

--- a/internal/cli/show_test.go
+++ b/internal/cli/show_test.go
@@ -1,0 +1,288 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/lazypower/continuity/internal/engine"
+	"github.com/lazypower/continuity/internal/server"
+	"github.com/lazypower/continuity/internal/store"
+)
+
+// showTestServer spins up an in-memory server and points the CLI client at it
+// via CONTINUITY_URL. Returns the store so tests can seed nodes directly.
+func showTestServer(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	eng := engine.New(db, nil)
+	srv := server.New(db, eng, "test-version")
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	prev := os.Getenv("CONTINUITY_URL")
+	os.Setenv("CONTINUITY_URL", ts.URL)
+	t.Cleanup(func() { os.Setenv("CONTINUITY_URL", prev) })
+
+	return db
+}
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what was
+// written. Used because runShow prints with fmt.Println, matching the existing
+// CLI style (other commands also write directly to os.Stdout).
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+
+	runErr := fn()
+
+	w.Close()
+	os.Stdout = orig
+
+	out, _ := io.ReadAll(r)
+	return string(out), runErr
+}
+
+// resetShowFlags resets package-level flag vars between test cases.
+func resetShowFlags() {
+	showLayer = "all"
+	showJSON = false
+}
+
+func seedShowNode(t *testing.T, db *store.DB, uri, l0, l1, l2 string) {
+	t.Helper()
+	n := &store.MemNode{
+		URI:        uri,
+		NodeType:   "leaf",
+		Category:   "patterns",
+		L0Abstract: l0,
+		L1Overview: l1,
+		L2Content:  l2,
+	}
+	if err := db.CreateNode(n); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+func TestShowAllLayers(t *testing.T) {
+	db := showTestServer(t)
+	seedShowNode(t, db,
+		"mem://agent/patterns/test-journal",
+		"tiny test",
+		"section A\n- entry 1\n\nsection B\n- entry 2\n",
+		"",
+	)
+
+	resetShowFlags()
+	out, err := captureStdout(t, func() error {
+		return runShow(showCmd, []string{"mem://agent/patterns/test-journal"})
+	})
+	if err != nil {
+		t.Fatalf("runShow: %v", err)
+	}
+
+	// Should include delimiters + both sections of the body
+	for _, want := range []string{"## Summary", "tiny test", "## Body", "section A", "- entry 1", "section B", "- entry 2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	// Detail header should be absent when detail is empty
+	if strings.Contains(out, "## Detail") {
+		t.Errorf("## Detail should be hidden when empty, got:\n%s", out)
+	}
+}
+
+func TestShowLayerBodyOnly(t *testing.T) {
+	db := showTestServer(t)
+	seedShowNode(t, db,
+		"mem://agent/patterns/body-only",
+		"the summary",
+		"the body content",
+		"",
+	)
+
+	resetShowFlags()
+	showLayer = "body"
+	out, err := captureStdout(t, func() error {
+		return runShow(showCmd, []string{"mem://agent/patterns/body-only"})
+	})
+	if err != nil {
+		t.Fatalf("runShow: %v", err)
+	}
+
+	if strings.TrimSpace(out) != "the body content" {
+		t.Errorf("expected body only, got: %q", out)
+	}
+}
+
+func TestShowLayerSummaryOnly(t *testing.T) {
+	db := showTestServer(t)
+	seedShowNode(t, db,
+		"mem://agent/patterns/summary-only",
+		"the summary",
+		"the body content",
+		"",
+	)
+
+	resetShowFlags()
+	showLayer = "summary"
+	out, err := captureStdout(t, func() error {
+		return runShow(showCmd, []string{"mem://agent/patterns/summary-only"})
+	})
+	if err != nil {
+		t.Fatalf("runShow: %v", err)
+	}
+
+	if strings.TrimSpace(out) != "the summary" {
+		t.Errorf("expected summary only, got: %q", out)
+	}
+}
+
+func TestShowJSON(t *testing.T) {
+	db := showTestServer(t)
+	seedShowNode(t, db,
+		"mem://agent/patterns/json-test",
+		"s",
+		"b",
+		"d",
+	)
+
+	resetShowFlags()
+	showJSON = true
+	out, err := captureStdout(t, func() error {
+		return runShow(showCmd, []string{"mem://agent/patterns/json-test"})
+	})
+	if err != nil {
+		t.Fatalf("runShow: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if parsed["uri"] != "mem://agent/patterns/json-test" {
+		t.Errorf("uri = %v", parsed["uri"])
+	}
+	if parsed["summary"] != "s" || parsed["body"] != "b" || parsed["detail"] != "d" {
+		t.Errorf("tier values wrong: %+v", parsed)
+	}
+}
+
+func TestShowJSONLayerFiltering(t *testing.T) {
+	db := showTestServer(t)
+	seedShowNode(t, db,
+		"mem://agent/patterns/json-filter",
+		"s",
+		"b",
+		"d",
+	)
+
+	resetShowFlags()
+	showJSON = true
+	showLayer = "body"
+	out, err := captureStdout(t, func() error {
+		return runShow(showCmd, []string{"mem://agent/patterns/json-filter"})
+	})
+	if err != nil {
+		t.Fatalf("runShow: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if _, hasSummary := parsed["summary"]; hasSummary {
+		t.Errorf("summary should be absent when --layer=body, got: %+v", parsed)
+	}
+	if _, hasDetail := parsed["detail"]; hasDetail {
+		t.Errorf("detail should be absent when --layer=body, got: %+v", parsed)
+	}
+	if parsed["body"] != "b" {
+		t.Errorf("body = %v, want b", parsed["body"])
+	}
+}
+
+func TestShowAutoPrependsPrefix(t *testing.T) {
+	db := showTestServer(t)
+	seedShowNode(t, db,
+		"mem://agent/patterns/no-prefix",
+		"the summary",
+		"the body",
+		"",
+	)
+
+	resetShowFlags()
+	out, err := captureStdout(t, func() error {
+		// Omit the mem:// prefix
+		return runShow(showCmd, []string{"agent/patterns/no-prefix"})
+	})
+	if err != nil {
+		t.Fatalf("runShow: %v", err)
+	}
+	if !strings.Contains(out, "the summary") || !strings.Contains(out, "the body") {
+		t.Errorf("auto-prepend failed, got: %s", out)
+	}
+}
+
+func TestShowNotFound(t *testing.T) {
+	showTestServer(t)
+
+	resetShowFlags()
+	_, err := captureStdout(t, func() error {
+		return runShow(showCmd, []string{"mem://agent/patterns/never-existed"})
+	})
+	if err == nil {
+		t.Fatal("expected error for missing memory, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+}
+
+func TestShowInvalidLayer(t *testing.T) {
+	showTestServer(t)
+
+	resetShowFlags()
+	showLayer = "bogus"
+	_, err := captureStdout(t, func() error {
+		return runShow(showCmd, []string{"mem://agent/patterns/anything"})
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid layer, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid --layer") {
+		t.Errorf("error should mention invalid --layer, got: %v", err)
+	}
+}
+
+func TestShowServerDown(t *testing.T) {
+	// Point at a URL that won't respond.
+	prev := os.Getenv("CONTINUITY_URL")
+	os.Setenv("CONTINUITY_URL", "http://127.0.0.1:1") // port 1 is reserved, should refuse
+	t.Cleanup(func() { os.Setenv("CONTINUITY_URL", prev) })
+
+	resetShowFlags()
+	_, err := captureStdout(t, func() error {
+		return runShow(showCmd, []string{"mem://agent/patterns/anything"})
+	})
+	if err == nil {
+		t.Fatal("expected error when server is unreachable, got nil")
+	}
+	if !strings.Contains(err.Error(), "server is not running") {
+		t.Errorf("error should mention server not running, got: %v", err)
+	}
+}

--- a/internal/cli/show_test.go
+++ b/internal/cli/show_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
@@ -275,6 +276,42 @@ func TestShowInvalidLayer(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid --layer") {
 		t.Errorf("error should mention invalid --layer, got: %v", err)
+	}
+}
+
+// TestShowBadSuccessResponse simulates a proxy or misbehaving server that
+// returns 200 OK with a non-JSON body. runShow should fail fast with a
+// "parse response" error instead of silently printing empty fields.
+func TestShowBadSuccessResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/health") {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"status":"ok"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("<html><body>proxy intercepted this</body></html>"))
+	}))
+	t.Cleanup(ts.Close)
+
+	prev := os.Getenv("CONTINUITY_URL")
+	os.Setenv("CONTINUITY_URL", ts.URL)
+	t.Cleanup(func() { os.Setenv("CONTINUITY_URL", prev) })
+
+	resetShowFlags()
+	out, err := captureStdout(t, func() error {
+		return runShow(showCmd, []string{"mem://agent/patterns/anything"})
+	})
+	if err == nil {
+		t.Fatalf("expected parse error for non-JSON 200, got nil (stdout: %q)", out)
+	}
+	if !strings.Contains(err.Error(), "parse response") {
+		t.Errorf("error should mention 'parse response', got: %v", err)
+	}
+	// Must not have silently printed empty fields to stdout.
+	if strings.Contains(out, "## Summary") || strings.Contains(out, "## Body") {
+		t.Errorf("expected no output on parse failure, got:\n%s", out)
 	}
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -166,6 +166,40 @@ func (s *Server) handleSignal(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{"status": "processing"})
 }
 
+func (s *Server) handleGetMemory(w http.ResponseWriter, r *http.Request) {
+	uri := r.URL.Query().Get("uri")
+	if uri == "" {
+		http.Error(w, `{"error":"uri parameter required"}`, http.StatusBadRequest)
+		return
+	}
+
+	node, err := s.db.GetNodeByURI(uri)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if node == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "memory not found: " + uri})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"uri":         node.URI,
+		"category":    node.Category,
+		"node_type":   node.NodeType,
+		"summary":     node.L0Abstract,
+		"body":        node.L1Overview,
+		"detail":      node.L2Content,
+		"relevance":   node.Relevance,
+		"created_at":  node.CreatedAt,
+		"updated_at":  node.UpdatedAt,
+		"access_count": node.AccessCount,
+	})
+}
+
 func (s *Server) handleRemember(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Category  string `json:"category"`

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -169,13 +169,17 @@ func (s *Server) handleSignal(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleGetMemory(w http.ResponseWriter, r *http.Request) {
 	uri := r.URL.Query().Get("uri")
 	if uri == "" {
-		http.Error(w, `{"error":"uri parameter required"}`, http.StatusBadRequest)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "uri parameter required"})
 		return
 	}
 
 	node, err := s.db.GetNodeByURI(uri)
 	if err != nil {
-		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
 	if node == nil {

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -238,6 +238,68 @@ func TestRememberRouteUpdate(t *testing.T) {
 	}
 }
 
+func TestGetMemoryRoute(t *testing.T) {
+	srv := testServerWithEngine(t)
+
+	// Seed a memory via POST
+	body := `{"category":"patterns","name":"test-journal","summary":"tiny test","body":"section A\n- entry 1\n\nsection B\n- entry 2\n"}`
+	req := httptest.NewRequest("POST", "/api/memories", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("seed: status = %d, want %d", w.Code, http.StatusCreated)
+	}
+
+	// Read it back
+	req = httptest.NewRequest("GET", "/api/memories?uri=mem://agent/patterns/test-journal", nil)
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["uri"] != "mem://agent/patterns/test-journal" {
+		t.Errorf("uri = %v, want mem://agent/patterns/test-journal", resp["uri"])
+	}
+	if resp["summary"] != "tiny test" {
+		t.Errorf("summary = %v, want tiny test", resp["summary"])
+	}
+	gotBody, _ := resp["body"].(string)
+	if !strings.Contains(gotBody, "section A") || !strings.Contains(gotBody, "section B") {
+		t.Errorf("body did not preserve both sections: %q", gotBody)
+	}
+	if resp["category"] != "patterns" {
+		t.Errorf("category = %v, want patterns", resp["category"])
+	}
+}
+
+func TestGetMemoryRouteNotFound(t *testing.T) {
+	srv := testServerWithEngine(t)
+
+	req := httptest.NewRequest("GET", "/api/memories?uri=mem://agent/patterns/does-not-exist", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestGetMemoryRouteMissingURI(t *testing.T) {
+	srv := testServerWithEngine(t)
+
+	req := httptest.NewRequest("GET", "/api/memories", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
 func TestRememberRouteNoEngine(t *testing.T) {
 	srv := testServer(t) // engine is nil
 

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -260,7 +260,9 @@ func TestGetMemoryRoute(t *testing.T) {
 	}
 
 	var resp map[string]any
-	json.Unmarshal(w.Body.Bytes(), &resp)
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response is not valid JSON: %v\n%s", err, w.Body.String())
+	}
 	if resp["uri"] != "mem://agent/patterns/test-journal" {
 		t.Errorf("uri = %v, want mem://agent/patterns/test-journal", resp["uri"])
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -69,6 +69,7 @@ func (s *Server) routes() {
 		r.Get("/sessions", stub("sessions"))
 		r.Get("/sessions/{sessionID}", stub("session detail"))
 		r.Post("/memories", s.handleRemember)
+		r.Get("/memories", s.handleGetMemory)
 	})
 
 	// Serve embedded UI at all non-API paths


### PR DESCRIPTION
Closes #1.

## Summary

- New `GET /api/memories?uri=<uri>` returns the full memory node (all three tiers, category, timestamps, access_count). 404 on missing URI, 400 on missing `uri` param.
- New `continuity show <uri>` CLI command (aliases `get`, `cat`) prints delimited summary/body/detail. Supports `--layer {summary,body,detail,all}` for tier filtering and `--json` for machine-readable output. Auto-prepends `mem://` when missing.

Both halves of the proposal from the issue landed together since the CLI talks to the server anyway — agents that want JSON can hit the HTTP endpoint directly; interactive use gets a cleanly formatted CLI.

## Why

`remember` already supports in-place updates, but there was no read-back path — `search` truncates at ~250 chars, `tree` lists children not content. In any session other than the one that wrote a memory, an append had to either reconstruct from a truncated summary or overwrite blind. This closes that gap.

## Test plan

- [x] `go test ./...` green across all packages
- [x] Server handler tests: round-trip (both body sections preserved), 404 on missing, 400 on missing uri param
- [x] CLI tests (new — `internal/cli` was previously untested): all layer modes, JSON shape + layer filtering, `mem://` auto-prepend, 404 surfacing, invalid layer, server-down

The reusable test scaffolding (`showTestServer`, `captureStdout`) is now available for future CLI command tests.

## Notes for reviewer

- One small fix alongside: the `show --help` example URIs originally used `mem://user/patterns/...`, but patterns actually land under `mem://agent/patterns/...`. Help text uses `mem://user/preferences/devbox` instead — a real URI shape.
- I considered backfilling CLI tests for all existing commands (none had any) but opted against — most CLI files are thin glue over already-tested engine/store code, so coverage value is low and scope bloat is high. `show` is an exception because its delimited output, layer filtering, and JSON shape only exist in the CLI. Happy to file a follow-up if there are specific commands worth pinning down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)