### PR TITLE
Honor caller-supplied slug on Remember API

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -250,6 +250,13 @@ type RememberInput struct {
 
 // Remember stores a structured memory directly — no LLM round-trip needed.
 // Returns the resulting URI, whether the node was newly created, and any error.
+//
+// The caller-supplied slug (input.Name) is always honored. The semantic-similarity
+// dedup heuristic that runs on the LLM extraction path is intentionally skipped
+// here: a direct write through this API is explicit user/agent intent, and
+// silently redirecting it onto a near-duplicate's URI causes silent data loss
+// (see issue #11). For immutable-category slug collisions, the underlying
+// UpsertNode appends a timestamp suffix; we report the actual stored URI.
 func (e *Engine) Remember(ctx context.Context, input RememberInput) (string, bool, error) {
 	c := memoryCandidate{
 		Category: input.Category,
@@ -266,28 +273,15 @@ func (e *Engine) Remember(ctx context.Context, input RememberInput) (string, boo
 	c = vc
 
 	owner := ownerForCategory(c.Category)
-	uri := fmt.Sprintf("mem://%s/%s/%s", owner, c.Category, c.URIHint)
+	requestedURI := fmt.Sprintf("mem://%s/%s/%s", owner, c.Category, c.URIHint)
 
-	// For immutable categories, check for near-duplicates via embeddings
-	if e.Embedder != nil && !mergeableCategory(c.Category) {
-		match, sim, err := findSimilarNode(ctx, e.DB, e.Embedder, c.L0, c.Category, defaultSimilarityThreshold)
-		if err != nil {
-			log.Printf("remember: similarity check failed: %v", err)
-		} else if match != nil {
-			log.Printf("remember: merging %s → %s (similarity: %.3f)", uri, match.URI, sim)
-			uri = match.URI
-		}
-	}
-
-	// Check if node already exists to determine created vs updated
-	existing, err := e.DB.GetNodeByURI(uri)
+	existing, err := e.DB.GetNodeByURI(requestedURI)
 	if err != nil {
 		return "", false, fmt.Errorf("check existing: %w", err)
 	}
-	created := existing == nil
 
 	node := &store.MemNode{
-		URI:           uri,
+		URI:           requestedURI,
 		NodeType:      "leaf",
 		Category:      c.Category,
 		L0Abstract:    c.L0,
@@ -299,14 +293,21 @@ func (e *Engine) Remember(ctx context.Context, input RememberInput) (string, boo
 	if err := e.DB.UpsertNode(node); err != nil {
 		return "", false, fmt.Errorf("upsert: %w", err)
 	}
-	log.Printf("remember: stored %s [%s] (created=%v)", uri, c.Category, created)
+
+	// UpsertNode mutates node.URI when an immutable-category slug collision
+	// triggers the timestamp-suffix path. created reflects whether a new row
+	// was inserted (fresh slug, OR collision-with-suffix), as opposed to an
+	// in-place merge of a mergeable category.
+	created := existing == nil || node.URI != requestedURI
+	storedURI := node.URI
+	log.Printf("remember: stored %s [%s] (created=%v)", storedURI, c.Category, created)
 
 	// Embed if available
 	if e.Embedder != nil && node.L0Abstract != "" {
-		stored, err := e.DB.GetNodeByURI(uri)
+		stored, err := e.DB.GetNodeByURI(storedURI)
 		if err == nil && stored != nil {
 			if err := e.EmbedNode(ctx, stored); err != nil {
-				log.Printf("remember: embed %s: %v", uri, err)
+				log.Printf("remember: embed %s: %v", storedURI, err)
 			}
 		}
 	}
@@ -320,7 +321,7 @@ func (e *Engine) Remember(ctx context.Context, input RememberInput) (string, boo
 		}
 	}
 
-	return uri, created, nil
+	return storedURI, created, nil
 }
 
 const maxMoments = 10

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -534,6 +534,78 @@ func TestRememberMerge(t *testing.T) {
 	}
 }
 
+// TestRememberHonorsExplicitSlug is the regression test for issue #11.
+// Two distinct events with overlapping summary words (high TFIDF cosine) used
+// to be silently deduped: the second write was redirected onto the first
+// memory's URI, the new content was created at a hidden timestamp-suffixed
+// node, and the response reported `updated:` pointing at the unrelated first
+// memory. The fix is to honor the caller-supplied slug verbatim on the
+// Remember API and report the actually-stored URI.
+func TestRememberHonorsExplicitSlug(t *testing.T) {
+	db := testDB(t)
+	mock := &llm.MockClient{Response: &llm.Response{Content: "[]"}}
+	eng := New(db, mock)
+
+	embedder, err := NewTFIDFEmbedder(db, 512)
+	if err != nil {
+		t.Fatalf("NewTFIDFEmbedder: %v", err)
+	}
+	eng.SetEmbedder(embedder)
+
+	ctx := context.Background()
+
+	uri1, created1, err := eng.Remember(ctx, RememberInput{
+		Category: "events",
+		Name:     "test-dedup-foo-1234",
+		Summary:  "Foo test memory for dedup repro",
+		Body:     "This is the FOO memory for testing dedup. It should be a brand new node at events/test-dedup-foo-1234.",
+	})
+	if err != nil {
+		t.Fatalf("first Remember: %v", err)
+	}
+	if !created1 {
+		t.Errorf("first call: created=false, want true")
+	}
+	if want := "mem://user/events/test-dedup-foo-1234"; uri1 != want {
+		t.Errorf("first URI = %q, want %q", uri1, want)
+	}
+
+	// Second write: distinct slug, body content, but overlapping summary words —
+	// pre-fix this would trip the similarity dedup and silently merge onto FOO.
+	uri2, created2, err := eng.Remember(ctx, RememberInput{
+		Category: "events",
+		Name:     "test-dedup-bar-5678",
+		Summary:  "Bar test memory for dedup repro",
+		Body:     "This is the BAR memory for testing dedup. It should be a brand new node at events/test-dedup-bar-5678 — completely unrelated content from foo.",
+	})
+	if err != nil {
+		t.Fatalf("second Remember: %v", err)
+	}
+	if !created2 {
+		t.Errorf("second call: created=false, want true (distinct slug should be a fresh node)")
+	}
+	if want := "mem://user/events/test-dedup-bar-5678"; uri2 != want {
+		t.Errorf("second URI = %q, want %q (caller's slug must be honored verbatim)", uri2, want)
+	}
+
+	// Both nodes must exist independently — neither has consumed the other.
+	foo, err := db.GetNodeByURI("mem://user/events/test-dedup-foo-1234")
+	if err != nil || foo == nil {
+		t.Fatalf("FOO node missing after second write")
+	}
+	if !strings.Contains(foo.L1Overview, "FOO") {
+		t.Errorf("FOO node body was overwritten: %q", foo.L1Overview)
+	}
+
+	bar, err := db.GetNodeByURI("mem://user/events/test-dedup-bar-5678")
+	if err != nil || bar == nil {
+		t.Fatalf("BAR node missing — second write was silently dropped (#11 regression)")
+	}
+	if !strings.Contains(bar.L1Overview, "BAR") {
+		t.Errorf("BAR node body wrong: %q", bar.L1Overview)
+	}
+}
+
 func TestMomentPoolEviction(t *testing.T) {
 	db := testDB(t)
 	mock := &llm.MockClient{Response: &llm.Response{Content: "[]"}}


### PR DESCRIPTION
## Summary

- Closes #11. Two writes with distinct slugs but overlapping summary words were silently merging because the LLM-extraction-path similarity dedup was also running on the direct \`Remember\` API. The reporter's BAR write was redirected onto FOO's URI; \`UpsertNode\` then took the immutable-collision branch and wrote the BAR content to a hidden timestamp-suffixed node; the response reported \`updated: <FOO-URI>\` pointing at unrelated content. Net effect: silent data loss with a success-shaped response.
- Direct \`Remember\` calls are explicit user/agent intent — the slug is the contract. Skip the similarity gate here. The LLM extraction path (\`extractor.go:170\`) is untouched and keeps its dedup, since LLM-generated slugs benefit from near-duplicate collapsing.
- Also fix the response to reflect reality: when \`UpsertNode\` mutates the URI on an immutable-category slug collision (timestamp suffix), report the actually-stored URI and \`created=true\` instead of the original requested URI.

## Repro from issue (now passes)

\`\`\`
$ continuity remember -c events -n test-dedup-foo-1234 -s "Foo test..." -b "FOO body..."
created: mem://user/events/test-dedup-foo-1234 [events]

$ continuity remember -c events -n test-dedup-bar-5678 -s "Bar test..." -b "BAR body..."
created: mem://user/events/test-dedup-bar-5678 [events]   # was: updated: mem://user/events/test-dedup-foo-1234
\`\`\`

## Triage answers (from the issue body)

> Is there an intentional fuzzy-match dedup heuristic on remember?

There was. It was inherited from the LLM-extraction path, where it makes sense (the LLM may pick slightly different slugs for the same fact). On the direct API it's the wrong default — the slug is provided.

> Is the \`updated:\` URI in the response intentional?

No, that was a second bug stacked on top: the engine returned the pre-upsert \`uri\` variable instead of the post-upsert \`node.URI\`, which masked the timestamp-suffix mutation. Fixed.

> Should the slug from \`-n\` always create a distinct node when no exact-slug collision exists?

Yes. That's now the contract.

## Test plan

- [x] \`go test ./internal/engine/... -run TestRememberHonorsExplicitSlug -v\` — new regression test built from the issue's exact repro: two writes with overlapping summary words, distinct slugs, both under \`events\` (immutable). Asserts both URIs match the requested slug, both report \`created=true\`, and both nodes exist with the right body content.
- [x] \`go test ./...\` — full suite green; existing \`TestRememberMerge\` (mergeable update path) still passes.
- [x] \`go vet ./...\` — clean.

## Out of scope

- The LLM extraction dedup heuristic at \`extractor.go:170\` is unchanged. If we ever want it tunable on the \`Remember\` path, that's an opt-in flag, not a default.
- #12 (no delete/forget path) is the natural follow-up — once direct writes are honest, we need a way to remove what gets stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)