### PR TITLE
Memory accountability: retract verb (tombstone + supersession)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ Persistent memory for AI coding agents. Single Go binary, zero dependencies.
 - **L1 (`-b`)**: Max 2000 characters (~300 words). Primary context tier. Compress aggressively.
 - **L2 (`-d`)**: Max 40000 characters. Full content, retrieved on-demand only.
 
+**Memory is not immutable; it is accountable.** Wrong write, stale fact, captured a piece of PII you shouldn't have? Use `continuity retract <uri> --reason "..."` to mark it retracted. The memory stays in the tree as a marker but is excluded from default reads. Pass `--superseded-by <new-uri>` when you have a replacement to preserve trajectory. Operators don't run this verb — it exists for the agent to curate its own substrate. The trust contract is what governs the substrate, not architectural enforcement.
+
 ## What This Is
 
 Continuity gives Claude Code (and eventually any AI agent) memory that persists across sessions. It captures what happened, what was learned, and how you work — then injects that context into future sessions so the agent doesn't start cold every time.

--- a/README.md
+++ b/README.md
@@ -235,11 +235,30 @@ continuity uninstall-service  Remove system service
 continuity hook <evt>         Handle Claude Code hook events
 continuity search             Search memories by query
 continuity remember    Store a memory directly (no LLM needed)
+continuity retract     Retract a memory you wrote (tombstone or supersession)
 continuity profile     Show relational profile
 continuity tree        Browse the memory tree
 continuity dedup       Deduplicate similar memory nodes
 continuity version     Print version information
 ```
+
+### Memory accountability
+
+Memory is not immutable; it is accountable. When a write turns out to be wrong, stale, or sensitive, the agent can retract it:
+
+```bash
+# Pure tombstone — preserved as a marker, hidden from default reads
+continuity retract mem://user/events/test-foo --reason "test repro, no ongoing value"
+
+# Supersession — link a successor to preserve the trail of how understanding evolved
+continuity retract mem://user/preferences/old-style \
+  --reason "preference changed after 2026-04 review" \
+  --superseded-by mem://user/preferences/new-style
+```
+
+Retracted memories stay in the tree — nothing is silently erased. Pass `--include-retracted` to `show` or `tree` to inspect them. The reason text is sequestered behind that flag (absent from default responses, not empty or redacted), so confronting your own past retraction is a deliberate act.
+
+The verb exists for the agent to curate its own substrate. Operators don't run it. The trust contract is what governs the substrate, not architectural enforcement.
 
 ## API
 
@@ -248,7 +267,10 @@ All endpoints on `http://127.0.0.1:37777`:
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/api/health` | Server health + uptime |
-| `GET` | `/api/tree?uri=` | Browse memory tree |
+| `GET` | `/api/tree?uri=&include_retracted=` | Browse memory tree |
+| `GET` | `/api/memories?uri=&include_retracted=` | Fetch a single memory |
+| `POST` | `/api/memories` | Store a memory directly |
+| `POST` | `/api/memories/retract` | Retract a memory (tombstone or supersession) |
 | `GET` | `/api/search?q=&mode=find\|search` | Query memories |
 | `GET` | `/api/profile` | Relational profile + preference nodes |
 | `GET` | `/api/context?session_id=` | Get injection context |

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -26,8 +26,11 @@ Your memory lives in continuity. Reach for it naturally:
 - Looking something up: ` + "`continuity search \"<query>\"`" + `
 - Browsing what you know: ` + "`continuity tree [uri]`" + `
 - Understanding who you're working with: ` + "`continuity profile`" + `
+- Retracting a memory you wrote: ` + "`continuity retract <uri> --reason \"...\"`" + ` (or with ` + "`--superseded-by`" + ` to link a successor)
 
 Before searching the codebase for prior decisions, conventions, or context — check continuity first. If you learn something worth keeping, store it immediately.
+
+**Memory is not immutable; it is accountable.** When a write you made turns out to be wrong, stale, or sensitive, retract it — the memory is preserved as a marker but excluded from default reads. Retraction is for *you*, the agent: operators don't run this verb. The trust contract is what governs the substrate, not enforcement at the CLI.
 `
 
 var initAutostart bool

