### PR TITLE
Fix install-service writing versioned Cellar path to plist

### DIFF
--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -4,10 +4,47 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 )
+
+// resolveBinaryPath returns a stable path to the running continuity binary,
+// suitable for embedding in launchd plists or systemd unit files.
+//
+// On Homebrew installs, os.Executable() + EvalSymlinks resolves to a versioned
+// Cellar path (e.g. /opt/homebrew/Cellar/continuity/0.3.0/bin/continuity) which
+// breaks after `brew upgrade`. We prefer a PATH-resolved location when it points
+// to the same underlying binary, since the symlink in /opt/homebrew/bin or
+// /usr/local/bin remains valid across upgrades.
+func resolveBinaryPath() (string, error) {
+	self, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve binary path: %w", err)
+	}
+	pathLoc, _ := exec.LookPath("continuity")
+	return resolveBinaryPathFrom(self, pathLoc)
+}
+
+func resolveBinaryPathFrom(self, pathLoc string) (string, error) {
+	selfReal, err := filepath.EvalSymlinks(self)
+	if err != nil {
+		return "", fmt.Errorf("resolve symlinks: %w", err)
+	}
+
+	if pathLoc != "" {
+		if pathLocReal, err := filepath.EvalSymlinks(pathLoc); err == nil && pathLocReal == selfReal {
+			if abs, err := filepath.Abs(pathLoc); err == nil {
+				return abs, nil
+			}
+			return pathLoc, nil
+		}
+	}
+
+	return selfReal, nil
+}
 
 var installServiceCmd = &cobra.Command{
 	Use:   "install-service",

--- a/internal/cli/service_darwin.go
+++ b/internal/cli/service_darwin.go
@@ -24,14 +24,9 @@ func plistPath() (string, error) {
 }
 
 func generatePlist() (string, error) {
-	self, err := os.Executable()
+	self, err := resolveBinaryPath()
 	if err != nil {
-		return "", fmt.Errorf("resolve binary path: %w", err)
-	}
-	// Resolve symlinks so the plist points to the real binary
-	self, err = filepath.EvalSymlinks(self)
-	if err != nil {
-		return "", fmt.Errorf("resolve symlinks: %w", err)
+		return "", err
 	}
 
 	home, err := os.UserHomeDir()
@@ -82,11 +77,10 @@ func platformServiceStatus() (installed bool, status string) {
 }
 
 func platformServicePlan() (string, error) {
-	self, err := os.Executable()
+	self, err := resolveBinaryPath()
 	if err != nil {
-		return "", fmt.Errorf("resolve binary: %w", err)
+		return "", err
 	}
-	self, _ = filepath.EvalSymlinks(self)
 
 	path, err := plistPath()
 	if err != nil {

--- a/internal/cli/service_linux.go
+++ b/internal/cli/service_linux.go
@@ -23,13 +23,9 @@ func unitPath() (string, error) {
 }
 
 func generateUnit() (string, error) {
-	self, err := os.Executable()
+	self, err := resolveBinaryPath()
 	if err != nil {
-		return "", fmt.Errorf("resolve binary path: %w", err)
-	}
-	self, err = filepath.EvalSymlinks(self)
-	if err != nil {
-		return "", fmt.Errorf("resolve symlinks: %w", err)
+		return "", err
 	}
 
 	home, err := os.UserHomeDir()
@@ -78,11 +74,10 @@ func platformServicePlan() (string, error) {
 		return "", fmt.Errorf("systemctl not found — systemd is required for install-service on Linux")
 	}
 
-	self, err := os.Executable()
+	self, err := resolveBinaryPath()
 	if err != nil {
-		return "", fmt.Errorf("resolve binary: %w", err)
+		return "", err
 	}
-	self, _ = filepath.EvalSymlinks(self)
 
 	path, err := unitPath()
 	if err != nil {

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveBinaryPathFrom(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Simulate Homebrew layout:
+	//   <tmp>/Cellar/continuity/0.3.0/bin/continuity   (real binary)
+	//   <tmp>/bin/continuity -> ../Cellar/.../continuity (stable symlink)
+	cellarDir := filepath.Join(tmp, "Cellar", "continuity", "0.3.0", "bin")
+	if err := os.MkdirAll(cellarDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cellarBin := filepath.Join(cellarDir, "continuity")
+	if err := os.WriteFile(cellarBin, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	stableLink := filepath.Join(binDir, "continuity")
+	if err := os.Symlink(cellarBin, stableLink); err != nil {
+		t.Fatal(err)
+	}
+
+	cellarReal, err := filepath.EvalSymlinks(cellarBin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("prefers stable symlink when both resolve to same real binary", func(t *testing.T) {
+		// os.Executable() returned the Cellar path; PATH has the stable symlink.
+		got, err := resolveBinaryPathFrom(cellarBin, stableLink)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantAbs, _ := filepath.Abs(stableLink)
+		if got != wantAbs {
+			t.Errorf("expected stable symlink %q, got %q", wantAbs, got)
+		}
+	})
+
+	t.Run("prefers stable symlink when self is the symlink itself", func(t *testing.T) {
+		// os.Executable() returned the symlink (as it does on some systems).
+		got, err := resolveBinaryPathFrom(stableLink, stableLink)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantAbs, _ := filepath.Abs(stableLink)
+		if got != wantAbs {
+			t.Errorf("expected stable symlink %q, got %q", wantAbs, got)
+		}
+	})
+
+	t.Run("falls back to realpath when no PATH match", func(t *testing.T) {
+		got, err := resolveBinaryPathFrom(cellarBin, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != cellarReal {
+			t.Errorf("expected realpath %q, got %q", cellarReal, got)
+		}
+	})
+
+	t.Run("falls back to realpath when PATH points to a different binary", func(t *testing.T) {
+		// User runs ./continuity from a dev tree but also has a different brew install on PATH.
+		otherDir := filepath.Join(tmp, "other")
+		if err := os.MkdirAll(otherDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		otherBin := filepath.Join(otherDir, "continuity")
+		if err := os.WriteFile(otherBin, []byte("#!/bin/sh\n# different\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := resolveBinaryPathFrom(cellarBin, otherBin)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != cellarReal {
+			t.Errorf("expected realpath %q (different binary on PATH should be ignored), got %q", cellarReal, got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Closes #9. `install-service` was writing `/opt/homebrew/Cellar/continuity/<ver>/bin/continuity` into the launchd plist (and the systemd unit on Linux). After `brew upgrade`, that path no longer exists and the service fails to spawn (`EX_CONFIG`/exit 78), surfacing as `405 Method Not Allowed` or `continuity server is not running` on the CLI side.
- New `resolveBinaryPath()` helper prefers a PATH-resolved location (e.g. `/opt/homebrew/bin/continuity`) when it points to the same realpath as the running binary. Falls back to the realpath otherwise (dev builds, or when a different `continuity` is on PATH).
- Wired into both the macOS plist generator and the Linux unit generator.
- Helper is split into `resolveBinaryPathFrom(self, pathLoc)` so it's testable without touching the real `os.Executable()` / PATH lookup.

## Migration

Existing users on a buggy plist need to run, once:

\`\`\`
continuity uninstall-service && continuity install-service
\`\`\`

Worth a line in release notes for the next version.

## Test plan

- [x] `go test ./internal/cli/... -run TestResolveBinaryPathFrom -v` — covers four cases: stable symlink preferred when self is Cellar path, stable symlink preferred when self is the symlink itself, fallback to realpath when PATH has no match, fallback when PATH points to a different binary.
- [x] `go test ./...` — full suite green.
- [x] `GOOS=linux/darwin/windows go build ./...` — all three build clean.
- [ ] Manual: `brew upgrade continuity` after install, confirm plist still points to a stable path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)