### PR TITLE
Document AUR install source

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ curl -fsSL https://raw.githubusercontent.com/lazypower/continuity/main/install.s
 # Homebrew
 brew install lazypower/tap/continuity
 
+# Arch Linux (AUR) — community-maintained by @klrmngr
+yay -S continuity-bin     # or: paru -S continuity-bin
+
 # From source
 git clone https://github.com/lazypower/continuity.git
 cd continuity && make build


### PR DESCRIPTION
## Summary

- Closes #17. @klrmngr submitted continuity to the AUR as [`continuity-bin`](https://aur.archlinux.org/packages/continuity-bin) on 2026-05-01 (version 0.4.0-1, MIT, `Provides: continuity` / `Conflicts: continuity` — anticipating a from-source variant later).
- Adds a four-line entry to the README install block alongside the existing install.sh, Homebrew, and from-source paths so Arch users have the canonical entry point.
- The "community-maintained by @klrmngr" tag is intentional. Community AUR packages are best supported by routing breakage reports to the package maintainer first; the README should set that expectation rather than send Arch users to file every PKGBUILD complaint here.

## Out of scope (for separate triage)

- The AUR description currently reads "A self-hosted personal changelog and activity tracker," which is an off-shape read of what continuity actually is. If we want to nudge it toward "Persistent memory for AI coding agents," that's a polite ping to klrmngr, not a unilateral edit.
- No CHANGELOG file exists in the repo, so no release-note update was needed. If we add one later, the AUR landing date is worth a line.

## Test plan

- [x] `git diff README.md` — three lines added, no other surfaces touched.
- [ ] Visual: render the README on GitHub after merge, confirm the install block reads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)