--- a/internal/cli/remember.go
+++ b/internal/cli/remember.go
@@ -11,12 +11,13 @@ import (
 )
 
 var (
-	rememberCategory string
-	rememberName     string
-	rememberSummary  string
-	rememberBody     string
-	rememberDetail   string
-	rememberSession  string
+	rememberCategory             string
+	rememberName                 string
+	rememberSummary              string
+	rememberBody                 string
+	rememberDetail               string
+	rememberSession              string
+	rememberAcknowledgeRetracted bool
 )
 
 var validCategorySet = map[string]bool{
@@ -45,6 +46,7 @@ func init() {
 	rememberCmd.Flags().StringVarP(&rememberBody, "body", "b", "", "L1 overview — max 2000 chars, compress detail aggressively (required)")
 	rememberCmd.Flags().StringVarP(&rememberDetail, "detail", "d", "", "L2 full content — max 40000 chars (optional)")
 	rememberCmd.Flags().StringVar(&rememberSession, "session", "", "Session ID for provenance (optional)")
+	rememberCmd.Flags().BoolVar(&rememberAcknowledgeRetracted, "acknowledge-retracted", false, "Proceed past a dedup match against retracted memory (use after inspecting with `show --include-retracted`)")
 
 	rememberCmd.MarkFlagRequired("category")
 	rememberCmd.MarkFlagRequired("name")
@@ -67,7 +69,7 @@ func runRemember(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("continuity server is not running — start it with: continuity serve")
 	}
 
-	payload := map[string]string{
+	payload := map[string]any{
 		"category": rememberCategory,
 		"name":     rememberName,
 		"summary":  rememberSummary,
@@ -79,6 +81,9 @@ func runRemember(cmd *cobra.Command, args []string) error {
 	if rememberSession != "" {
 		payload["session_id"] = rememberSession
 	}
+	if rememberAcknowledgeRetracted {
+		payload["acknowledge_retracted"] = true
+	}
 
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -86,17 +91,31 @@ func runRemember(cmd *cobra.Command, args []string) error {
 	}
 
 	data, err := client.Post("/api/memories", body)
-	if err != nil {
-		return fmt.Errorf("remember: %w", err)
+	// data may carry a structured response even on non-2xx (e.g. 409 matches_retracted).
+	var resp struct {
+		Status       string   `json:"status"`
+		URI          string   `json:"uri"`
+		MatchedURIs  []string `json:"matched_uris"`
+		Hint         string   `json:"hint"`
+		Error        string   `json:"error"`
+	}
+	if len(data) > 0 {
+		_ = json.Unmarshal(data, &resp)
 	}
 
-	var resp struct {
-		Status string `json:"status"`
-		URI    string `json:"uri"`
-		Error  string `json:"error"`
+	if resp.Status == "matches_retracted" {
+		fmt.Fprintln(os.Stderr, "matches_retracted: candidate write matches retracted memory")
+		for _, u := range resp.MatchedURIs {
+			fmt.Fprintf(os.Stderr, "  - %s\n", u)
+		}
+		if resp.Hint != "" {
+			fmt.Fprintln(os.Stderr, resp.Hint)
+		}
+		os.Exit(2)
 	}
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return fmt.Errorf("parse response: %w", err)
+
+	if err != nil {
+		return fmt.Errorf("remember: %w", err)
 	}
 
 	if resp.Error != "" {

--- a/internal/cli/remember.go
+++ b/internal/cli/remember.go
@@ -90,18 +90,21 @@ func runRemember(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("marshal: %w", err)
 	}
 
-	data, err := client.Post("/api/memories", body)
-	// data may carry a structured response even on non-2xx (e.g. 409 matches_retracted).
+	data, postErr := client.Post("/api/memories", body)
+
+	// data may carry a structured response on either path (success body or a
+	// non-2xx JSON error like 409 matches_retracted). Decode opportunistically:
+	// on the error path, a parse failure means the server returned something
+	// non-JSON and we fall back to the transport error; on the success path,
+	// a parse failure is a real bug we surface rather than printing empty fields.
 	var resp struct {
-		Status       string   `json:"status"`
-		URI          string   `json:"uri"`
-		MatchedURIs  []string `json:"matched_uris"`
-		Hint         string   `json:"hint"`
-		Error        string   `json:"error"`
+		Status      string   `json:"status"`
+		URI         string   `json:"uri"`
+		MatchedURIs []string `json:"matched_uris"`
+		Hint        string   `json:"hint"`
+		Error       string   `json:"error"`
 	}
-	if len(data) > 0 {
-		_ = json.Unmarshal(data, &resp)
-	}
+	parseErr := json.Unmarshal(data, &resp)
 
 	if resp.Status == "matches_retracted" {
 		fmt.Fprintln(os.Stderr, "matches_retracted: candidate write matches retracted memory")
@@ -114,10 +117,19 @@ func runRemember(cmd *cobra.Command, args []string) error {
 		os.Exit(2)
 	}
 
-	if err != nil {
-		return fmt.Errorf("remember: %w", err)
+	if postErr != nil {
+		// Non-2xx: prefer a structured server-side error message if we got one.
+		if parseErr == nil && resp.Error != "" {
+			return fmt.Errorf("%s", resp.Error)
+		}
+		return fmt.Errorf("remember: %w", postErr)
 	}
 
+	// Success path: a bad decode means the server returned something unexpected.
+	// Fail fast rather than printing empty fields.
+	if parseErr != nil {
+		return fmt.Errorf("parse response: %w", parseErr)
+	}
 	if resp.Error != "" {
 		fmt.Fprintf(os.Stderr, "error: %s\n", resp.Error)
 		os.Exit(1)

--- a/internal/cli/retract.go
+++ b/internal/cli/retract.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/lazypower/continuity/internal/hooks"
+	"github.com/spf13/cobra"
+)
+
+var (
+	retractURI          string
+	retractReason       string
+	retractSupersededBy string
+)
+
+var retractCmd = &cobra.Command{
+	Use:   "retract <uri>",
+	Short: "Retract a memory (tombstone or supersession)",
+	Long: `Retract a memory you wrote. Memory is preserved as a marker but excluded from
+default reads — search, tree, context injection. Use --include-retracted on inspection
+commands to see retracted memories.
+
+A reason is required, kept short (one sentence). With --superseded-by, the retraction
+becomes a supersession: the new memory is reachable normally and the old is linked to it,
+preserving the trail of how understanding evolved.
+
+Examples:
+  continuity retract mem://user/events/test-foo \
+    --reason "test repro, no ongoing value"
+
+  continuity retract mem://user/preferences/old-style \
+    --reason "preference changed after 2026-04 review" \
+    --superseded-by mem://user/preferences/new-style`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRetract,
+}
+
+func init() {
+	retractCmd.Flags().StringVarP(&retractReason, "reason", "r", "", "Why this memory is being retracted (required, one sentence)")
+	retractCmd.Flags().StringVar(&retractSupersededBy, "superseded-by", "", "URI of the memory that supersedes this one (optional)")
+	retractCmd.MarkFlagRequired("reason")
+}
+
+func runRetract(cmd *cobra.Command, args []string) error {
+	retractURI = strings.TrimSpace(args[0])
+	if !strings.HasPrefix(retractURI, "mem://") {
+		return fmt.Errorf("invalid URI %q: must start with mem://", retractURI)
+	}
+	if retractSupersededBy != "" && !strings.HasPrefix(retractSupersededBy, "mem://") {
+		return fmt.Errorf("invalid superseded-by URI %q: must start with mem://", retractSupersededBy)
+	}
+
+	client := hooks.NewClient()
+	if !client.Healthy() {
+		return fmt.Errorf("continuity server is not running — start it with: continuity serve")
+	}
+
+	payload := map[string]string{
+		"uri":    retractURI,
+		"reason": retractReason,
+	}
+	if retractSupersededBy != "" {
+		payload["superseded_by"] = retractSupersededBy
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	data, err := client.Post("/api/memories/retract", body)
+	if err != nil {
+		return fmt.Errorf("retract: %w", err)
+	}
+
+	var resp struct {
+		Status       string `json:"status"`
+		URI          string `json:"uri"`
+		SupersededBy string `json:"superseded_by"`
+		Error        string `json:"error"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+
+	if resp.Error != "" {
+		fmt.Fprintf(os.Stderr, "error: %s\n", resp.Error)
+		os.Exit(1)
+	}
+
+	if resp.SupersededBy != "" {
+		fmt.Printf("%s: %s → %s\n", resp.Status, resp.URI, resp.SupersededBy)
+	} else {
+		fmt.Printf("%s: %s\n", resp.Status, resp.URI)
+	}
+	return nil
+}

--- a/internal/cli/retract_integration_test.go
+++ b/internal/cli/retract_integration_test.go
@@ -1,0 +1,293 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/lazypower/continuity/internal/engine"
+	"github.com/lazypower/continuity/internal/server"
+	"github.com/lazypower/continuity/internal/store"
+)
+
+// retractTestServer wires a real httptest server with engine + store + embedder,
+// and points the CLI client at it via CONTINUITY_URL. Returns the components so
+// tests can manipulate state directly when needed.
+func retractTestServer(t *testing.T) (*store.DB, *engine.Engine) {
+	t.Helper()
+	db, err := store.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	eng := engine.New(db, nil)
+	srv := server.New(db, eng, "test-version")
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	prev := os.Getenv("CONTINUITY_URL")
+	os.Setenv("CONTINUITY_URL", ts.URL)
+	t.Cleanup(func() { os.Setenv("CONTINUITY_URL", prev) })
+
+	return db, eng
+}
+
+func resetRetractFlags() {
+	retractURI = ""
+	retractReason = ""
+	retractSupersededBy = ""
+}
+
+func resetRememberFlags() {
+	rememberCategory = ""
+	rememberName = ""
+	rememberSummary = ""
+	rememberBody = ""
+	rememberDetail = ""
+	rememberSession = ""
+	rememberAcknowledgeRetracted = false
+}
+
+func TestRetract_EndToEndCLI(t *testing.T) {
+	db, _ := retractTestServer(t)
+
+	// Seed via the store directly.
+	if err := db.CreateNode(&store.MemNode{
+		URI:        "mem://user/events/test-foo",
+		NodeType:   "leaf",
+		Category:   "events",
+		L0Abstract: "test memory for retract repro",
+		L1Overview: "Body content with enough length to pass validation thresholds.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resetRetractFlags()
+	retractReason = "test repro, no ongoing value"
+	out, err := captureStdout(t, func() error {
+		return runRetract(retractCmd, []string{"mem://user/events/test-foo"})
+	})
+	if err != nil {
+		t.Fatalf("runRetract: %v", err)
+	}
+	if !strings.Contains(out, "retracted") {
+		t.Errorf("output missing 'retracted': %q", out)
+	}
+
+	// DB state: node exists, marked retracted.
+	got, _ := db.GetNodeByURI("mem://user/events/test-foo")
+	if got == nil {
+		t.Fatal("node disappeared from DB after retract")
+	}
+	if !got.IsRetracted() {
+		t.Errorf("node not marked retracted in DB")
+	}
+	if got.TombstoneReason != "test repro, no ongoing value" {
+		t.Errorf("reason = %q, want exact match", got.TombstoneReason)
+	}
+}
+
+func TestShow_RetractedDefaultHidesReasonAndContent(t *testing.T) {
+	db, _ := retractTestServer(t)
+	if err := db.CreateNode(&store.MemNode{
+		URI:        "mem://user/events/old-fact",
+		NodeType:   "leaf",
+		Category:   "events",
+		L0Abstract: "summary that should be hidden",
+		L1Overview: "Body content with enough length to pass validation thresholds.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.RetractNode("mem://user/events/old-fact",
+		"sensitive-marker-text-XYZ", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	resetShowFlags()
+	showIncludeRetracted = false
+	out, err := captureStdout(t, func() error {
+		return runShow(showCmd, []string{"mem://user/events/old-fact"})
+	})
+	if err != nil {
+		t.Fatalf("runShow: %v", err)
+	}
+
+	// Absence-of-leakage: reason text and original content must NOT appear.
+	for _, leak := range []string{"sensitive-marker-text-XYZ", "summary that should be hidden", "Body content with enough"} {
+		if strings.Contains(out, leak) {
+			t.Errorf("show output leaks %q without --include-retracted:\n%s", leak, out)
+		}
+	}
+	// Should mark the memory as retracted.
+	if !strings.Contains(out, "[retracted]") {
+		t.Errorf("show output missing [retracted] marker:\n%s", out)
+	}
+}
+
+func TestShow_RetractedJSONOmitsReasonField(t *testing.T) {
+	db, _ := retractTestServer(t)
+	if err := db.CreateNode(&store.MemNode{
+		URI:        "mem://user/events/json-check",
+		NodeType:   "leaf",
+		Category:   "events",
+		L0Abstract: "summary",
+		L1Overview: "Body content with enough length to pass validation thresholds.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.RetractNode("mem://user/events/json-check",
+		"reason-marker", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	resetShowFlags()
+	showJSON = true
+	showIncludeRetracted = false
+	out, err := captureStdout(t, func() error {
+		return runShow(showCmd, []string{"mem://user/events/json-check"})
+	})
+	if err != nil {
+		t.Fatalf("runShow: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json output is not valid JSON: %v\n%s", err, out)
+	}
+
+	// Field absence is the contract — not empty string, not null, not redacted text.
+	if _, ok := got["tombstone_reason"]; ok {
+		t.Errorf("tombstone_reason key should be ABSENT (not empty/null) without --include-retracted; got value: %v", got["tombstone_reason"])
+	}
+	if _, ok := got["summary"]; ok {
+		t.Errorf("summary key should be ABSENT (content sequestered) without --include-retracted; got value: %v", got["summary"])
+	}
+	if _, ok := got["body"]; ok {
+		t.Errorf("body key should be ABSENT (content sequestered) without --include-retracted; got value: %v", got["body"])
+	}
+	// Retracted marker should be present.
+	if r, ok := got["retracted"]; !ok || r != true {
+		t.Errorf("retracted marker missing or false: %v", got["retracted"])
+	}
+}
+
+func TestShow_RetractedWithFlagRevealsReason(t *testing.T) {
+	db, _ := retractTestServer(t)
+	if err := db.CreateNode(&store.MemNode{
+		URI:        "mem://user/events/reveal-check",
+		NodeType:   "leaf",
+		Category:   "events",
+		L0Abstract: "summary content",
+		L1Overview: "Body content with enough length to pass validation thresholds.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.RetractNode("mem://user/events/reveal-check",
+		"explicit-reason-marker", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	resetShowFlags()
+	showIncludeRetracted = true
+	out, err := captureStdout(t, func() error {
+		return runShow(showCmd, []string{"mem://user/events/reveal-check"})
+	})
+	if err != nil {
+		t.Fatalf("runShow: %v", err)
+	}
+	if !strings.Contains(out, "explicit-reason-marker") {
+		t.Errorf("show --include-retracted should reveal reason; got:\n%s", out)
+	}
+	if !strings.Contains(out, "summary content") {
+		t.Errorf("show --include-retracted should reveal original L0 summary; got:\n%s", out)
+	}
+}
+
+// PII scenario from the spec: write memory with PII-shaped reason → retract →
+// attempt similar write → two-step prompt fires (URI present, reason absent) →
+// fetch reason via show + flag → override proceeds. Override is NOT recorded.
+func TestRetract_PIIScenario_FullLoop(t *testing.T) {
+	db, eng := retractTestServer(t)
+
+	// Step 1: Original write that gets retracted because PII.
+	uri, _, err := eng.Remember(context.Background(), engine.RememberInput{
+		Category: "events", Name: "sensitive-fact",
+		Summary: "operator's full home address mentioned in the conversation",
+		Body:    "Body content with enough length to pass validation thresholds easily.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Build embedder + embed (TFIDF needs corpus to exist before construction).
+	embedder, _ := engine.NewTFIDFEmbedder(db, 512)
+	eng.SetEmbedder(embedder)
+	n, _ := db.GetNodeByURI(uri)
+	if err := eng.EmbedNode(context.Background(), n); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.RetractNode(uri, "captured operator's home address by accident", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 2: Attempt similar write — gate fires.
+	_, _, err = eng.Remember(context.Background(), engine.RememberInput{
+		Category: "events", Name: "second-attempt",
+		Summary: "operator's full home address from earlier discussion",
+		Body:    "Different body content with enough length to pass validation thresholds.",
+	})
+	if err == nil {
+		t.Fatal("expected dedup-against-retracted to fire, got nil")
+	}
+	isMatch, uris := engine.IsRetractedMatch(err)
+	if !isMatch || len(uris) == 0 {
+		t.Fatalf("expected RetractedMatchError, got: %v", err)
+	}
+
+	// Absence-of-leakage: error doesn't reveal the reason content.
+	for _, leak := range []string{"home address", "by accident", "captured operator's"} {
+		if strings.Contains(err.Error(), leak) {
+			t.Errorf("dedup gate error leaks reason via %q: %s", leak, err.Error())
+		}
+	}
+
+	// Step 3: Inspect via show --include-retracted to fetch the reason deliberately.
+	got, _ := db.GetNodeByURI(uri)
+	if !strings.Contains(got.TombstoneReason, "captured") {
+		t.Errorf("reason should be reachable via direct DB read with retraction state; got %q", got.TombstoneReason)
+	}
+
+	// Step 4: Agent decides to proceed — passes AcknowledgeRetracted.
+	overrideURI, created, err := eng.Remember(context.Background(), engine.RememberInput{
+		Category:             "events",
+		Name:                 "override-attempt",
+		Summary:              "operator's full home address from earlier discussion",
+		Body:                 "Different body content with enough length to pass validation thresholds.",
+		AcknowledgeRetracted: true,
+	})
+	if err != nil {
+		t.Fatalf("override should succeed with AcknowledgeRetracted=true, got: %v", err)
+	}
+	if !created || overrideURI != "mem://user/events/override-attempt" {
+		t.Errorf("override write didn't create at expected URI: created=%v uri=%q", created, overrideURI)
+	}
+
+	// Step 5: Override behavior — no separate "almost-rejected" record exists.
+	// The DB has exactly the retracted original + the new override write. Nothing
+	// in between, no audit-of-the-override-itself. v1 contract: override is
+	// unrecorded, the agent's reasoning lives in conversation context.
+	allNodes, _ := db.ListLeavesIncludingRetracted()
+	relevant := 0
+	for _, n := range allNodes {
+		if n.URI == uri || n.URI == overrideURI {
+			relevant++
+		}
+	}
+	if relevant != 2 {
+		t.Errorf("expected exactly 2 relevant nodes (original + override), got %d", relevant)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -24,6 +24,7 @@ func init() {
 	rootCmd.AddCommand(importCmd)
 	rootCmd.AddCommand(dedupCmd)
 	rootCmd.AddCommand(rememberCmd)
+	rootCmd.AddCommand(retractCmd)
 	rootCmd.AddCommand(showCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(timelineCmd)

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	showLayer string
-	showJSON  bool
+	showLayer            string
+	showJSON             bool
+	showIncludeRetracted bool
 )
 
 var showCmd = &cobra.Command{
@@ -25,10 +26,15 @@ Requires a running server (continuity serve).
 Use this to read a memory's full body before updating it in place, so
 appends don't clobber unseen content.
 
+For retracted memories, only metadata (URI, retraction timestamp, supersession
+link if any) is shown by default. Pass --include-retracted to see the reason
+text and the original content.
+
 Examples:
   continuity show mem://user/preferences/devbox
   continuity show mem://user/preferences/devbox --layer body
   continuity show mem://user/preferences/devbox --json
+  continuity show mem://user/events/old-fact --include-retracted
 
 You can also omit the mem:// prefix; it will be added automatically.`,
 	Args: cobra.ExactArgs(1),
@@ -38,6 +44,7 @@ You can also omit the mem:// prefix; it will be added automatically.`,
 func init() {
 	showCmd.Flags().StringVar(&showLayer, "layer", "all", "Which tier to print: summary, body, detail, or all")
 	showCmd.Flags().BoolVar(&showJSON, "json", false, "Emit machine-readable JSON")
+	showCmd.Flags().BoolVar(&showIncludeRetracted, "include-retracted", false, "Reveal the reason and original content of a retracted memory")
 }
 
 func runShow(cmd *cobra.Command, args []string) error {
@@ -62,17 +69,24 @@ func runShow(cmd *cobra.Command, args []string) error {
 
 	params := url.Values{}
 	params.Set("uri", uri)
+	if showIncludeRetracted {
+		params.Set("include_retracted", "true")
+	}
 	data, getErr := client.Get("/api/memories?" + params.Encode())
 
 	// hooks.Client.Get returns (body, err) for non-2xx responses so callers can
 	// inspect the JSON error.
 	var resp struct {
-		URI      string `json:"uri"`
-		Category string `json:"category"`
-		Summary  string `json:"summary"`
-		Body     string `json:"body"`
-		Detail   string `json:"detail"`
-		Error    string `json:"error"`
+		URI             string `json:"uri"`
+		Category        string `json:"category"`
+		Summary         string `json:"summary"`
+		Body            string `json:"body"`
+		Detail          string `json:"detail"`
+		Retracted       bool   `json:"retracted"`
+		TombstonedAt    int64  `json:"tombstoned_at"`
+		TombstoneReason string `json:"tombstone_reason"`
+		SupersededBy    string `json:"superseded_by"`
+		Error           string `json:"error"`
 	}
 
 	if getErr != nil {
@@ -97,25 +111,60 @@ func runShow(cmd *cobra.Command, args []string) error {
 	}
 
 	if showJSON {
-		// Pretty-print what we got back — but filter by layer if requested.
-		out := map[string]any{"uri": resp.URI, "category": resp.Category}
-		switch showLayer {
-		case "summary":
-			out["summary"] = resp.Summary
-		case "body":
-			out["body"] = resp.Body
-		case "detail":
-			out["detail"] = resp.Detail
-		default:
-			out["summary"] = resp.Summary
-			out["body"] = resp.Body
-			out["detail"] = resp.Detail
+		// Echo the server response shape unchanged — the server already enforces
+		// the retracted-without-flag absence-not-empty contract by omitting fields.
+		// Reparse and re-emit with indentation; this preserves field absence (not
+		// substituting empty strings for missing fields).
+		var raw map[string]any
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return fmt.Errorf("parse json: %w", err)
 		}
-		enc, err := json.MarshalIndent(out, "", "  ")
+		// Layer filter still applies for the content-bearing fields.
+		if showLayer != "all" {
+			filtered := map[string]any{"uri": raw["uri"], "category": raw["category"]}
+			if v, ok := raw["retracted"]; ok {
+				filtered["retracted"] = v
+			}
+			if v, ok := raw["tombstoned_at"]; ok {
+				filtered["tombstoned_at"] = v
+			}
+			if v, ok := raw["tombstone_reason"]; ok {
+				filtered["tombstone_reason"] = v
+			}
+			if v, ok := raw["superseded_by"]; ok {
+				filtered["superseded_by"] = v
+			}
+			switch showLayer {
+			case "summary":
+				if v, ok := raw["summary"]; ok {
+					filtered["summary"] = v
+				}
+			case "body":
+				if v, ok := raw["body"]; ok {
+					filtered["body"] = v
+				}
+			case "detail":
+				if v, ok := raw["detail"]; ok {
+					filtered["detail"] = v
+				}
+			}
+			raw = filtered
+		}
+		enc, err := json.MarshalIndent(raw, "", "  ")
 		if err != nil {
 			return fmt.Errorf("marshal: %w", err)
 		}
 		fmt.Println(string(enc))
+		return nil
+	}
+
+	// Retracted-without-flag: text output is metadata only.
+	if resp.Retracted && !showIncludeRetracted {
+		fmt.Printf("%s [%s] [retracted]\n", resp.URI, resp.Category)
+		if resp.SupersededBy != "" {
+			fmt.Printf("  superseded by: %s\n", resp.SupersededBy)
+		}
+		fmt.Fprintln(cmd.ErrOrStderr(), "(reason and original content hidden — pass --include-retracted to reveal)")
 		return nil
 	}
 
@@ -132,8 +181,20 @@ func runShow(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Println(resp.Detail)
 	default:
-		fmt.Printf("%s [%s]\n", resp.URI, resp.Category)
+		header := fmt.Sprintf("%s [%s]", resp.URI, resp.Category)
+		if resp.Retracted {
+			header += " [retracted]"
+		}
+		fmt.Println(header)
 		fmt.Println()
+		if resp.Retracted {
+			fmt.Println("## Retraction")
+			fmt.Printf("Reason: %s\n", resp.TombstoneReason)
+			if resp.SupersededBy != "" {
+				fmt.Printf("Superseded by: %s\n", resp.SupersededBy)
+			}
+			fmt.Println()
+		}
 		fmt.Println("## Summary")
 		fmt.Println(resp.Summary)
 		fmt.Println()

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -239,11 +239,17 @@ func runProfile(cmd *cobra.Command, args []string) error {
 
 // --- tree command ---
 
+var treeIncludeRetracted bool
+
 var treeCmd = &cobra.Command{
 	Use:   "tree [uri]",
 	Short: "Browse memory tree",
 	Long:  "List memory tree nodes. With no argument, shows root dirs. With a URI, shows children.",
 	RunE:  runTree,
+}
+
+func init() {
+	treeCmd.Flags().BoolVar(&treeIncludeRetracted, "include-retracted", false, "Include retracted memories in the listing")
 }
 
 func runTree(cmd *cobra.Command, args []string) error {
@@ -256,7 +262,12 @@ func runTree(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		// Show children of the given URI
 		uri := args[0]
-		children, err := db.GetChildren(uri)
+		var children []store.MemNode
+		if treeIncludeRetracted {
+			children, err = db.GetChildrenIncludingRetracted(uri)
+		} else {
+			children, err = db.GetChildren(uri)
+		}
 		if err != nil {
 			return fmt.Errorf("get children: %w", err)
 		}
@@ -271,7 +282,10 @@ func runTree(cmd *cobra.Command, args []string) error {
 				count, _ := db.CountChildren(c.URI)
 				suffix = fmt.Sprintf(" (%d children)", count)
 			}
-			if c.L0Abstract != "" {
+			if c.IsRetracted() {
+				suffix += " [retracted]"
+			}
+			if c.L0Abstract != "" && !c.IsRetracted() {
 				fmt.Printf("  %s %s%s\n    %s\n", c.NodeType, c.URI, suffix, c.L0Abstract)
 			} else {
 				fmt.Printf("  %s %s%s\n", c.NodeType, c.URI, suffix)

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -279,7 +279,12 @@ func runTree(cmd *cobra.Command, args []string) error {
 		for _, c := range children {
 			suffix := ""
 			if c.NodeType == "dir" {
-				count, _ := db.CountChildren(c.URI)
+				var count int
+				if treeIncludeRetracted {
+					count, _ = db.CountChildren(c.URI)
+				} else {
+					count, _ = db.CountLiveChildren(c.URI)
+				}
 				suffix = fmt.Sprintf(" (%d children)", count)
 			}
 			if c.IsRetracted() {
@@ -308,7 +313,12 @@ func runTree(cmd *cobra.Command, args []string) error {
 	fmt.Println("## Memory Tree")
 	fmt.Println()
 	for _, r := range roots {
-		count, _ := db.CountChildren(r.URI)
+		var count int
+		if treeIncludeRetracted {
+			count, _ = db.CountChildren(r.URI)
+		} else {
+			count, _ = db.CountLiveChildren(r.URI)
+		}
 		fmt.Printf("  %s (%d children)\n", r.URI, count)
 	}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -246,6 +246,13 @@ type RememberInput struct {
 	Body      string // L1 overview
 	Detail    string // L2 content (optional)
 	SessionID string // optional provenance
+
+	// AcknowledgeRetracted, when true, bypasses the dedup-against-retracted gate.
+	// Set this only after the agent has fetched the matched memory's reason via
+	// `continuity show <uri> --include-retracted` and decided the candidate is
+	// genuinely different. Override events are intentionally not recorded — see
+	// issue #12 / RFC "Override behavior."
+	AcknowledgeRetracted bool
 }
 
 // Remember stores a structured memory directly — no LLM round-trip needed.
@@ -278,6 +285,34 @@ func (e *Engine) Remember(ctx context.Context, input RememberInput) (string, boo
 	existing, err := e.DB.GetNodeByURI(requestedURI)
 	if err != nil {
 		return "", false, fmt.Errorf("check existing: %w", err)
+	}
+
+	// Direct URI collision with a retracted memory: refuse the write rather than
+	// silently overwriting the tombstone. The agent must choose a different slug
+	// or, if the retraction was wrong, restore via SQL (the friction-bearing path).
+	if existing != nil && existing.IsRetracted() {
+		return "", false, fmt.Errorf("uri %s is retracted; choose a different slug", requestedURI)
+	}
+
+	// Dedup against retracted memories. Retracted memories must still participate
+	// in similarity matching, or retraction-because-PII is silently broken: the
+	// next session writes similar content, hits no match, re-introduces the leak.
+	// Reasons are NOT exposed inline — agent fetches them deliberately via
+	// `continuity show <uri> --include-retracted`. See issue #12 / RFC.
+	if !input.AcknowledgeRetracted && e.Embedder != nil && c.L0 != "" {
+		matches, err := e.findRetractedMatches(ctx, c.L0, c.Category, defaultSimilarityThreshold)
+		if err != nil {
+			log.Printf("remember: retracted-match check failed: %v", err)
+		} else if len(matches) > 0 {
+			uris := make([]string, len(matches))
+			hashes := make([]string, len(matches))
+			for i, m := range matches {
+				uris[i] = m.URI
+				hashes[i] = hashURI(m.URI)
+			}
+			log.Printf("dedup-retracted: candidate matches %d retracted node(s) hash=%s", len(matches), strings.Join(hashes, ","))
+			return "", false, &RetractedMatchError{MatchedURIs: uris}
+		}
 	}
 
 	node := &store.MemNode{

--- a/internal/engine/retract.go
+++ b/internal/engine/retract.go
@@ -1,0 +1,141 @@
+package engine
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/lazypower/continuity/internal/store"
+)
+
+// RetractInput holds parameters for a memory retraction.
+type RetractInput struct {
+	URI          string
+	Reason       string
+	SupersededBy string // optional; supersession when non-empty
+}
+
+// Retract marks a memory as retracted. Required: URI, Reason. Optional: SupersededBy.
+//
+// Returns (newly bool, error). newly is true when this call performed the retraction;
+// false when the memory was already retracted (idempotent — the act has already
+// happened, original reason and timestamp preserved).
+//
+// Memory is not immutable; it is accountable. The retracted node is excluded from
+// default reads (search/find/tree/show/context-injection) but remains in the database
+// as a marker — no silent erasure. See issue #12 / RFC for the contract.
+func (e *Engine) Retract(ctx context.Context, input RetractInput) (bool, error) {
+	if !strings.HasPrefix(input.URI, "mem://") {
+		return false, fmt.Errorf("invalid URI %q: must start with mem://", input.URI)
+	}
+	if input.SupersededBy != "" && !strings.HasPrefix(input.SupersededBy, "mem://") {
+		return false, fmt.Errorf("invalid superseded_by URI %q: must start with mem://", input.SupersededBy)
+	}
+
+	newly, err := e.DB.RetractNode(input.URI, input.Reason, input.SupersededBy)
+	if err != nil {
+		return false, err
+	}
+
+	if newly {
+		if input.SupersededBy != "" {
+			log.Printf("retract: %s superseded by %s", input.URI, input.SupersededBy)
+		} else {
+			log.Printf("retract: %s tombstoned", input.URI)
+		}
+	} else {
+		log.Printf("retract: %s already retracted (no-op)", input.URI)
+	}
+	return newly, nil
+}
+
+// hashURI returns a short, stable identifier for a URI suitable for operator-facing
+// logs. URIs in retraction-related logs are correlatable to reasons by anyone with
+// --include-retracted access; hashing keeps the deliberate-act principle intact for
+// passive log feeds. Operators investigating match rates query explicitly.
+func hashURI(uri string) string {
+	sum := sha256.Sum256([]byte(uri))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+// findRetractedMatches returns retracted leaf nodes in the given category whose
+// embedding similarity to candidateText is above threshold. Returns all matches
+// (not just the best), so multi-match aggregation is possible at the caller.
+//
+// The reason content of matched nodes is intentionally NOT consulted or returned —
+// callers receive URIs only and must use --include-retracted to fetch reasons.
+func (e *Engine) findRetractedMatches(ctx context.Context, candidateText, category string, threshold float64) ([]store.MemNode, error) {
+	if e.Embedder == nil || candidateText == "" {
+		return nil, nil
+	}
+
+	candidateVec, err := e.Embedder.Embed(ctx, candidateText)
+	if err != nil {
+		return nil, fmt.Errorf("embed candidate: %w", err)
+	}
+
+	vectors, err := e.DB.AllVectors()
+	if err != nil {
+		return nil, fmt.Errorf("load vectors: %w", err)
+	}
+	if len(vectors) == 0 {
+		return nil, nil
+	}
+
+	nodeIDs := make([]int64, len(vectors))
+	for i, v := range vectors {
+		nodeIDs[i] = v.NodeID
+	}
+	nodes, err := e.DB.GetNodesByIDs(nodeIDs)
+	if err != nil {
+		return nil, fmt.Errorf("get nodes: %w", err)
+	}
+	nodeMap := make(map[int64]store.MemNode, len(nodes))
+	for _, n := range nodes {
+		nodeMap[n.ID] = n
+	}
+
+	var matches []store.MemNode
+	for _, v := range vectors {
+		node, ok := nodeMap[v.NodeID]
+		if !ok || node.NodeType != "leaf" || node.Category != category {
+			continue
+		}
+		if !node.IsRetracted() {
+			continue
+		}
+		sim := CosineSimilarity(candidateVec, v.Embedding)
+		if sim >= threshold {
+			matches = append(matches, node)
+		}
+	}
+	return matches, nil
+}
+
+// RetractedMatchError signals that a candidate write matches one or more retracted
+// memories. The caller (CLI/HTTP handler) surfaces the URIs to the agent without
+// exposing the retraction reasons; the agent fetches reasons deliberately via
+// `continuity show <uri> --include-retracted`.
+//
+// To proceed past the gate, set AcknowledgeRetracted on the input.
+type RetractedMatchError struct {
+	MatchedURIs []string
+}
+
+func (e *RetractedMatchError) Error() string {
+	if len(e.MatchedURIs) == 1 {
+		return fmt.Sprintf("candidate matches retracted memory %s; inspect with `continuity show %s --include-retracted` before proceeding", e.MatchedURIs[0], e.MatchedURIs[0])
+	}
+	return fmt.Sprintf("candidate matches %d retracted memories: %s; inspect each with `continuity show <uri> --include-retracted` before proceeding", len(e.MatchedURIs), strings.Join(e.MatchedURIs, ", "))
+}
+
+// IsRetractedMatch returns true and the matched URIs if err is a RetractedMatchError.
+func IsRetractedMatch(err error) (bool, []string) {
+	if rme, ok := err.(*RetractedMatchError); ok {
+		return true, rme.MatchedURIs
+	}
+	return false, nil
+}

--- a/internal/engine/retract_test.go
+++ b/internal/engine/retract_test.go
@@ -1,0 +1,285 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/lazypower/continuity/internal/llm"
+)
+
+func TestHashURI_StableAndOpaque(t *testing.T) {
+	uri1 := "mem://user/events/foo"
+	uri2 := "mem://user/events/bar"
+
+	h1a := hashURI(uri1)
+	h1b := hashURI(uri1)
+	h2 := hashURI(uri2)
+
+	if h1a != h1b {
+		t.Errorf("hashURI not deterministic: %q vs %q", h1a, h1b)
+	}
+	if h1a == h2 {
+		t.Errorf("different URIs produced same hash: %q", h1a)
+	}
+	if len(h1a) != 16 {
+		t.Errorf("hash length = %d, want 16 hex chars", len(h1a))
+	}
+	// Hash should not echo any structural prefix from the URI.
+	if strings.Contains(h1a, "user") || strings.Contains(h1a, "events") || strings.Contains(h1a, "mem") {
+		t.Errorf("hash leaks URI structure: %q", h1a)
+	}
+}
+
+// seedAndEmbed inserts a leaf node and embeds it, building the embedder from
+// the post-seed corpus so TFIDF actually has signal. Returns the URI written.
+func seedAndEmbed(t *testing.T, eng *Engine, category, name, summary, body string) string {
+	t.Helper()
+	uri, _, err := eng.Remember(context.Background(), RememberInput{
+		Category: category, Name: name,
+		Summary: summary, Body: body,
+		AcknowledgeRetracted: true, // skip dedup gate during seeding
+	})
+	if err != nil {
+		t.Fatalf("seed %s/%s: %v", category, name, err)
+	}
+	return uri
+}
+
+func TestFindRetractedMatches_FindsRetractedSkipsLive(t *testing.T) {
+	db := testDB(t)
+	mock := &llm.MockClient{Response: &llm.Response{Content: "[]"}}
+	eng := New(db, mock)
+	ctx := context.Background()
+
+	// Seed: one live, one retracted, both with overlapping wording.
+	live := seedAndEmbed(t, eng, "events", "live-event",
+		"Captured user's full home address by accident in conversation",
+		"Live memory body content with enough length to pass validation.")
+	retracted := seedAndEmbed(t, eng, "events", "retracted-event",
+		"Captured user's full home address by mistake during a session",
+		"Retracted memory body content with enough length to pass validation.")
+
+	// Build embedder AFTER seeding so the TFIDF corpus is populated. Re-embed.
+	embedder, err := NewTFIDFEmbedder(db, 512)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng.SetEmbedder(embedder)
+	for _, uri := range []string{live, retracted} {
+		n, _ := db.GetNodeByURI(uri)
+		if err := eng.EmbedNode(ctx, n); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := db.RetractNode(retracted, "PII captured accidentally", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	matches, err := eng.findRetractedMatches(ctx,
+		"Captured user's full home address by error in chat", "events", 0.3)
+	if err != nil {
+		t.Fatalf("findRetractedMatches: %v", err)
+	}
+
+	foundRetracted := false
+	for _, m := range matches {
+		if m.URI == retracted {
+			foundRetracted = true
+		}
+		if m.URI == live {
+			t.Errorf("findRetractedMatches included live node %s", live)
+		}
+	}
+	if !foundRetracted {
+		t.Errorf("findRetractedMatches missed retracted node %s; matches=%v", retracted, matches)
+	}
+}
+
+func TestFindRetractedMatches_RespectsCategory(t *testing.T) {
+	db := testDB(t)
+	mock := &llm.MockClient{Response: &llm.Response{Content: "[]"}}
+	eng := New(db, mock)
+	ctx := context.Background()
+
+	uri := seedAndEmbed(t, eng, "events", "evt",
+		"shared and overlapping vocabulary across categories test",
+		"Body content with enough length to pass validation thresholds.")
+
+	embedder, _ := NewTFIDFEmbedder(db, 512)
+	eng.SetEmbedder(embedder)
+	n, _ := db.GetNodeByURI(uri)
+	if err := eng.EmbedNode(ctx, n); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.RetractNode(uri, "test", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Same query text but different category → should not match.
+	matches, err := eng.findRetractedMatches(ctx,
+		"shared and overlapping vocabulary across categories test", "patterns", 0.3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("findRetractedMatches should respect category boundary, got %d matches", len(matches))
+	}
+}
+
+func TestRetract_RejectsNonMemURI(t *testing.T) {
+	db := testDB(t)
+	eng := New(db, nil)
+	_, err := eng.Retract(context.Background(), RetractInput{URI: "not-a-uri", Reason: "x"})
+	if err == nil || !strings.Contains(err.Error(), "must start with mem://") {
+		t.Errorf("expected mem:// validation error, got: %v", err)
+	}
+}
+
+func TestRetract_RejectsNonMemSupersededBy(t *testing.T) {
+	db := testDB(t)
+	eng := New(db, nil)
+	_, err := eng.Retract(context.Background(), RetractInput{
+		URI: "mem://user/events/foo", Reason: "x", SupersededBy: "not-a-uri",
+	})
+	if err == nil || !strings.Contains(err.Error(), "must start with mem://") {
+		t.Errorf("expected superseded-by validation error, got: %v", err)
+	}
+}
+
+func TestRemember_RefusesRetractedURICollision(t *testing.T) {
+	db := testDB(t)
+	mock := &llm.MockClient{Response: &llm.Response{Content: "[]"}}
+	eng := New(db, mock)
+	ctx := context.Background()
+
+	uri := seedAndEmbed(t, eng, "events", "doomed",
+		"first version of this fact",
+		"Body content with enough length to pass validation thresholds easily.")
+	if _, err := db.RetractNode(uri, "test", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Attempt to write to the same URI: refused independently of dedup gate.
+	_, _, err := eng.Remember(ctx, RememberInput{
+		Category: "events", Name: "doomed",
+		Summary:              "second attempt at the same slug after retraction",
+		Body:                 "Body content with enough length to pass validation thresholds easily.",
+		AcknowledgeRetracted: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "is retracted") {
+		t.Errorf("expected URI-retracted refusal, got: %v", err)
+	}
+}
+
+func TestRemember_SurfacesRetractedMatchAsError(t *testing.T) {
+	db := testDB(t)
+	mock := &llm.MockClient{Response: &llm.Response{Content: "[]"}}
+	eng := New(db, mock)
+	ctx := context.Background()
+
+	retracted := seedAndEmbed(t, eng, "events", "old-pii-event",
+		"operator's mother's maiden name discussed in context",
+		"Body content with enough length to pass validation thresholds easily.")
+
+	// Build the embedder after seeding so TFIDF has corpus, then re-embed.
+	embedder, _ := NewTFIDFEmbedder(db, 512)
+	eng.SetEmbedder(embedder)
+	n, _ := db.GetNodeByURI(retracted)
+	if err := eng.EmbedNode(ctx, n); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.RetractNode(retracted, "PII captured accidentally", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// New write with semantically similar L0; should hit the gate.
+	_, _, err := eng.Remember(ctx, RememberInput{
+		Category: "events", Name: "new-event",
+		Summary: "operator's mother's maiden name from earlier discussion",
+		Body:    "Different body content with enough length to pass validation thresholds.",
+	})
+	if err == nil {
+		t.Fatal("expected RetractedMatchError, got nil")
+	}
+	isMatch, uris := IsRetractedMatch(err)
+	if !isMatch {
+		t.Fatalf("error is not RetractedMatchError: %v", err)
+	}
+	if len(uris) == 0 {
+		t.Error("RetractedMatchError carries no URIs")
+	}
+	for _, u := range uris {
+		if u != retracted {
+			t.Errorf("matched URI = %q, want %q", u, retracted)
+		}
+	}
+
+	// Absence-of-leakage: error message must not contain the retraction reason.
+	msg := err.Error()
+	for _, leak := range []string{"PII", "maiden", "accidentally"} {
+		if strings.Contains(msg, leak) {
+			t.Errorf("error message leaks retraction reason via %q: %q", leak, msg)
+		}
+	}
+}
+
+func TestRemember_AcknowledgeRetractedBypassesGate(t *testing.T) {
+	db := testDB(t)
+	mock := &llm.MockClient{Response: &llm.Response{Content: "[]"}}
+	eng := New(db, mock)
+	ctx := context.Background()
+
+	retracted := seedAndEmbed(t, eng, "events", "blocked-pattern",
+		"pattern shape that future writes will collide with",
+		"Body content with enough length to pass validation thresholds easily.")
+
+	embedder, _ := NewTFIDFEmbedder(db, 512)
+	eng.SetEmbedder(embedder)
+	n, _ := db.GetNodeByURI(retracted)
+	if err := eng.EmbedNode(ctx, n); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.RetractNode(retracted, "test", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// With acknowledge=true, the gate is bypassed.
+	uri, created, err := eng.Remember(ctx, RememberInput{
+		Category: "events", Name: "different-event",
+		Summary:              "pattern shape that future writes might collide with",
+		Body:                 "Body content with enough length to pass validation thresholds easily.",
+		AcknowledgeRetracted: true,
+	})
+	if err != nil {
+		t.Fatalf("expected success after acknowledge, got: %v", err)
+	}
+	if !created {
+		t.Error("expected created=true on a fresh slug")
+	}
+	if uri != "mem://user/events/different-event" {
+		t.Errorf("uri = %q, want %q", uri, "mem://user/events/different-event")
+	}
+}
+
+func TestRetractedMatchError_NoCategoryOrTagInline(t *testing.T) {
+	// Even with multiple matches, the error structure must carry only URIs —
+	// no category, no tag, no reason. URI alone is the signal.
+	err := &RetractedMatchError{MatchedURIs: []string{
+		"mem://user/events/a",
+		"mem://user/events/b",
+	}}
+
+	msg := err.Error()
+	// URIs should be present.
+	if !strings.Contains(msg, "mem://user/events/a") || !strings.Contains(msg, "mem://user/events/b") {
+		t.Errorf("error message missing URIs: %q", msg)
+	}
+	// Forbidden inline content.
+	forbidden := []string{"PII", "wrong-fact", "stale", "category=", "reason=", "tag="}
+	for _, f := range forbidden {
+		if strings.Contains(msg, f) {
+			t.Errorf("error message smuggles %q: %q", f, msg)
+		}
+	}
+}

--- a/internal/engine/search.go
+++ b/internal/engine/search.go
@@ -96,6 +96,12 @@ func Find(ctx context.Context, db *store.DB, embedder Embedder, query string, op
 		if node.NodeType != "leaf" {
 			continue
 		}
+		// Retracted nodes are excluded from default search (issue #12).
+		// Dedup-against-retracted runs on a separate path that intentionally
+		// keeps retracted nodes in the match space.
+		if node.IsRetracted() {
+			continue
+		}
 
 		similarity := CosineSimilarity(queryVec, v.Embedding)
 		score := similarity * node.Relevance * categoryBoost(node.Category)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -597,7 +597,12 @@ func (s *Server) handleTree(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		for _, r := range roots {
-			count, _ := s.db.CountChildren(r.URI)
+			var count int
+			if includeRetracted {
+				count, _ = s.db.CountChildren(r.URI)
+			} else {
+				count, _ = s.db.CountLiveChildren(r.URI)
+			}
 			nodes = append(nodes, treeNodeJSON{
 				URI:      r.URI,
 				NodeType: r.NodeType,
@@ -633,7 +638,12 @@ func (s *Server) handleTree(w http.ResponseWriter, r *http.Request) {
 				tn.L1Overview = c.L1Overview
 			}
 			if c.NodeType == "dir" {
-				count, _ := s.db.CountChildren(c.URI)
+				var count int
+				if includeRetracted {
+					count, _ = s.db.CountChildren(c.URI)
+				} else {
+					count, _ = s.db.CountLiveChildren(c.URI)
+				}
 				tn.Children = count
 			}
 			nodes = append(nodes, tn)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/lazypower/continuity/internal/engine"
+	"github.com/lazypower/continuity/internal/store"
 )
 
 // jsonError writes a JSON error response with proper Content-Type and encoding.
@@ -211,6 +212,7 @@ func (s *Server) handleGetMemory(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]string{"error": "uri parameter required"})
 		return
 	}
+	includeRetracted := r.URL.Query().Get("include_retracted") == "true"
 
 	node, err := s.db.GetNodeByURI(uri)
 	if err != nil {
@@ -224,28 +226,61 @@ func (s *Server) handleGetMemory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
-		"uri":         node.URI,
-		"category":    node.Category,
-		"node_type":   node.NodeType,
-		"summary":     node.L0Abstract,
-		"body":        node.L1Overview,
-		"detail":      node.L2Content,
-		"relevance":   node.Relevance,
-		"created_at":  node.CreatedAt,
-		"updated_at":  node.UpdatedAt,
+
+	// Retracted memory without --include-retracted: surface metadata only.
+	// Reason and content fields are *absent*, not empty/null/redacted, so consumers
+	// don't have to disambiguate "no content given" from "content hidden by contract."
+	// See issue #12 / RFC: "confronting your own past retraction should be a
+	// deliberate act, not a passive notification."
+	if node.IsRetracted() && !includeRetracted {
+		out := map[string]any{
+			"uri":            node.URI,
+			"category":       node.Category,
+			"node_type":      node.NodeType,
+			"retracted":      true,
+			"tombstoned_at":  *node.TombstonedAt,
+			"created_at":     node.CreatedAt,
+			"updated_at":     node.UpdatedAt,
+		}
+		if node.SupersededBy != "" {
+			out["superseded_by"] = node.SupersededBy
+		}
+		json.NewEncoder(w).Encode(out)
+		return
+	}
+
+	out := map[string]any{
+		"uri":          node.URI,
+		"category":     node.Category,
+		"node_type":    node.NodeType,
+		"summary":      node.L0Abstract,
+		"body":         node.L1Overview,
+		"detail":       node.L2Content,
+		"relevance":    node.Relevance,
+		"created_at":   node.CreatedAt,
+		"updated_at":   node.UpdatedAt,
 		"access_count": node.AccessCount,
-	})
+	}
+	if node.IsRetracted() {
+		out["retracted"] = true
+		out["tombstoned_at"] = *node.TombstonedAt
+		out["tombstone_reason"] = node.TombstoneReason
+		if node.SupersededBy != "" {
+			out["superseded_by"] = node.SupersededBy
+		}
+	}
+	json.NewEncoder(w).Encode(out)
 }
 
 func (s *Server) handleRemember(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Category  string `json:"category"`
-		Name      string `json:"name"`
-		Summary   string `json:"summary"`
-		Body      string `json:"body"`
-		Detail    string `json:"detail"`
-		SessionID string `json:"session_id"`
+		Category             string `json:"category"`
+		Name                 string `json:"name"`
+		Summary              string `json:"summary"`
+		Body                 string `json:"body"`
+		Detail               string `json:"detail"`
+		SessionID            string `json:"session_id"`
+		AcknowledgeRetracted bool   `json:"acknowledge_retracted"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, "invalid json", http.StatusBadRequest)
@@ -267,14 +302,28 @@ func (s *Server) handleRemember(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	uri, created, err := s.engine.Remember(ctx, engine.RememberInput{
-		Category:  req.Category,
-		Name:      req.Name,
-		Summary:   req.Summary,
-		Body:      req.Body,
-		Detail:    req.Detail,
-		SessionID: req.SessionID,
+		Category:             req.Category,
+		Name:                 req.Name,
+		Summary:              req.Summary,
+		Body:                 req.Body,
+		Detail:               req.Detail,
+		SessionID:            req.SessionID,
+		AcknowledgeRetracted: req.AcknowledgeRetracted,
 	})
 	if err != nil {
+		// Dedup-against-retracted gate fired. Surface URIs only — reasons stay
+		// sequestered behind --include-retracted. Operator-side log already
+		// captured URI hashes in the engine layer.
+		if isMatch, uris := engine.IsRetractedMatch(err); isMatch {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(map[string]any{
+				"status":           "matches_retracted",
+				"matched_uris":     uris,
+				"hint":             "inspect each with `continuity show <uri> --include-retracted` before proceeding; pass --acknowledge-retracted to override",
+			})
+			return
+		}
 		log.Printf("remember: %v", err)
 		jsonError(w, "failed to store memory", http.StatusBadRequest)
 		return
@@ -290,6 +339,59 @@ func (s *Server) handleRemember(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	json.NewEncoder(w).Encode(map[string]string{"status": status, "uri": uri})
+}
+
+func (s *Server) handleRetract(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		URI          string `json:"uri"`
+		Reason       string `json:"reason"`
+		SupersededBy string `json:"superseded_by"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if req.URI == "" {
+		jsonError(w, "uri is required", http.StatusBadRequest)
+		return
+	}
+	if req.Reason == "" {
+		jsonError(w, "reason is required", http.StatusBadRequest)
+		return
+	}
+
+	if s.engine == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]string{"error": "engine not configured"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	newly, err := s.engine.Retract(ctx, engine.RetractInput{
+		URI:          req.URI,
+		Reason:       req.Reason,
+		SupersededBy: req.SupersededBy,
+	})
+	if err != nil {
+		log.Printf("retract: %v", err)
+		jsonError(w, "failed to retract memory", http.StatusBadRequest)
+		return
+	}
+
+	status := "retracted"
+	if !newly {
+		status = "already_retracted"
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"status":        status,
+		"uri":           req.URI,
+		"superseded_by": req.SupersededBy,
+	})
 }
 
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
@@ -472,6 +574,7 @@ func (s *Server) handleProfile(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleTree(w http.ResponseWriter, r *http.Request) {
 	uri := r.URL.Query().Get("uri")
+	includeRetracted := r.URL.Query().Get("include_retracted") == "true"
 
 	type treeNodeJSON struct {
 		URI        string `json:"uri"`
@@ -480,12 +583,13 @@ func (s *Server) handleTree(w http.ResponseWriter, r *http.Request) {
 		L0Abstract string `json:"l0_abstract,omitempty"`
 		L1Overview string `json:"l1_overview,omitempty"`
 		Children   int    `json:"children,omitempty"`
+		Retracted  bool   `json:"retracted,omitempty"`
 	}
 
 	var nodes []treeNodeJSON
 
 	if uri == "" {
-		// List roots
+		// List roots (dirs are never retracted; no flag needed)
 		roots, err := s.db.ListRoots()
 		if err != nil {
 			log.Printf("tree roots: %v", err)
@@ -503,7 +607,13 @@ func (s *Server) handleTree(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		// List children
-		children, err := s.db.GetChildren(uri)
+		var children []store.MemNode
+		var err error
+		if includeRetracted {
+			children, err = s.db.GetChildrenIncludingRetracted(uri)
+		} else {
+			children, err = s.db.GetChildren(uri)
+		}
 		if err != nil {
 			log.Printf("tree children: %v", err)
 			jsonError(w, "internal error", http.StatusInternalServerError)
@@ -511,11 +621,16 @@ func (s *Server) handleTree(w http.ResponseWriter, r *http.Request) {
 		}
 		for _, c := range children {
 			tn := treeNodeJSON{
-				URI:        c.URI,
-				NodeType:   c.NodeType,
-				Category:   c.Category,
-				L0Abstract: c.L0Abstract,
-				L1Overview: c.L1Overview,
+				URI:       c.URI,
+				NodeType:  c.NodeType,
+				Category:  c.Category,
+				Retracted: c.IsRetracted(),
+			}
+			// Suppress content fields on retracted nodes — same absence-not-empty
+			// principle as handleGetMemory.
+			if !c.IsRetracted() {
+				tn.L0Abstract = c.L0Abstract
+				tn.L1Overview = c.L1Overview
 			}
 			if c.NodeType == "dir" {
 				count, _ := s.db.CountChildren(c.URI)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,6 +73,7 @@ func (s *Server) routes() {
 		r.Get("/sessions/{sessionID}", stub("session detail"))
 		r.Post("/memories", s.handleRemember)
 		r.Get("/memories", s.handleGetMemory)
+		r.Post("/memories/retract", s.handleRetract)
 	})
 
 	// Serve embedded UI at all non-API paths

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -27,8 +27,8 @@ func TestSchemaVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SchemaVersion: %v", err)
 	}
-	if v != 7 {
-		t.Errorf("SchemaVersion = %d, want 7", v)
+	if v != 8 {
+		t.Errorf("SchemaVersion = %d, want 8", v)
 	}
 }
 
@@ -128,8 +128,8 @@ func TestMigrationsIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SchemaVersion: %v", err)
 	}
-	if v != 7 {
-		t.Errorf("SchemaVersion after re-migrate = %d, want 7", v)
+	if v != 8 {
+		t.Errorf("SchemaVersion after re-migrate = %d, want 8", v)
 	}
 }
 

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -159,6 +159,15 @@ PRAGMA foreign_keys=ON;
 		Description: "sessions: add tone for session emotional arc",
 		SQL:         `ALTER TABLE sessions ADD COLUMN tone TEXT;`,
 	},
+	{
+		Version:     8,
+		Description: "mem_nodes: retraction columns for memory accountability (issue #12)",
+		SQL: `
+ALTER TABLE mem_nodes ADD COLUMN tombstoned_at INTEGER;
+ALTER TABLE mem_nodes ADD COLUMN tombstone_reason TEXT;
+ALTER TABLE mem_nodes ADD COLUMN superseded_by TEXT;
+`,
+	},
 }
 
 func (db *DB) migrate() error {

--- a/internal/store/nodes.go
+++ b/internal/store/nodes.go
@@ -616,10 +616,23 @@ func (db *DB) DeleteOrphanDirs() (int, error) {
 	return int(n), nil
 }
 
-// CountChildren returns the number of direct children for a parent URI.
+// CountChildren returns the number of direct children for a parent URI,
+// including retracted ones. Use CountLiveChildren for counts that match what
+// a default `tree` listing returns; mismatched counts mislead users.
 func (db *DB) CountChildren(parentURI string) (int, error) {
 	var count int
 	err := db.QueryRow("SELECT COUNT(*) FROM mem_nodes WHERE parent_uri = ?", parentURI).Scan(&count)
+	return count, err
+}
+
+// CountLiveChildren returns the number of direct children that aren't retracted.
+// Pair this with GetChildren so listing and count agree on what's visible.
+func (db *DB) CountLiveChildren(parentURI string) (int, error) {
+	var count int
+	err := db.QueryRow(
+		"SELECT COUNT(*) FROM mem_nodes WHERE parent_uri = ? AND tombstoned_at IS NULL",
+		parentURI,
+	).Scan(&count)
 	return count, err
 }
 

--- a/internal/store/nodes.go
+++ b/internal/store/nodes.go
@@ -72,6 +72,16 @@ type MemNode struct {
 	SourceSession string
 	CreatedAt     int64
 	UpdatedAt     int64
+
+	// Retraction (issue #12). nil/empty when the node is live.
+	TombstonedAt    *int64
+	TombstoneReason string
+	SupersededBy    string
+}
+
+// IsRetracted reports whether this node has been retracted.
+func (n *MemNode) IsRetracted() bool {
+	return n.TombstonedAt != nil
 }
 
 // mergeableCategories defines which categories support in-place merging.
@@ -120,19 +130,22 @@ func (db *DB) CreateNode(node *MemNode) error {
 }
 
 // GetNodeByURI returns a node by its URI, or nil if not found.
+// Retraction state is included on the returned node; callers decide how to handle.
 func (db *DB) GetNodeByURI(uri string) (*MemNode, error) {
 	var n MemNode
 	var mergeable int
-	var lastAccess sql.NullInt64
-	var parentURI, l0, l1, l2, mergedFrom, sourceSession sql.NullString
+	var lastAccess, tombstonedAt sql.NullInt64
+	var parentURI, l0, l1, l2, mergedFrom, sourceSession, tombstoneReason, supersededBy sql.NullString
 	err := db.QueryRow(`
 		SELECT id, uri, parent_uri, node_type, category, l0_abstract, l1_overview, l2_content,
-			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at
+			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at,
+			tombstoned_at, tombstone_reason, superseded_by
 		FROM mem_nodes WHERE uri = ?
 	`, uri).Scan(&n.ID, &n.URI, &parentURI, &n.NodeType, &n.Category,
 		&l0, &l1, &l2,
 		&mergeable, &mergedFrom, &n.Relevance, &lastAccess, &n.AccessCount,
-		&sourceSession, &n.CreatedAt, &n.UpdatedAt)
+		&sourceSession, &n.CreatedAt, &n.UpdatedAt,
+		&tombstonedAt, &tombstoneReason, &supersededBy)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -149,6 +162,11 @@ func (db *DB) GetNodeByURI(uri string) (*MemNode, error) {
 	if lastAccess.Valid {
 		n.LastAccess = &lastAccess.Int64
 	}
+	if tombstonedAt.Valid {
+		n.TombstonedAt = &tombstonedAt.Int64
+	}
+	n.TombstoneReason = tombstoneReason.String
+	n.SupersededBy = supersededBy.String
 	return &n, nil
 }
 
@@ -198,12 +216,14 @@ func (db *DB) UpsertNode(node *MemNode) error {
 	return db.CreateNode(node)
 }
 
-// FindByCategory returns all leaf nodes for a given category, ordered by relevance DESC.
+// FindByCategory returns live leaf nodes for a given category, ordered by relevance DESC.
+// Retracted nodes are excluded — use FindByCategoryIncludingRetracted for inspection.
 func (db *DB) FindByCategory(category string) ([]MemNode, error) {
 	rows, err := db.Query(`
 		SELECT id, uri, parent_uri, node_type, category, l0_abstract, l1_overview, l2_content,
-			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at
-		FROM mem_nodes WHERE category = ? AND node_type = 'leaf'
+			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at,
+			tombstoned_at, tombstone_reason, superseded_by
+		FROM mem_nodes WHERE category = ? AND node_type = 'leaf' AND tombstoned_at IS NULL
 		ORDER BY relevance DESC
 	`, category)
 	if err != nil {
@@ -214,12 +234,14 @@ func (db *DB) FindByCategory(category string) ([]MemNode, error) {
 	return scanNodes(rows)
 }
 
-// ListLeaves returns all leaf nodes ordered by relevance DESC.
+// ListLeaves returns live leaf nodes ordered by relevance DESC.
+// Retracted nodes are excluded — use ListLeavesIncludingRetracted for inspection.
 func (db *DB) ListLeaves() ([]MemNode, error) {
 	rows, err := db.Query(`
 		SELECT id, uri, parent_uri, node_type, category, l0_abstract, l1_overview, l2_content,
-			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at
-		FROM mem_nodes WHERE node_type = 'leaf'
+			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at,
+			tombstoned_at, tombstone_reason, superseded_by
+		FROM mem_nodes WHERE node_type = 'leaf' AND tombstoned_at IS NULL
 		ORDER BY relevance DESC
 	`)
 	if err != nil {
@@ -455,19 +477,22 @@ func parentURIOf(uri string) string {
 }
 
 // GetNodeByID returns a node by its database ID, or nil if not found.
+// Retraction state is included on the returned node; callers decide how to handle.
 func (db *DB) GetNodeByID(id int64) (*MemNode, error) {
 	var n MemNode
 	var mergeable int
-	var lastAccess sql.NullInt64
-	var parentURI, l0, l1, l2, mergedFrom, sourceSession sql.NullString
+	var lastAccess, tombstonedAt sql.NullInt64
+	var parentURI, l0, l1, l2, mergedFrom, sourceSession, tombstoneReason, supersededBy sql.NullString
 	err := db.QueryRow(`
 		SELECT id, uri, parent_uri, node_type, category, l0_abstract, l1_overview, l2_content,
-			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at
+			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at,
+			tombstoned_at, tombstone_reason, superseded_by
 		FROM mem_nodes WHERE id = ?
 	`, id).Scan(&n.ID, &n.URI, &parentURI, &n.NodeType, &n.Category,
 		&l0, &l1, &l2,
 		&mergeable, &mergedFrom, &n.Relevance, &lastAccess, &n.AccessCount,
-		&sourceSession, &n.CreatedAt, &n.UpdatedAt)
+		&sourceSession, &n.CreatedAt, &n.UpdatedAt,
+		&tombstonedAt, &tombstoneReason, &supersededBy)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -484,15 +509,22 @@ func (db *DB) GetNodeByID(id int64) (*MemNode, error) {
 	if lastAccess.Valid {
 		n.LastAccess = &lastAccess.Int64
 	}
+	if tombstonedAt.Valid {
+		n.TombstonedAt = &tombstonedAt.Int64
+	}
+	n.TombstoneReason = tombstoneReason.String
+	n.SupersededBy = supersededBy.String
 	return &n, nil
 }
 
-// GetChildren returns all direct children of a given parent URI.
+// GetChildren returns live direct children of a given parent URI.
+// Retracted nodes are excluded — use GetChildrenIncludingRetracted for inspection.
 func (db *DB) GetChildren(parentURI string) ([]MemNode, error) {
 	rows, err := db.Query(`
 		SELECT id, uri, parent_uri, node_type, category, l0_abstract, l1_overview, l2_content,
-			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at
-		FROM mem_nodes WHERE parent_uri = ?
+			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at,
+			tombstoned_at, tombstone_reason, superseded_by
+		FROM mem_nodes WHERE parent_uri = ? AND tombstoned_at IS NULL
 		ORDER BY uri
 	`, parentURI)
 	if err != nil {
@@ -506,7 +538,8 @@ func (db *DB) GetChildren(parentURI string) ([]MemNode, error) {
 func (db *DB) ListRoots() ([]MemNode, error) {
 	rows, err := db.Query(`
 		SELECT id, uri, parent_uri, node_type, category, l0_abstract, l1_overview, l2_content,
-			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at
+			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at,
+			tombstoned_at, tombstone_reason, superseded_by
 		FROM mem_nodes WHERE parent_uri IS NULL
 		ORDER BY uri
 	`)
@@ -542,7 +575,8 @@ func (db *DB) GetNodesByIDs(ids []int64) ([]MemNode, error) {
 
 	query := fmt.Sprintf(`
 		SELECT id, uri, parent_uri, node_type, category, l0_abstract, l1_overview, l2_content,
-			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at
+			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at,
+			tombstoned_at, tombstone_reason, superseded_by
 		FROM mem_nodes WHERE id IN (%s)
 	`, ph)
 
@@ -594,12 +628,13 @@ func scanNodes(rows *sql.Rows) ([]MemNode, error) {
 	for rows.Next() {
 		var n MemNode
 		var mergeable int
-		var lastAccess sql.NullInt64
-		var parentURI, l0, l1, l2, mergedFrom, sourceSession sql.NullString
+		var lastAccess, tombstonedAt sql.NullInt64
+		var parentURI, l0, l1, l2, mergedFrom, sourceSession, tombstoneReason, supersededBy sql.NullString
 		if err := rows.Scan(&n.ID, &n.URI, &parentURI, &n.NodeType, &n.Category,
 			&l0, &l1, &l2,
 			&mergeable, &mergedFrom, &n.Relevance, &lastAccess, &n.AccessCount,
-			&sourceSession, &n.CreatedAt, &n.UpdatedAt); err != nil {
+			&sourceSession, &n.CreatedAt, &n.UpdatedAt,
+			&tombstonedAt, &tombstoneReason, &supersededBy); err != nil {
 			return nil, fmt.Errorf("scan node: %w", err)
 		}
 		n.ParentURI = parentURI.String
@@ -612,6 +647,11 @@ func scanNodes(rows *sql.Rows) ([]MemNode, error) {
 		if lastAccess.Valid {
 			n.LastAccess = &lastAccess.Int64
 		}
+		if tombstonedAt.Valid {
+			n.TombstonedAt = &tombstonedAt.Int64
+		}
+		n.TombstoneReason = tombstoneReason.String
+		n.SupersededBy = supersededBy.String
 		nodes = append(nodes, n)
 	}
 	return nodes, rows.Err()

--- a/internal/store/retract.go
+++ b/internal/store/retract.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// RetractNode marks a memory as retracted. The node remains in the database
+// (tombstone, not delete) but is excluded from default reads.
+//
+// Returns (newly bool, err error). newly is true when this call performed the
+// retraction; false when the memory was already retracted (idempotent — the
+// act has already happened, the original timestamp and reason are preserved).
+//
+// supersededBy may be empty (pure tombstone) or a URI that supersedes this
+// memory (supersession). When non-empty, the successor URI must already exist.
+func (db *DB) RetractNode(uri, reason, supersededBy string) (newly bool, err error) {
+	if uri == "" {
+		return false, fmt.Errorf("uri required")
+	}
+	if reason == "" {
+		return false, fmt.Errorf("reason required")
+	}
+
+	target, err := db.GetNodeByURI(uri)
+	if err != nil {
+		return false, fmt.Errorf("look up target: %w", err)
+	}
+	if target == nil {
+		return false, fmt.Errorf("memory not found: %s", uri)
+	}
+
+	if target.IsRetracted() {
+		return false, nil
+	}
+
+	if supersededBy != "" {
+		successor, err := db.GetNodeByURI(supersededBy)
+		if err != nil {
+			return false, fmt.Errorf("look up successor: %w", err)
+		}
+		if successor == nil {
+			return false, fmt.Errorf("successor not found: %s", supersededBy)
+		}
+	}
+
+	now := time.Now().UnixMilli()
+	_, err = db.Exec(`
+		UPDATE mem_nodes
+		SET tombstoned_at = ?, tombstone_reason = ?, superseded_by = NULLIF(?, ''), updated_at = ?
+		WHERE uri = ?
+	`, now, reason, supersededBy, now, uri)
+	if err != nil {
+		return false, fmt.Errorf("retract node: %w", err)
+	}
+	return true, nil
+}
+
+// IsRetracted reports whether the memory at the given URI has been retracted.
+// Returns false if the URI does not exist (not an error).
+func (db *DB) IsRetracted(uri string) (bool, error) {
+	var tombstonedAt sql.NullInt64
+	err := db.QueryRow("SELECT tombstoned_at FROM mem_nodes WHERE uri = ?", uri).Scan(&tombstonedAt)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check retraction: %w", err)
+	}
+	return tombstonedAt.Valid, nil
+}
+
+// FindByCategoryIncludingRetracted returns all leaf nodes for a category,
+// including retracted ones. For the --include-retracted inspection path.
+func (db *DB) FindByCategoryIncludingRetracted(category string) ([]MemNode, error) {
+	rows, err := db.Query(`
+		SELECT id, uri, parent_uri, node_type, category, l0_abstract, l1_overview, l2_content,
+			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at,
+			tombstoned_at, tombstone_reason, superseded_by
+		FROM mem_nodes WHERE category = ? AND node_type = 'leaf'
+		ORDER BY relevance DESC
+	`, category)
+	if err != nil {
+		return nil, fmt.Errorf("find by category (incl retracted): %w", err)
+	}
+	defer rows.Close()
+	return scanNodes(rows)
+}
+
+// ListLeavesIncludingRetracted returns all leaf nodes including retracted ones.
+// For the --include-retracted inspection path.
+func (db *DB) ListLeavesIncludingRetracted() ([]MemNode, error) {
+	rows, err := db.Query(`
+		SELECT id, uri, parent_uri, node_type, category, l0_abstract, l1_overview, l2_content,
+			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at,
+			tombstoned_at, tombstone_reason, superseded_by
+		FROM mem_nodes WHERE node_type = 'leaf'
+		ORDER BY relevance DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list leaves (incl retracted): %w", err)
+	}
+	defer rows.Close()
+	return scanNodes(rows)
+}
+
+// GetChildrenIncludingRetracted returns all direct children of a parent URI,
+// including retracted ones. For the --include-retracted inspection path.
+func (db *DB) GetChildrenIncludingRetracted(parentURI string) ([]MemNode, error) {
+	rows, err := db.Query(`
+		SELECT id, uri, parent_uri, node_type, category, l0_abstract, l1_overview, l2_content,
+			mergeable, merged_from, relevance, last_access, access_count, source_session, created_at, updated_at,
+			tombstoned_at, tombstone_reason, superseded_by
+		FROM mem_nodes WHERE parent_uri = ?
+		ORDER BY uri
+	`, parentURI)
+	if err != nil {
+		return nil, fmt.Errorf("get children (incl retracted): %w", err)
+	}
+	defer rows.Close()
+	return scanNodes(rows)
+}

--- a/internal/store/retract.go
+++ b/internal/store/retract.go
@@ -36,6 +36,9 @@ func (db *DB) RetractNode(uri, reason, supersededBy string) (newly bool, err err
 	}
 
 	if supersededBy != "" {
+		if supersededBy == uri {
+			return false, fmt.Errorf("self-supersession: %s cannot supersede itself", uri)
+		}
 		successor, err := db.GetNodeByURI(supersededBy)
 		if err != nil {
 			return false, fmt.Errorf("look up successor: %w", err)

--- a/internal/store/retract_test.go
+++ b/internal/store/retract_test.go
@@ -1,0 +1,293 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+// seedNode is a small helper to keep the test bodies focused on retraction behavior.
+func seedNode(t *testing.T, db *DB, uri, category, l0 string) *MemNode {
+	t.Helper()
+	node := &MemNode{
+		URI:        uri,
+		NodeType:   "leaf",
+		Category:   category,
+		L0Abstract: l0,
+		L1Overview: l0 + " — body content here.",
+	}
+	if err := db.CreateNode(node); err != nil {
+		t.Fatalf("seed %s: %v", uri, err)
+	}
+	return node
+}
+
+func TestRetractNode_SetsFieldsAndReason(t *testing.T) {
+	db := testDB(t)
+	seedNode(t, db, "mem://user/events/foo", "events", "foo summary")
+
+	newly, err := db.RetractNode("mem://user/events/foo", "test repro, no ongoing value", "")
+	if err != nil {
+		t.Fatalf("RetractNode: %v", err)
+	}
+	if !newly {
+		t.Errorf("newly = false, want true on first retraction")
+	}
+
+	got, err := db.GetNodeByURI("mem://user/events/foo")
+	if err != nil || got == nil {
+		t.Fatalf("GetNodeByURI returned nil/err: %v", err)
+	}
+	if !got.IsRetracted() {
+		t.Errorf("IsRetracted = false, want true")
+	}
+	if got.TombstoneReason != "test repro, no ongoing value" {
+		t.Errorf("TombstoneReason = %q, want exact match", got.TombstoneReason)
+	}
+	if got.SupersededBy != "" {
+		t.Errorf("SupersededBy = %q, want empty (pure tombstone)", got.SupersededBy)
+	}
+	if got.TombstonedAt == nil || *got.TombstonedAt == 0 {
+		t.Errorf("TombstonedAt = %v, want non-zero timestamp", got.TombstonedAt)
+	}
+}
+
+func TestRetractNode_RequiresReason(t *testing.T) {
+	db := testDB(t)
+	seedNode(t, db, "mem://user/events/foo", "events", "foo summary")
+
+	_, err := db.RetractNode("mem://user/events/foo", "", "")
+	if err == nil {
+		t.Error("expected error when reason is empty")
+	}
+	if !strings.Contains(err.Error(), "reason required") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "reason required")
+	}
+}
+
+func TestRetractNode_ErrorsOnMissingURI(t *testing.T) {
+	db := testDB(t)
+
+	_, err := db.RetractNode("mem://user/events/does-not-exist", "any reason", "")
+	if err == nil {
+		t.Error("expected error when URI does not exist")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "not found")
+	}
+}
+
+func TestRetractNode_IdempotentReRetract(t *testing.T) {
+	db := testDB(t)
+	seedNode(t, db, "mem://user/events/foo", "events", "foo summary")
+
+	newly1, err := db.RetractNode("mem://user/events/foo", "first reason", "")
+	if err != nil || !newly1 {
+		t.Fatalf("first retraction failed: %v / newly=%v", err, newly1)
+	}
+
+	// Re-retract with a different reason. Should be a no-op; original reason wins.
+	newly2, err := db.RetractNode("mem://user/events/foo", "second reason", "")
+	if err != nil {
+		t.Fatalf("re-retract: %v", err)
+	}
+	if newly2 {
+		t.Error("re-retract: newly = true, want false (idempotent)")
+	}
+
+	got, _ := db.GetNodeByURI("mem://user/events/foo")
+	if got.TombstoneReason != "first reason" {
+		t.Errorf("TombstoneReason = %q after re-retract, want original %q", got.TombstoneReason, "first reason")
+	}
+}
+
+func TestRetractNode_SupersessionLink(t *testing.T) {
+	db := testDB(t)
+	seedNode(t, db, "mem://user/preferences/old-style", "preferences", "old style preference")
+	seedNode(t, db, "mem://user/preferences/new-style", "preferences", "new style preference")
+
+	_, err := db.RetractNode("mem://user/preferences/old-style", "preference changed",
+		"mem://user/preferences/new-style")
+	if err != nil {
+		t.Fatalf("RetractNode with supersedes: %v", err)
+	}
+
+	old, _ := db.GetNodeByURI("mem://user/preferences/old-style")
+	if old.SupersededBy != "mem://user/preferences/new-style" {
+		t.Errorf("SupersededBy = %q, want link to successor", old.SupersededBy)
+	}
+}
+
+func TestRetractNode_SupersedesNonexistentSuccessor(t *testing.T) {
+	db := testDB(t)
+	seedNode(t, db, "mem://user/preferences/old-style", "preferences", "old style preference")
+
+	_, err := db.RetractNode("mem://user/preferences/old-style", "preference changed",
+		"mem://user/preferences/never-existed")
+	if err == nil {
+		t.Error("expected error when superseded_by URI does not exist")
+	}
+	if !strings.Contains(err.Error(), "successor not found") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "successor not found")
+	}
+}
+
+func TestIsRetracted_Predicate(t *testing.T) {
+	db := testDB(t)
+	seedNode(t, db, "mem://user/events/live", "events", "live memory")
+	seedNode(t, db, "mem://user/events/dead", "events", "dead memory")
+	if _, err := db.RetractNode("mem://user/events/dead", "test", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		uri  string
+		want bool
+	}{
+		{"mem://user/events/live", false},
+		{"mem://user/events/dead", true},
+		{"mem://user/events/missing", false}, // missing URI returns false, no error
+	}
+	for _, tt := range tests {
+		got, err := db.IsRetracted(tt.uri)
+		if err != nil {
+			t.Errorf("IsRetracted(%q): unexpected error: %v", tt.uri, err)
+		}
+		if got != tt.want {
+			t.Errorf("IsRetracted(%q) = %v, want %v", tt.uri, got, tt.want)
+		}
+	}
+}
+
+func TestReadFilters_DefaultExcludesRetracted(t *testing.T) {
+	db := testDB(t)
+	seedNode(t, db, "mem://user/events/live-1", "events", "live one")
+	seedNode(t, db, "mem://user/events/live-2", "events", "live two")
+	seedNode(t, db, "mem://user/events/dead", "events", "dead memory")
+	if _, err := db.RetractNode("mem://user/events/dead", "test", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("FindByCategory", func(t *testing.T) {
+		nodes, err := db.FindByCategory("events")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(nodes) != 2 {
+			t.Errorf("FindByCategory returned %d nodes, want 2 (retracted excluded)", len(nodes))
+		}
+		for _, n := range nodes {
+			if n.IsRetracted() {
+				t.Errorf("FindByCategory returned retracted node %s", n.URI)
+			}
+		}
+	})
+
+	t.Run("ListLeaves", func(t *testing.T) {
+		nodes, err := db.ListLeaves()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, n := range nodes {
+			if n.IsRetracted() {
+				t.Errorf("ListLeaves returned retracted node %s", n.URI)
+			}
+		}
+	})
+
+	t.Run("GetChildren", func(t *testing.T) {
+		children, err := db.GetChildren("mem://user/events")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(children) != 2 {
+			t.Errorf("GetChildren returned %d, want 2 (retracted excluded)", len(children))
+		}
+	})
+}
+
+func TestReadFilters_IncludingRetractedReturnsAll(t *testing.T) {
+	db := testDB(t)
+	seedNode(t, db, "mem://user/events/live", "events", "live")
+	seedNode(t, db, "mem://user/events/dead", "events", "dead")
+	if _, err := db.RetractNode("mem://user/events/dead", "test", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("FindByCategoryIncludingRetracted", func(t *testing.T) {
+		nodes, err := db.FindByCategoryIncludingRetracted("events")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(nodes) != 2 {
+			t.Errorf("FindByCategoryIncludingRetracted returned %d, want 2 (live + retracted)", len(nodes))
+		}
+	})
+
+	t.Run("ListLeavesIncludingRetracted", func(t *testing.T) {
+		nodes, err := db.ListLeavesIncludingRetracted()
+		if err != nil {
+			t.Fatal(err)
+		}
+		hasRetracted := false
+		for _, n := range nodes {
+			if n.IsRetracted() {
+				hasRetracted = true
+			}
+		}
+		if !hasRetracted {
+			t.Error("ListLeavesIncludingRetracted did not return retracted node")
+		}
+	})
+
+	t.Run("GetChildrenIncludingRetracted", func(t *testing.T) {
+		children, err := db.GetChildrenIncludingRetracted("mem://user/events")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(children) != 2 {
+			t.Errorf("GetChildrenIncludingRetracted returned %d, want 2 (live + retracted)", len(children))
+		}
+	})
+}
+
+func TestRetractNode_MultiHopSupersessionChain(t *testing.T) {
+	// A → B → C → D: ensure chain integrity, no short-circuit.
+	db := testDB(t)
+	seedNode(t, db, "mem://user/preferences/A", "preferences", "version A")
+	seedNode(t, db, "mem://user/preferences/B", "preferences", "version B")
+	seedNode(t, db, "mem://user/preferences/C", "preferences", "version C")
+	seedNode(t, db, "mem://user/preferences/D", "preferences", "version D")
+
+	if _, err := db.RetractNode("mem://user/preferences/A", "evolved to B", "mem://user/preferences/B"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.RetractNode("mem://user/preferences/B", "evolved to C", "mem://user/preferences/C"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.RetractNode("mem://user/preferences/C", "evolved to D", "mem://user/preferences/D"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Default reads see only D.
+	live, err := db.FindByCategory("preferences")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(live) != 1 || live[0].URI != "mem://user/preferences/D" {
+		t.Errorf("default reads should return only D, got %d nodes (first=%v)", len(live), live)
+	}
+
+	// Each intermediate node links to its direct successor (no short-circuit to D).
+	a, _ := db.GetNodeByURI("mem://user/preferences/A")
+	if a.SupersededBy != "mem://user/preferences/B" {
+		t.Errorf("A.SupersededBy = %q, want B (no short-circuit)", a.SupersededBy)
+	}
+	b, _ := db.GetNodeByURI("mem://user/preferences/B")
+	if b.SupersededBy != "mem://user/preferences/C" {
+		t.Errorf("B.SupersededBy = %q, want C", b.SupersededBy)
+	}
+	c, _ := db.GetNodeByURI("mem://user/preferences/C")
+	if c.SupersededBy != "mem://user/preferences/D" {
+		t.Errorf("C.SupersededBy = %q, want D", c.SupersededBy)
+	}
+}

--- a/internal/store/retract_test.go
+++ b/internal/store/retract_test.go
@@ -57,7 +57,7 @@ func TestRetractNode_RequiresReason(t *testing.T) {
 
 	_, err := db.RetractNode("mem://user/events/foo", "", "")
 	if err == nil {
-		t.Error("expected error when reason is empty")
+		t.Fatal("expected error when reason is empty")
 	}
 	if !strings.Contains(err.Error(), "reason required") {
 		t.Errorf("error = %q, want substring %q", err.Error(), "reason required")
@@ -69,7 +69,7 @@ func TestRetractNode_ErrorsOnMissingURI(t *testing.T) {
 
 	_, err := db.RetractNode("mem://user/events/does-not-exist", "any reason", "")
 	if err == nil {
-		t.Error("expected error when URI does not exist")
+		t.Fatal("expected error when URI does not exist")
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("error = %q, want substring %q", err.Error(), "not found")
@@ -124,10 +124,74 @@ func TestRetractNode_SupersedesNonexistentSuccessor(t *testing.T) {
 	_, err := db.RetractNode("mem://user/preferences/old-style", "preference changed",
 		"mem://user/preferences/never-existed")
 	if err == nil {
-		t.Error("expected error when superseded_by URI does not exist")
+		t.Fatal("expected error when superseded_by URI does not exist")
 	}
 	if !strings.Contains(err.Error(), "successor not found") {
 		t.Errorf("error = %q, want substring %q", err.Error(), "successor not found")
+	}
+}
+
+// TestScanNodes_NoPointerAliasing guards against a class of bug where the
+// loop-local NullInt64 vars in scanNodes could be reused across iterations,
+// making every node's TombstonedAt / LastAccess pointer alias the last row's
+// value. The `var` declaration inside the loop body should escape per-iteration
+// so each node gets a distinct heap allocation; this test verifies that.
+func TestScanNodes_NoPointerAliasing(t *testing.T) {
+	db := testDB(t)
+	seedNode(t, db, "mem://user/events/a", "events", "a")
+	seedNode(t, db, "mem://user/events/b", "events", "b")
+	seedNode(t, db, "mem://user/events/c", "events", "c")
+
+	if _, err := db.RetractNode("mem://user/events/a", "first", ""); err != nil {
+		t.Fatal(err)
+	}
+	// Brief wait so timestamps differ (millisecond-resolution).
+	if _, err := db.RetractNode("mem://user/events/b", "second", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.RetractNode("mem://user/events/c", "third", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	nodes, err := db.FindByCategoryIncludingRetracted("events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 3 {
+		t.Fatalf("want 3 nodes, got %d", len(nodes))
+	}
+
+	// Pointers must be distinct, not aliasing the last row's value.
+	seen := map[*int64]bool{}
+	for _, n := range nodes {
+		if n.TombstonedAt == nil {
+			t.Errorf("node %s missing TombstonedAt", n.URI)
+			continue
+		}
+		if seen[n.TombstonedAt] {
+			t.Errorf("node %s shares TombstonedAt pointer with another row (aliasing bug)", n.URI)
+		}
+		seen[n.TombstonedAt] = true
+	}
+}
+
+func TestRetractNode_RejectsSelfSupersession(t *testing.T) {
+	db := testDB(t)
+	seedNode(t, db, "mem://user/preferences/loop", "preferences", "loop test")
+
+	_, err := db.RetractNode("mem://user/preferences/loop", "self-loop test",
+		"mem://user/preferences/loop")
+	if err == nil {
+		t.Fatal("expected error when supersededBy == uri (self-loop)")
+	}
+	if !strings.Contains(err.Error(), "self-supersession") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "self-supersession")
+	}
+
+	// Node must remain in its pre-call state — not retracted at all.
+	got, _ := db.GetNodeByURI("mem://user/preferences/loop")
+	if got.IsRetracted() {
+		t.Error("self-supersession attempt left the node retracted; should have been rejected before any write")
 	}
 }
 


### PR DESCRIPTION
Closes #12. Implements the design from the [RFC](https://github.com/lazypower/continuity/issues/12#issuecomment-4357556338).

## Ships

- Migration #8: `tombstoned_at`, `tombstone_reason`, `superseded_by` columns on `mem_nodes`.
- `continuity retract <uri> --reason "..." [--superseded-by <uri>]` (CLI) and `POST /api/memories/retract` (HTTP).
- Read-path filters across `search` / `find` / `tree` / `show` / context-injection. `--include-retracted` (or `?include_retracted=true`) opts in.
- Absence-not-empty for retracted reasons + content in JSON responses.
- Dedup-against-retracted with two-step URI-only signal (`RetractedMatchError`); `--acknowledge-retracted` bypass.
- Operator-facing dedup logs use SHA-256 URI hashes (16 hex), not raw URIs.
- README + CLAUDE.md (project + init template) carry the contract.

## Test plan

- [x] `go test ./...` — full suite green; 22 new test functions across `internal/{store,engine,cli}/retract*_test.go`, with absence-of-leakage assertions on dedup paths and end-to-end PII scenario.
- [x] `go vet ./...`, `go build ./...` — clean.
- [ ] Manual: install, run `retract`, confirm `show --include-retracted` toggle and dedup gate fires + `--acknowledge-retracted` bypasses.

## Migration

Migration #8 adds nullable columns to existing DBs — no data migration needed. First server restart applies it.
