### PR TITLE
Inject PATH into launchd plist so LLM extraction can find claude/ollama

### DIFF
--- a/internal/cli/service_darwin.go
+++ b/internal/cli/service_darwin.go
@@ -13,6 +13,12 @@ import (
 const (
 	launchAgentLabel = "com.continuity.server"
 	plistFilename    = "com.continuity.server.plist"
+
+	// servicePATH is what we inject into the launchd EnvironmentVariables.
+	// launchd hands daemons a stripped PATH (/usr/bin:/bin:/usr/sbin:/sbin), so the
+	// service can't find `claude` (Homebrew) and LLM extraction silently fails.
+	// Both Apple-Silicon and Intel Homebrew prefixes are listed first.
+	servicePATH = "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin"
 )
 
 func plistPath() (string, error) {
@@ -54,9 +60,14 @@ func generatePlist() (string, error) {
     <string>%s</string>
     <key>StandardErrorPath</key>
     <string>%s</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>%s</string>
+    </dict>
 </dict>
 </plist>
-`, launchAgentLabel, self, logPath, logPath), nil
+`, launchAgentLabel, self, logPath, logPath, servicePATH), nil
 }
 
 func platformServiceStatus() (installed bool, status string) {

--- a/internal/cli/service_darwin_test.go
+++ b/internal/cli/service_darwin_test.go
@@ -1,0 +1,36 @@
+//go:build darwin
+
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGeneratePlistInjectsEnvironmentPATH(t *testing.T) {
+	got, err := generatePlist()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(got, "<key>EnvironmentVariables</key>") {
+		t.Errorf("plist missing EnvironmentVariables key:\n%s", got)
+	}
+	if !strings.Contains(got, "<key>PATH</key>") {
+		t.Errorf("plist missing PATH key inside EnvironmentVariables:\n%s", got)
+	}
+	if !strings.Contains(got, "/opt/homebrew/bin") {
+		t.Errorf("plist PATH missing Apple-Silicon homebrew prefix:\n%s", got)
+	}
+	if !strings.Contains(got, "/usr/local/bin") {
+		t.Errorf("plist PATH missing Intel homebrew prefix:\n%s", got)
+	}
+
+	// Homebrew prefixes must come before system stubs so `claude` resolves to the
+	// brew install rather than any Apple-shipped binary of the same name.
+	hbIdx := strings.Index(got, "/opt/homebrew/bin")
+	sysIdx := strings.Index(got, "/usr/bin")
+	if hbIdx < 0 || sysIdx < 0 || hbIdx > sysIdx {
+		t.Errorf("homebrew prefix must precede /usr/bin in PATH (hb=%d sys=%d)", hbIdx, sysIdx)
+	}
+}


### PR DESCRIPTION
## Summary

- Closes #10. Stacked on #13 since both touch the plist template — merge #13 first and this rebases trivially.
- Add `<key>EnvironmentVariables</key>` with a `PATH` containing Apple-Silicon + Intel Homebrew prefixes ahead of the system paths. launchd was handing the daemon `/usr/bin:/bin:/usr/sbin:/sbin`, so `claude -p` (and `ollama`, when shelled out) failed to resolve and LLM extraction silently no-op'd — sessions ended clean but the relational profile never built.
- Linux is intentionally unchanged. systemd user units inherit user PATH from the manager session and a hardcoded `Environment=PATH=` would risk regressing users with `claude` in `~/.local/bin` or via mise/asdf. The reported bug is launchd-only.

## Migration

\`\`\`
continuity uninstall-service && continuity install-service
\`\`\`

Same migration as #13 — operators on a buggy plist already need to bounce the service for the path fix.

## Test plan

- [x] `go test ./internal/cli/... -run TestGeneratePlist -v` — asserts the plist contains `EnvironmentVariables`, both homebrew prefixes, and that `/opt/homebrew/bin` precedes `/usr/bin`.
- [x] `go test ./...` — full suite green.
- [x] `GOOS=linux/darwin/windows go build ./...` — clean.
- [ ] Manual: `continuity install-service && launchctl print gui/\$UID/com.continuity.server | grep PATH` should show the homebrew-first PATH.

## Out of scope

The issue suggests a `continuity health` subcommand or non-zero hook exit when extraction fails — worth a separate issue. This PR keeps the change minimal and focused on the silent-failure root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)