### PR TITLE
Fix silent extraction lock-out (closes #2)

### DIFF
--- a/internal/cli/extract.go
+++ b/internal/cli/extract.go
@@ -1,0 +1,155 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/lazypower/continuity/internal/hooks"
+	"github.com/spf13/cobra"
+)
+
+var (
+	extractForce        bool
+	extractTranscript   string
+	extractBackfillEmpty bool
+)
+
+var extractCmd = &cobra.Command{
+	Use:   "extract [session-id]",
+	Short: "Re-run extraction for a session",
+	Long: `Trigger memory extraction for a completed session.
+
+Typical uses:
+  continuity extract <session-id>              — re-extract if not already done
+  continuity extract <session-id> --force      — re-extract even if marked done
+  continuity extract --backfill-empty          — unmark every session that was
+                                                 flagged as extracted but has
+                                                 no memories attributed to it
+
+When a session-id is given, continuity auto-discovers the transcript at
+~/.claude/projects/*/<session-id>.jsonl. Pass --transcript to override.
+
+Requires a running server (continuity serve).`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runExtract,
+}
+
+func init() {
+	extractCmd.Flags().BoolVar(&extractForce, "force", false, "Bypass the idempotency guard (re-extract already-extracted sessions)")
+	extractCmd.Flags().StringVar(&extractTranscript, "transcript", "", "Path to transcript JSONL (overrides auto-discovery)")
+	extractCmd.Flags().BoolVar(&extractBackfillEmpty, "backfill-empty", false, "Unmark every session marked extracted with zero attributed memories")
+}
+
+func runExtract(cmd *cobra.Command, args []string) error {
+	client := hooks.NewClient()
+	if !client.Healthy() {
+		return fmt.Errorf("continuity server is not running — start it with: continuity serve")
+	}
+
+	if extractBackfillEmpty {
+		if len(args) > 0 || extractForce || extractTranscript != "" {
+			return fmt.Errorf("--backfill-empty cannot be combined with a session-id, --force, or --transcript")
+		}
+		return runBackfillEmpty(client)
+	}
+
+	if len(args) != 1 {
+		return fmt.Errorf("session-id is required (or use --backfill-empty)")
+	}
+	sessionID := strings.TrimSpace(args[0])
+	if sessionID == "" {
+		return fmt.Errorf("session-id is required")
+	}
+
+	transcriptPath := extractTranscript
+	if transcriptPath == "" {
+		found, err := findTranscript(sessionID)
+		if err != nil {
+			return err
+		}
+		transcriptPath = found
+	}
+	if _, err := os.Stat(transcriptPath); err != nil {
+		return fmt.Errorf("transcript not readable: %w", err)
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"transcript_path": transcriptPath,
+		"force":           extractForce,
+	})
+
+	data, err := client.Post("/api/sessions/"+sessionID+"/extract", body)
+	if err != nil {
+		if len(data) > 0 {
+			var resp struct {
+				Error string `json:"error"`
+			}
+			if jsonErr := json.Unmarshal(data, &resp); jsonErr == nil && resp.Error != "" {
+				return fmt.Errorf("%s", resp.Error)
+			}
+		}
+		return fmt.Errorf("extract: %w", err)
+	}
+
+	fmt.Printf("extraction queued for %s (transcript: %s, force: %v)\n", sessionID, transcriptPath, extractForce)
+	fmt.Println("check serve.log for progress — extraction runs asynchronously")
+	return nil
+}
+
+func runBackfillEmpty(client *hooks.Client) error {
+	data, err := client.Post("/api/sessions/unmark-empty-extractions", nil)
+	if err != nil {
+		if len(data) > 0 {
+			var resp struct {
+				Error string `json:"error"`
+			}
+			if jsonErr := json.Unmarshal(data, &resp); jsonErr == nil && resp.Error != "" {
+				return fmt.Errorf("%s", resp.Error)
+			}
+		}
+		return fmt.Errorf("backfill: %w", err)
+	}
+
+	var resp struct {
+		Status   string `json:"status"`
+		Unmarked int64  `json:"unmarked"`
+		Error    string `json:"error"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+
+	fmt.Printf("unmarked %d session(s) that were extracted with no attributed memories\n", resp.Unmarked)
+	if resp.Unmarked > 0 {
+		fmt.Println("they will be re-extracted on their next Stop/SessionEnd hook,")
+		fmt.Println("or force one now with: continuity extract <session-id> --force")
+	}
+	return nil
+}
+
+// findTranscript searches ~/.claude/projects/*/<session-id>.jsonl for a
+// Claude Code transcript matching the given session id.
+func findTranscript(sessionID string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	pattern := filepath.Join(home, ".claude", "projects", "*", sessionID+".jsonl")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", fmt.Errorf("glob transcripts: %w", err)
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no transcript found for session %s (looked in %s)", sessionID, pattern)
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf("multiple transcripts found for %s — pass --transcript to disambiguate:\n  %s", sessionID, strings.Join(matches, "\n  "))
+	}
+	return matches[0], nil
+}

--- a/internal/cli/extract.go
+++ b/internal/cli/extract.go
@@ -134,8 +134,15 @@ func runBackfillEmpty(client *hooks.Client) error {
 }
 
 // findTranscript searches ~/.claude/projects/*/<session-id>.jsonl for a
-// Claude Code transcript matching the given session id.
+// Claude Code transcript matching the given session id. The sessionID is
+// validated first — path separators or ".." would let a glob pattern escape
+// ~/.claude/projects, which is surprising for "auto-discovery". Callers who
+// genuinely need to point at a transcript outside that tree should pass
+// --transcript explicitly.
 func findTranscript(sessionID string) (string, error) {
+	if err := validateSessionIDForGlob(sessionID); err != nil {
+		return "", fmt.Errorf("%w — pass --transcript to point at a specific file", err)
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve home dir: %w", err)
@@ -152,4 +159,21 @@ func findTranscript(sessionID string) (string, error) {
 		return "", fmt.Errorf("multiple transcripts found for %s — pass --transcript to disambiguate:\n  %s", sessionID, strings.Join(matches, "\n  "))
 	}
 	return matches[0], nil
+}
+
+// validateSessionIDForGlob rejects session IDs that would let the
+// auto-discovery glob escape ~/.claude/projects. Real Claude Code session
+// IDs are UUIDs, but continuity imports from other sources so we don't
+// require that — we just refuse anything that would traverse the filesystem.
+func validateSessionIDForGlob(sessionID string) error {
+	if sessionID == "" {
+		return fmt.Errorf("session-id is empty")
+	}
+	if strings.ContainsAny(sessionID, `/\`) {
+		return fmt.Errorf("session-id %q contains a path separator", sessionID)
+	}
+	if sessionID == "." || sessionID == ".." || strings.Contains(sessionID, "..") {
+		return fmt.Errorf("session-id %q contains path traversal", sessionID)
+	}
+	return nil
 }

--- a/internal/cli/extract_test.go
+++ b/internal/cli/extract_test.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lazypower/continuity/internal/engine"
+	"github.com/lazypower/continuity/internal/server"
+	"github.com/lazypower/continuity/internal/store"
+)
+
+// extractTestServer stands up an in-memory server and points the CLI client
+// at it via CONTINUITY_URL. Mirrors showTestServer.
+func extractTestServer(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	eng := engine.New(db, nil)
+	srv := server.New(db, eng, "test-version")
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	prev := os.Getenv("CONTINUITY_URL")
+	os.Setenv("CONTINUITY_URL", ts.URL)
+	t.Cleanup(func() { os.Setenv("CONTINUITY_URL", prev) })
+
+	return db
+}
+
+func resetExtractFlags() {
+	extractForce = false
+	extractTranscript = ""
+	extractBackfillEmpty = false
+}
+
+func writeDummyTranscript(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	entries := []map[string]any{
+		{"type": "user", "message": map[string]any{"role": "user", "content": "Hello please help me out with this task"}},
+		{"type": "assistant", "message": map[string]any{"role": "assistant", "content": "Sure, I can help."}},
+		{"type": "user", "message": map[string]any{"role": "user", "content": "Another message here"}},
+	}
+	f, _ := os.Create(path)
+	defer f.Close()
+	for _, e := range entries {
+		data, _ := json.Marshal(e)
+		f.Write(data)
+		f.Write([]byte("\n"))
+	}
+	return path
+}
+
+func TestExtractCLIWithExplicitTranscript(t *testing.T) {
+	db := extractTestServer(t)
+	db.InitSession("cli-sess", "proj")
+	path := writeDummyTranscript(t)
+
+	resetExtractFlags()
+	extractTranscript = path
+
+	out, err := captureStdout(t, func() error {
+		return runExtract(extractCmd, []string{"cli-sess"})
+	})
+	if err != nil {
+		t.Fatalf("runExtract: %v", err)
+	}
+	if !strings.Contains(out, "extraction queued") {
+		t.Errorf("expected queued message, got: %s", out)
+	}
+}
+
+func TestExtractCLIBackfillEmpty(t *testing.T) {
+	db := extractTestServer(t)
+	db.InitSession("damaged", "proj")
+	db.MarkExtracted("damaged")
+
+	resetExtractFlags()
+	extractBackfillEmpty = true
+
+	out, err := captureStdout(t, func() error {
+		return runExtract(extractCmd, nil)
+	})
+	if err != nil {
+		t.Fatalf("runExtract --backfill-empty: %v", err)
+	}
+	if !strings.Contains(out, "unmarked 1 session") {
+		t.Errorf("expected unmark count, got: %s", out)
+	}
+
+	// Verify the damaged session was actually unmarked.
+	s, _ := db.GetSession("damaged")
+	if s.ExtractedAt != nil {
+		t.Error("damaged session should have been unmarked via CLI path")
+	}
+}
+
+func TestExtractCLIBackfillExclusiveFlags(t *testing.T) {
+	extractTestServer(t)
+
+	resetExtractFlags()
+	extractBackfillEmpty = true
+	extractForce = true
+
+	err := runExtract(extractCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --backfill-empty combined with --force")
+	}
+	if !strings.Contains(err.Error(), "cannot be combined") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestExtractCLIRequiresSessionID(t *testing.T) {
+	extractTestServer(t)
+	resetExtractFlags()
+
+	err := runExtract(extractCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when no session-id and no --backfill-empty")
+	}
+}
+
+func TestExtractCLITranscriptMissing(t *testing.T) {
+	extractTestServer(t)
+	resetExtractFlags()
+	extractTranscript = "/no/such/path.jsonl"
+
+	err := runExtract(extractCmd, []string{"abc"})
+	if err == nil {
+		t.Fatal("expected error for missing transcript")
+	}
+	if !strings.Contains(err.Error(), "not readable") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/cli/extract_test.go
+++ b/internal/cli/extract_test.go
@@ -50,12 +50,19 @@ func writeDummyTranscript(t *testing.T) string {
 		{"type": "assistant", "message": map[string]any{"role": "assistant", "content": "Sure, I can help."}},
 		{"type": "user", "message": map[string]any{"role": "user", "content": "Another message here"}},
 	}
-	f, _ := os.Create(path)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create transcript: %v", err)
+	}
 	defer f.Close()
 	for _, e := range entries {
 		data, _ := json.Marshal(e)
-		f.Write(data)
-		f.Write([]byte("\n"))
+		if _, err := f.Write(data); err != nil {
+			t.Fatalf("write transcript: %v", err)
+		}
+		if _, err := f.Write([]byte("\n")); err != nil {
+			t.Fatalf("write transcript: %v", err)
+		}
 	}
 	return path
 }
@@ -141,5 +148,31 @@ func TestExtractCLITranscriptMissing(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not readable") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateSessionIDForGlob(t *testing.T) {
+	cases := []struct {
+		name      string
+		sessionID string
+		wantErr   bool
+	}{
+		{"empty", "", true},
+		{"uuid", "0f5d812c-69e1-40d0-9eef-5436f5721a80", false},
+		{"plain slug", "my-session", false},
+		{"forward slash", "foo/bar", true},
+		{"backslash", `foo\bar`, true},
+		{"parent traversal", "..", true},
+		{"embedded traversal", "foo..bar", true},
+		{"dot", ".", true},
+		{"absolute escape", "/etc/passwd", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSessionIDForGlob(tc.sessionID)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateSessionIDForGlob(%q) err=%v wantErr=%v", tc.sessionID, err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,4 +29,5 @@ func init() {
 	rootCmd.AddCommand(timelineCmd)
 	rootCmd.AddCommand(installServiceCmd)
 	rootCmd.AddCommand(uninstallServiceCmd)
+	rootCmd.AddCommand(extractCmd)
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -516,18 +516,48 @@ func extractTone(db *store.DB, client llm.Client, sessionID, transcriptPath stri
 // ExtractSession runs the full extraction pipeline for a completed session.
 // This is designed to be called asynchronously (in a goroutine).
 // Idempotent: skips sessions that have already been extracted.
+// Content-gated: sessions with insufficient content (fewer than 3 user
+// messages or <100 chars condensed) return nil WITHOUT marking the session
+// as extracted, so subsequent Stop/SessionEnd hooks get another chance once
+// the conversation grows.
 func (e *Engine) ExtractSession(sessionID, transcriptPath string) error {
+	return e.extractSession(sessionID, transcriptPath, false)
+}
+
+// ExtractSessionForce runs extraction while bypassing the idempotency guard.
+// The content gate still applies — forcing extraction on a genuinely empty
+// session is a no-op. Used by `continuity extract --force` for reprocessing
+// sessions that were incorrectly marked as extracted.
+func (e *Engine) ExtractSessionForce(sessionID, transcriptPath string) error {
+	return e.extractSession(sessionID, transcriptPath, true)
+}
+
+func (e *Engine) extractSession(sessionID, transcriptPath string, force bool) error {
 	if transcriptPath == "" {
 		return fmt.Errorf("no transcript path provided")
 	}
 
-	// Idempotency guard: skip if already extracted
-	sess, err := e.DB.GetSession(sessionID)
-	if err != nil {
-		return fmt.Errorf("check session: %w", err)
+	// Idempotency guard: skip if already extracted (unless forced)
+	if !force {
+		sess, err := e.DB.GetSession(sessionID)
+		if err != nil {
+			return fmt.Errorf("check session: %w", err)
+		}
+		if sess != nil && sess.ExtractedAt != nil {
+			log.Printf("extraction: skipping %s — already extracted", sessionID)
+			return nil
+		}
 	}
-	if sess != nil && sess.ExtractedAt != nil {
-		log.Printf("extraction: skipping %s — already extracted", sessionID)
+
+	// Pre-flight content gate — return without marking if there's not enough
+	// to extract yet. Parsing the transcript here is cheap; the downstream
+	// extractors re-parse but that's a separate concern.
+	ok, reason, err := hasEnoughContent(transcriptPath)
+	if err != nil {
+		return fmt.Errorf("content gate: %w", err)
+	}
+	if !ok {
+		log.Printf("extraction: skipping %s — %s (not marking)", sessionID, reason)
 		return nil
 	}
 
@@ -549,4 +579,22 @@ func (e *Engine) ExtractSession(sessionID, transcriptPath string) error {
 	}
 
 	return nil
+}
+
+// hasEnoughContent returns true when the transcript meets the extractors'
+// minimum thresholds (>=3 user messages AND >=100 chars condensed). This is
+// the single source of truth for the content gate — mirrored client-side in
+// the Stop hook to avoid unnecessary HTTP round-trips.
+func hasEnoughContent(transcriptPath string) (bool, string, error) {
+	entries, err := transcript.ParseFile(transcriptPath)
+	if err != nil {
+		return false, "", fmt.Errorf("parse transcript: %w", err)
+	}
+	if transcript.CountUserMessages(entries) < 3 {
+		return false, "fewer than 3 user messages", nil
+	}
+	if len(transcript.Condense(entries)) < 100 {
+		return false, "condensed transcript too short", nil
+	}
+	return true, "", nil
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -640,3 +640,125 @@ func (m *multiResponseMock) Complete(ctx context.Context, prompt string) (*llm.R
 	m.callIdx++
 	return resp, nil
 }
+
+// TestExtractSessionGateSkipsWithoutMarking verifies the bug fix for issue
+// #2: when the transcript is too small to extract from, ExtractSession must
+// return without setting extracted_at, so a later Stop/SessionEnd can try
+// again once the conversation has grown.
+func TestExtractSessionGateSkipsWithoutMarking(t *testing.T) {
+	db := testDB(t)
+	mock := &llm.MockClient{
+		Response: &llm.Response{Content: "[]", Provider: "mock"},
+	}
+
+	// Two user messages — below the 3-message gate.
+	path := writeTranscript(t, []map[string]any{
+		{"type": "user", "message": map[string]any{"role": "user", "content": "Help me with a thing please"}},
+		{"type": "assistant", "message": map[string]any{"role": "assistant", "content": "Sure, what do you need?"}},
+		{"type": "user", "message": map[string]any{"role": "user", "content": "Never mind, bye"}},
+	})
+
+	// Seed the session row so GetSession returns non-nil.
+	if _, err := db.InitSession("gate-test", "test"); err != nil {
+		t.Fatalf("InitSession: %v", err)
+	}
+
+	eng := New(db, mock)
+	if err := eng.ExtractSession("gate-test", path); err != nil {
+		t.Fatalf("ExtractSession: %v", err)
+	}
+
+	// LLM must not have been called — gate should trip before any extractor runs.
+	if len(mock.Calls) != 0 {
+		t.Errorf("expected 0 LLM calls for sub-threshold transcript, got %d", len(mock.Calls))
+	}
+
+	// Critical: session must NOT be marked extracted, so later hooks get
+	// another chance once the conversation grows past the threshold.
+	sess, err := db.GetSession("gate-test")
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("expected session to exist")
+	}
+	if sess.ExtractedAt != nil {
+		t.Errorf("expected extracted_at=nil after gate skip, got %v", *sess.ExtractedAt)
+	}
+}
+
+// TestExtractSessionMarksWhenGatePasses confirms the happy path still marks
+// extracted_at once real extraction runs — guards against overcorrecting the
+// above fix.
+func TestExtractSessionMarksWhenGatePasses(t *testing.T) {
+	db := testDB(t)
+
+	mock := &multiResponseMock{
+		responses: []*llm.Response{
+			{Content: `[{"category":"preferences","uri_hint":"go-style","l0":"Uses Go","l1":"Prefers Go","l2":""}]`, Provider: "mock"},
+			{Content: "NO_UPDATE", Provider: "mock"},
+			{Content: "focused", Provider: "mock"},
+		},
+	}
+
+	if _, err := db.InitSession("passes-gate", "test"); err != nil {
+		t.Fatalf("InitSession: %v", err)
+	}
+
+	eng := New(db, mock)
+	if err := eng.ExtractSession("passes-gate", makeTranscript(t)); err != nil {
+		t.Fatalf("ExtractSession: %v", err)
+	}
+
+	sess, err := db.GetSession("passes-gate")
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess.ExtractedAt == nil {
+		t.Error("expected extracted_at to be set after successful extraction")
+	}
+}
+
+// TestExtractSessionForceBypassesIdempotency confirms --force re-runs
+// extraction on a session that was already marked.
+func TestExtractSessionForceBypassesIdempotency(t *testing.T) {
+	db := testDB(t)
+
+	if _, err := db.InitSession("already-extracted", "test"); err != nil {
+		t.Fatalf("InitSession: %v", err)
+	}
+	if err := db.MarkExtracted("already-extracted"); err != nil {
+		t.Fatalf("MarkExtracted: %v", err)
+	}
+
+	mock := &multiResponseMock{
+		responses: []*llm.Response{
+			{Content: `[{"category":"preferences","uri_hint":"reforced","l0":"Got reforced","l1":"reforced body content here","l2":""}]`, Provider: "mock"},
+			{Content: "NO_UPDATE", Provider: "mock"},
+			{Content: "focused", Provider: "mock"},
+		},
+	}
+	eng := New(db, mock)
+
+	// Without force: should skip.
+	if err := eng.ExtractSession("already-extracted", makeTranscript(t)); err != nil {
+		t.Fatalf("ExtractSession: %v", err)
+	}
+	if mock.callIdx != 0 {
+		t.Errorf("expected 0 LLM calls under idempotency, got %d", mock.callIdx)
+	}
+
+	// With force: should run.
+	if err := eng.ExtractSessionForce("already-extracted", makeTranscript(t)); err != nil {
+		t.Fatalf("ExtractSessionForce: %v", err)
+	}
+	if mock.callIdx == 0 {
+		t.Error("expected LLM to be called when forced")
+	}
+
+	// Verify new memory landed.
+	node, _ := db.GetNodeByURI("mem://user/preferences/reforced")
+	if node == nil {
+		t.Error("expected forced extraction to produce memory")
+	}
+}

--- a/internal/hooks/end.go
+++ b/internal/hooks/end.go
@@ -1,8 +1,23 @@
 package hooks
 
+import "encoding/json"
+
 func handleEnd(client *Client, input *HookInput) {
 	if _, err := client.Post("/api/sessions/"+input.SessionID+"/end", nil); err != nil {
 		ExitError(err)
 		return
+	}
+
+	// Belt-and-suspenders: also trigger extraction on SessionEnd. Stop fires
+	// per-turn and handles the common case, but SessionEnd is our last chance
+	// for sessions where Stop didn't run (e.g. terminal killed) or where the
+	// final turn pushed content across the threshold after the prior Stop.
+	// The server's idempotency guard + content gate make this safe to call
+	// even when Stop already extracted.
+	if input.TranscriptPath != "" {
+		body, _ := json.Marshal(map[string]string{
+			"transcript_path": input.TranscriptPath,
+		})
+		client.Post("/api/sessions/"+input.SessionID+"/extract", body)
 	}
 }

--- a/internal/hooks/stop.go
+++ b/internal/hooks/stop.go
@@ -1,6 +1,10 @@
 package hooks
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/lazypower/continuity/internal/transcript"
+)
 
 func handleStop(client *Client, input *HookInput) {
 	if _, err := client.Post("/api/sessions/"+input.SessionID+"/complete", nil); err != nil {
@@ -8,12 +12,32 @@ func handleStop(client *Client, input *HookInput) {
 		return
 	}
 
-	// Trigger async extraction with transcript path
-	if input.TranscriptPath != "" {
+	// Trigger async extraction only when the transcript has enough content
+	// to be worth extracting. Stop fires per-turn, so most early turns will
+	// skip here. The server applies the same gate as belt-and-suspenders,
+	// but doing the cheap parse locally avoids per-turn HTTP round-trips.
+	if input.TranscriptPath != "" && shouldExtract(input.TranscriptPath) {
 		body, _ := json.Marshal(map[string]string{
 			"transcript_path": input.TranscriptPath,
 		})
 		// Fire and forget — extraction is async (202 Accepted)
 		client.Post("/api/sessions/"+input.SessionID+"/extract", body)
 	}
+}
+
+// shouldExtract mirrors engine.hasEnoughContent so Stop can skip the HTTP
+// call on turns that wouldn't pass the server-side gate anyway.
+func shouldExtract(transcriptPath string) bool {
+	entries, err := transcript.ParseFile(transcriptPath)
+	if err != nil {
+		// If we can't read the transcript, let SessionEnd sort it out.
+		return false
+	}
+	if transcript.CountUserMessages(entries) < 3 {
+		return false
+	}
+	if len(transcript.Condense(entries)) < 100 {
+		return false
+	}
+	return true
 }

--- a/internal/hooks/stop_test.go
+++ b/internal/hooks/stop_test.go
@@ -1,0 +1,60 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeStopTranscript writes a JSONL transcript for stop-hook gate testing.
+func writeStopTranscript(t *testing.T, entries []map[string]any) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer f.Close()
+	for _, e := range entries {
+		data, _ := json.Marshal(e)
+		f.Write(data)
+		f.Write([]byte("\n"))
+	}
+	return path
+}
+
+func TestShouldExtractBelowUserMessageThreshold(t *testing.T) {
+	path := writeStopTranscript(t, []map[string]any{
+		{"type": "user", "message": map[string]any{"role": "user", "content": "Just saying hello please respond"}},
+		{"type": "assistant", "message": map[string]any{"role": "assistant", "content": "Hello! How can I help?"}},
+		{"type": "user", "message": map[string]any{"role": "user", "content": "Actually never mind, bye"}},
+	})
+
+	if shouldExtract(path) {
+		t.Error("expected false — only 2 user messages, below 3-message gate")
+	}
+}
+
+func TestShouldExtractPassesThreshold(t *testing.T) {
+	// Reuse the multi-message transcript shape from engine tests.
+	path := writeStopTranscript(t, []map[string]any{
+		{"type": "user", "message": map[string]any{"role": "user", "content": "Help me build a Go CLI tool with cobra for task management please"}},
+		{"type": "assistant", "message": map[string]any{"role": "assistant", "content": "I'll help you build a Go CLI tool using cobra. Let me start by setting up the project structure."}},
+		{"type": "user", "message": map[string]any{"role": "user", "content": "I prefer minimal dependencies. Always use the standard library where possible."}},
+		{"type": "assistant", "message": map[string]any{"role": "assistant", "content": "Good point. I'll stick to the standard library for HTTP, JSON, and file operations."}},
+		{"type": "user", "message": map[string]any{"role": "user", "content": "Can you add SQLite for storage? Use modernc.org/sqlite since it's pure Go."}},
+		{"type": "assistant", "message": map[string]any{"role": "assistant", "content": "I'll add modernc.org/sqlite. Pure Go, cross-compiles cleanly without CGO."}},
+	})
+
+	if !shouldExtract(path) {
+		t.Error("expected true — 3 user messages with plenty of content should pass")
+	}
+}
+
+func TestShouldExtractMissingFile(t *testing.T) {
+	if shouldExtract("/definitely/does/not/exist.jsonl") {
+		t.Error("expected false when transcript can't be read")
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -105,6 +105,7 @@ func (s *Server) handleExtractSession(w http.ResponseWriter, r *http.Request) {
 
 	var req struct {
 		TranscriptPath string `json:"transcript_path"`
+		Force          bool   `json:"force"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
@@ -120,7 +121,13 @@ func (s *Server) handleExtractSession(w http.ResponseWriter, r *http.Request) {
 
 	// Async extraction — return 202 immediately
 	go func() {
-		if err := s.engine.ExtractSession(sessionID, req.TranscriptPath); err != nil {
+		var err error
+		if req.Force {
+			err = s.engine.ExtractSessionForce(sessionID, req.TranscriptPath)
+		} else {
+			err = s.engine.ExtractSession(sessionID, req.TranscriptPath)
+		}
+		if err != nil {
 			log.Printf("extraction failed for %s: %v", sessionID, err)
 		}
 	}()
@@ -164,6 +171,26 @@ func (s *Server) handleSignal(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	json.NewEncoder(w).Encode(map[string]string{"status": "processing"})
+}
+
+// handleUnmarkEmptyExtractions clears extracted_at on every session marked
+// as extracted but with zero memories attributed. This is the backfill path
+// for sessions that were silently locked out by the pre-fix mark-on-skip
+// bug. Returns the number of sessions unmarked.
+func (s *Server) handleUnmarkEmptyExtractions(w http.ResponseWriter, r *http.Request) {
+	n, err := s.db.UnmarkEmptyExtractions()
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"status":   "ok",
+		"unmarked": n,
+	})
 }
 
 func (s *Server) handleGetMemory(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -386,3 +386,63 @@ func TestGetContextWithSessions(t *testing.T) {
 		t.Errorf("context missing project name: %s", resp["context"])
 	}
 }
+
+func TestUnmarkEmptyExtractionsRoute(t *testing.T) {
+	srv := testServerWithEngine(t)
+
+	// Seed: one session marked extracted with no memories (should unmark)
+	// and one marked-with-memory (should stay)
+	srv.db.InitSession("empty-sess", "proj")
+	srv.db.MarkExtracted("empty-sess")
+	srv.db.InitSession("real-sess", "proj")
+	srv.db.MarkExtracted("real-sess")
+	srv.db.UpsertNode(&store.MemNode{
+		URI:           "mem://user/preferences/x",
+		NodeType:      "leaf",
+		Category:      "preferences",
+		SourceSession: "real-sess",
+	})
+
+	req := httptest.NewRequest("POST", "/api/sessions/unmark-empty-extractions", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Status   string `json:"status"`
+		Unmarked int64  `json:"unmarked"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Unmarked != 1 {
+		t.Errorf("unmarked = %d, want 1", resp.Unmarked)
+	}
+
+	empty, _ := srv.db.GetSession("empty-sess")
+	if empty.ExtractedAt != nil {
+		t.Error("empty-sess should have been unmarked")
+	}
+	kept, _ := srv.db.GetSession("real-sess")
+	if kept.ExtractedAt == nil {
+		t.Error("real-sess should have stayed marked")
+	}
+}
+
+// TestExtractSessionRouteAcceptsForce verifies the extract endpoint accepts
+// and honors the force flag. Real extraction runs async so we only assert
+// the request is accepted cleanly.
+func TestExtractSessionRouteAcceptsForce(t *testing.T) {
+	srv := testServerWithEngine(t)
+	srv.db.InitSession("extract-001", "proj")
+
+	body := `{"transcript_path":"/nonexistent/transcript.jsonl","force":true}`
+	req := httptest.NewRequest("POST", "/api/sessions/extract-001/extract", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -396,12 +396,14 @@ func TestUnmarkEmptyExtractionsRoute(t *testing.T) {
 	srv.db.MarkExtracted("empty-sess")
 	srv.db.InitSession("real-sess", "proj")
 	srv.db.MarkExtracted("real-sess")
-	srv.db.UpsertNode(&store.MemNode{
+	if err := srv.db.UpsertNode(&store.MemNode{
 		URI:           "mem://user/preferences/x",
 		NodeType:      "leaf",
 		Category:      "preferences",
 		SourceSession: "real-sess",
-	})
+	}); err != nil {
+		t.Fatalf("UpsertNode: %v", err)
+	}
 
 	req := httptest.NewRequest("POST", "/api/sessions/unmark-empty-extractions", nil)
 	w := httptest.NewRecorder()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,6 +55,7 @@ func (s *Server) routes() {
 
 		// Phase 2: extraction
 		r.Post("/sessions/{sessionID}/extract", s.handleExtractSession)
+		r.Post("/sessions/unmark-empty-extractions", s.handleUnmarkEmptyExtractions)
 
 		// Phase 4: signal keywords
 		r.Post("/sessions/{sessionID}/signal", s.handleSignal)

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -166,6 +166,38 @@ func (db *DB) MarkExtracted(sessionID string) error {
 	return nil
 }
 
+// UnmarkExtracted clears extracted_at for a single session so it can be
+// re-extracted by a subsequent run without --force.
+func (db *DB) UnmarkExtracted(sessionID string) error {
+	_, err := db.Exec(`UPDATE sessions SET extracted_at = NULL WHERE session_id = ?`, sessionID)
+	if err != nil {
+		return fmt.Errorf("unmark extracted: %w", err)
+	}
+	return nil
+}
+
+// UnmarkEmptyExtractions unmarks every session that is flagged as extracted
+// but has no memories attributed to it via mem_nodes.source_session. This is
+// the backfill path for sessions that were silently locked out by the
+// mark-on-skip bug. Returns the number of rows affected.
+func (db *DB) UnmarkEmptyExtractions() (int64, error) {
+	result, err := db.Exec(`
+		UPDATE sessions
+		SET extracted_at = NULL
+		WHERE extracted_at IS NOT NULL
+		  AND session_id NOT IN (
+		      SELECT DISTINCT source_session
+		      FROM mem_nodes
+		      WHERE source_session IS NOT NULL
+		  )
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("unmark empty extractions: %w", err)
+	}
+	rows, _ := result.RowsAffected()
+	return rows, nil
+}
+
 // SetSessionTone stores the emotional arc tone for a session.
 func (db *DB) SetSessionTone(sessionID, tone string) error {
 	_, err := db.Exec(`UPDATE sessions SET tone = ? WHERE session_id = ?`, tone, sessionID)

--- a/internal/store/sessions_test.go
+++ b/internal/store/sessions_test.go
@@ -237,6 +237,91 @@ func TestSessionToneInRecentSessions(t *testing.T) {
 	}
 }
 
+func TestUnmarkExtracted(t *testing.T) {
+	db, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	defer db.Close()
+
+	db.InitSession("sess-001", "proj")
+	if err := db.MarkExtracted("sess-001"); err != nil {
+		t.Fatalf("MarkExtracted: %v", err)
+	}
+	s, _ := db.GetSession("sess-001")
+	if s.ExtractedAt == nil {
+		t.Fatal("precondition: expected extracted_at set")
+	}
+
+	if err := db.UnmarkExtracted("sess-001"); err != nil {
+		t.Fatalf("UnmarkExtracted: %v", err)
+	}
+	s, _ = db.GetSession("sess-001")
+	if s.ExtractedAt != nil {
+		t.Errorf("expected extracted_at=nil after unmark, got %v", *s.ExtractedAt)
+	}
+}
+
+// TestUnmarkEmptyExtractions is the backfill for issue #2: sessions marked
+// extracted but with no memories attributed should be eligible for
+// re-extraction. Sessions with at least one attributed memory must be
+// left alone.
+func TestUnmarkEmptyExtractions(t *testing.T) {
+	db, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	defer db.Close()
+
+	// Session A: marked extracted, no memories → should be unmarked.
+	db.InitSession("empty-a", "proj")
+	db.MarkExtracted("empty-a")
+
+	// Session B: marked extracted, has an attributed memory → keep marked.
+	db.InitSession("has-memory", "proj")
+	db.MarkExtracted("has-memory")
+	if err := db.UpsertNode(&MemNode{
+		URI:           "mem://user/preferences/real",
+		NodeType:      "leaf",
+		Category:      "preferences",
+		SourceSession: "has-memory",
+	}); err != nil {
+		t.Fatalf("UpsertNode: %v", err)
+	}
+
+	// Session C: never marked extracted → untouched.
+	db.InitSession("never-marked", "proj")
+
+	// Session D: marked extracted, no memories → also unmarked.
+	db.InitSession("empty-d", "proj")
+	db.MarkExtracted("empty-d")
+
+	n, err := db.UnmarkEmptyExtractions()
+	if err != nil {
+		t.Fatalf("UnmarkEmptyExtractions: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("unmarked count = %d, want 2", n)
+	}
+
+	a, _ := db.GetSession("empty-a")
+	if a.ExtractedAt != nil {
+		t.Error("empty-a should have been unmarked")
+	}
+	b, _ := db.GetSession("has-memory")
+	if b.ExtractedAt == nil {
+		t.Error("has-memory should have stayed marked")
+	}
+	c, _ := db.GetSession("never-marked")
+	if c.ExtractedAt != nil {
+		t.Error("never-marked should not have been touched")
+	}
+	d, _ := db.GetSession("empty-d")
+	if d.ExtractedAt != nil {
+		t.Error("empty-d should have been unmarked")
+	}
+}
+
 func TestIncrementToolCount(t *testing.T) {
 	db, err := OpenMemory()
 	if err != nil {


### PR DESCRIPTION
## Summary

- **Root cause**: `ExtractSession` called `MarkExtracted` unconditionally — even when extractors early-returned due to insufficient content. `Stop` fires per-turn, so the first Stop on a new session hit the `<3 user messages` gate, marked the session extracted, and silently locked it out of every subsequent Stop/SessionEnd hook. 1329 of 1644 sessions in the DB were damaged this way; the synthesized relational profile hasn't been updated by the pipeline since the bug landed.
- **Fix**: Gate extraction before marking, not during. Add `--force` path and a bulk unmark for recovering the damaged session cohort. Wire SessionEnd to also trigger extraction so crashed terminals don't miss the window.

## Changes

**Correctness:**
- `engine.ExtractSession`: pre-flight content gate returns nil **without** `MarkExtracted` when sub-threshold → later hooks get another chance once the conversation grows.
- `engine.ExtractSessionForce`: bypasses idempotency guard (gate still applies).
- `hooks/stop.go`: client-side gate mirrors the server gate, avoiding per-turn HTTP round-trips.
- `hooks/end.go`: also POSTs `/extract` — belt-and-suspenders for sessions where Stop never fired.

**Recovery:**
- `POST /api/sessions/unmark-empty-extractions` — unmarks every session flagged extracted with zero `source_session` rows in `mem_nodes`.
- `continuity extract <id> [--force]` — manual re-extract with auto-discovery of `~/.claude/projects/*/<session-id>.jsonl`.
- `continuity extract --backfill-empty` — bulk unmark, so all damaged sessions become eligible for re-extraction on their next Stop/SessionEnd.

## Test plan

- [x] `go test ./...` — full suite green
- [x] New: `TestExtractSessionGateSkipsWithoutMarking` — confirms the bug fix
- [x] New: `TestExtractSessionMarksWhenGatePasses` — happy path still marks
- [x] New: `TestExtractSessionForceBypassesIdempotency` — force flag works
- [x] New: `TestUnmarkEmptyExtractions` — correctly identifies empty-extracted sessions, leaves real ones alone
- [x] New: `TestShouldExtract*` — stop hook client-side gate
- [x] New: `TestExtractCLI*` — 5 CLI cases including `--backfill-empty`
- [x] New: `TestUnmarkEmptyExtractionsRoute`, `TestExtractSessionRouteAcceptsForce`
- [ ] Manual: run `continuity extract --backfill-empty` against real DB, verify ~1329 unmarked
- [ ] Manual: let sessions re-extract naturally on next Stop/SessionEnd and confirm relational profile updates appear in serve.log

Closes #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)