### PR TITLE
Stabilize retraction invariant: read + write guards

### DIFF
--- a/internal/engine/extractor.go
+++ b/internal/engine/extractor.go
@@ -85,6 +85,14 @@ func findSimilarNode(ctx context.Context, db *store.DB, embedder Embedder,
 		if !ok || node.NodeType != "leaf" || node.Category != category {
 			continue
 		}
+		// Retracted nodes must not influence similarity selection. Returning
+		// one as a merge target lets a later UpsertNode silently overwrite the
+		// retracted row's content — resurrection through the back door. The
+		// dedup-against-retracted gate (engine.findRetractedMatches) is a
+		// separate path that intentionally finds these; this one must not.
+		if node.IsRetracted() {
+			continue
+		}
 
 		sim := CosineSimilarity(candidateVec, v.Embedding)
 		if sim > bestSim && sim >= threshold {

--- a/internal/engine/no_resurrection_test.go
+++ b/internal/engine/no_resurrection_test.go
@@ -115,9 +115,17 @@ func TestNoResurrection_FindSimilarNodeDoesNotReturnRetracted(t *testing.T) {
 	if err := db.CreateNode(n); err != nil {
 		t.Fatal(err)
 	}
-	embedder, _ := NewTFIDFEmbedder(db, 512)
-	vec, _ := embedder.Embed(ctx, n.L0Abstract)
-	db.SaveVector(n.ID, vec, embedder.Model())
+	embedder, err := NewTFIDFEmbedder(db, 512)
+	if err != nil {
+		t.Fatalf("NewTFIDFEmbedder: %v", err)
+	}
+	vec, err := embedder.Embed(ctx, n.L0Abstract)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if err := db.SaveVector(n.ID, vec, embedder.Model()); err != nil {
+		t.Fatalf("SaveVector: %v", err)
+	}
 	if _, err := db.RetractNode(n.URI, "test retraction", ""); err != nil {
 		t.Fatal(err)
 	}
@@ -154,9 +162,17 @@ func TestNoResurrection_ExtractMemoriesDoesNotMutateRetracted(t *testing.T) {
 	if err := db.CreateNode(n); err != nil {
 		t.Fatal(err)
 	}
-	embedder, _ := NewTFIDFEmbedder(db, 512)
-	vec, _ := embedder.Embed(ctx, n.L0Abstract)
-	db.SaveVector(n.ID, vec, embedder.Model())
+	embedder, err := NewTFIDFEmbedder(db, 512)
+	if err != nil {
+		t.Fatalf("NewTFIDFEmbedder: %v", err)
+	}
+	vec, err := embedder.Embed(ctx, n.L0Abstract)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if err := db.SaveVector(n.ID, vec, embedder.Model()); err != nil {
+		t.Fatalf("SaveVector: %v", err)
+	}
 
 	if _, err := db.RetractNode(n.URI, "operator decided this preference was wrong", ""); err != nil {
 		t.Fatal(err)
@@ -200,9 +216,15 @@ func TestNoResurrection_RememberDoesNotMutateRetracted(t *testing.T) {
 	uri := seedAndEmbed(t, eng, "preferences", "doomed-pref",
 		"original preference content for testing the no-resurrection guard",
 		"ORIGINAL body content with enough length to pass validation thresholds.")
-	embedder, _ := NewTFIDFEmbedder(db, 512)
+	embedder, err := NewTFIDFEmbedder(db, 512)
+	if err != nil {
+		t.Fatalf("NewTFIDFEmbedder: %v", err)
+	}
 	eng.SetEmbedder(embedder)
-	n, _ := db.GetNodeByURI(uri)
+	n, err := db.GetNodeByURI(uri)
+	if err != nil {
+		t.Fatalf("GetNodeByURI: %v", err)
+	}
 	if err := eng.EmbedNode(ctx, n); err != nil {
 		t.Fatal(err)
 	}
@@ -213,7 +235,7 @@ func TestNoResurrection_RememberDoesNotMutateRetracted(t *testing.T) {
 	before := snapshotNode(t, db, uri)
 
 	// Path 1: write to the same URI — must error, must NOT mutate.
-	_, _, err := eng.Remember(ctx, RememberInput{
+	_, _, err = eng.Remember(ctx, RememberInput{
 		Category: "preferences", Name: "doomed-pref",
 		Summary:              "different summary text but same URI to test collision",
 		Body:                 "Different body content with enough length to pass validation thresholds.",

--- a/internal/engine/no_resurrection_test.go
+++ b/internal/engine/no_resurrection_test.go
@@ -1,0 +1,239 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/lazypower/continuity/internal/llm"
+	"github.com/lazypower/continuity/internal/store"
+)
+
+// snapshotNode captures the full row state of a node for byte-equal comparison
+// after running potentially-mutating paths. The retraction contract says
+// retracted nodes are inert except via explicit URI inspection — every column
+// must be unchanged after any non-inspection write path runs.
+func snapshotNode(t *testing.T, db *store.DB, uri string) store.MemNode {
+	t.Helper()
+	n, err := db.GetNodeByURI(uri)
+	if err != nil {
+		t.Fatalf("snapshot %s: %v", uri, err)
+	}
+	if n == nil {
+		t.Fatalf("snapshot %s: node not found", uri)
+	}
+	// Dereference the pointer fields so the snapshot doesn't share storage with
+	// the live row. TombstonedAt is the only pointer field on MemNode aside
+	// from LastAccess.
+	snap := *n
+	if n.TombstonedAt != nil {
+		v := *n.TombstonedAt
+		snap.TombstonedAt = &v
+	}
+	if n.LastAccess != nil {
+		v := *n.LastAccess
+		snap.LastAccess = &v
+	}
+	return snap
+}
+
+// assertNoResurrection compares a fresh read of `uri` against `before` and
+// fails if any field has changed. Equality is structural — two pointer fields
+// are considered equal if their pointed-to values match.
+func assertNoResurrection(t *testing.T, db *store.DB, uri string, before store.MemNode) {
+	t.Helper()
+	after, err := db.GetNodeByURI(uri)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if after == nil {
+		t.Fatalf("retracted node %s disappeared (this is also a violation)", uri)
+	}
+
+	// Compare value fields directly.
+	if !nodesEqualByValue(before, *after) {
+		t.Errorf("retracted node mutated after a write path ran:\n  before: %+v\n  after:  %+v",
+			fmtNode(before), fmtNode(*after))
+	}
+}
+
+func nodesEqualByValue(a, b store.MemNode) bool {
+	// All scalar fields must match.
+	if a.ID != b.ID || a.URI != b.URI || a.ParentURI != b.ParentURI ||
+		a.NodeType != b.NodeType || a.Category != b.Category ||
+		a.L0Abstract != b.L0Abstract || a.L1Overview != b.L1Overview ||
+		a.L2Content != b.L2Content || a.Mergeable != b.Mergeable ||
+		a.MergedFrom != b.MergedFrom || a.Relevance != b.Relevance ||
+		a.AccessCount != b.AccessCount || a.SourceSession != b.SourceSession ||
+		a.CreatedAt != b.CreatedAt || a.UpdatedAt != b.UpdatedAt ||
+		a.TombstoneReason != b.TombstoneReason || a.SupersededBy != b.SupersededBy {
+		return false
+	}
+	// Pointer fields: equal if both nil or both non-nil with same pointed value.
+	if !pointerEqualInt64(a.TombstonedAt, b.TombstonedAt) {
+		return false
+	}
+	if !pointerEqualInt64(a.LastAccess, b.LastAccess) {
+		return false
+	}
+	return true
+}
+
+func pointerEqualInt64(a, b *int64) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func fmtNode(n store.MemNode) string {
+	tombstoned := "<nil>"
+	if n.TombstonedAt != nil {
+		tombstoned = fmt.Sprintf("%d", *n.TombstonedAt)
+	}
+	return fmt.Sprintf("URI=%s L0=%q L1=%q TombstonedAt=%s Reason=%q SupersededBy=%q UpdatedAt=%d",
+		n.URI, n.L0Abstract, n.L1Overview, tombstoned, n.TombstoneReason, n.SupersededBy, n.UpdatedAt)
+}
+
+// TestNoResurrection_FindSimilarNodeDoesNotReturnRetracted is the unit-level
+// guard. findSimilarNode is called by the LLM extraction path; if it returns
+// a retracted node, the caller will merge new content into the retracted URI
+// and effectively un-retract it.
+func TestNoResurrection_FindSimilarNodeDoesNotReturnRetracted(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+
+	// Seed a node and embed it, then retract it.
+	n := &store.MemNode{
+		URI: "mem://user/preferences/retracted-pref", NodeType: "leaf", Category: "preferences",
+		L0Abstract: "Prefers minimal dependencies and standard library where possible",
+		L1Overview: "Body content here for validation thresholds and assertions to land.",
+	}
+	if err := db.CreateNode(n); err != nil {
+		t.Fatal(err)
+	}
+	embedder, _ := NewTFIDFEmbedder(db, 512)
+	vec, _ := embedder.Embed(ctx, n.L0Abstract)
+	db.SaveVector(n.ID, vec, embedder.Model())
+	if _, err := db.RetractNode(n.URI, "test retraction", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Search for a semantically very similar candidate. findSimilarNode must
+	// NOT return the retracted node — even though it's the closest match.
+	match, sim, err := findSimilarNode(ctx, db, embedder,
+		"Prefers minimal dependencies and standard library where possible", "preferences", 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if match != nil && match.URI == n.URI {
+		t.Errorf("findSimilarNode returned the retracted node (sim=%.3f); merging into it would resurrect it", sim)
+	}
+}
+
+// TestNoResurrection_ExtractMemoriesDoesNotMutateRetracted exercises the
+// full extractMemories path. With a retracted node already in the DB, an
+// LLM-extracted candidate that's semantically close must NOT mutate the
+// retracted row — not its content, not its metadata, not its tombstone state.
+//
+// Pre-fix this test fails: findSimilarNode returns the retracted node, the
+// extractor merges new L0/L1/L2 into it via UpsertNode → UpdateNode, and the
+// retracted row's content is silently overwritten while its tombstone stays.
+func TestNoResurrection_ExtractMemoriesDoesNotMutateRetracted(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+
+	n := &store.MemNode{
+		URI: "mem://user/preferences/minimal-deps", NodeType: "leaf", Category: "preferences",
+		L0Abstract: "Prefers minimal dependencies, standard library where possible",
+		L1Overview: "ORIGINAL body content with enough length to pass validation thresholds.",
+	}
+	if err := db.CreateNode(n); err != nil {
+		t.Fatal(err)
+	}
+	embedder, _ := NewTFIDFEmbedder(db, 512)
+	vec, _ := embedder.Embed(ctx, n.L0Abstract)
+	db.SaveVector(n.ID, vec, embedder.Model())
+
+	if _, err := db.RetractNode(n.URI, "operator decided this preference was wrong", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	before := snapshotNode(t, db, n.URI)
+
+	// LLM produces a candidate semantically similar to the retracted node.
+	extractionResponse := `[
+		{
+			"category": "preferences",
+			"uri_hint": "minimal-dependencies-preference",
+			"l0": "Prefers minimal dependencies, standard library where possible",
+			"l1": "RESURRECTED body content that should never reach the retracted row.",
+			"l2": "Full details from the new extraction"
+		}
+	]`
+	mock := &llm.MockClient{
+		Response: &llm.Response{Content: extractionResponse, Provider: "mock"},
+	}
+
+	transcriptPath := makeTranscript(t)
+	if err := extractMemories(db, mock, embedder, "test-session", transcriptPath); err != nil {
+		t.Fatalf("extractMemories: %v", err)
+	}
+
+	// Full-row equality — every column on the retracted node must be unchanged.
+	assertNoResurrection(t, db, n.URI, before)
+}
+
+// TestNoResurrection_RememberDoesNotMutateRetracted is the equivalent guard
+// for the public Remember API. The dedup-against-retracted gate already blocks
+// matching writes, but the URI-collision branch and the regular merge path
+// could in principle mutate a retracted row. This test pins both paths.
+func TestNoResurrection_RememberDoesNotMutateRetracted(t *testing.T) {
+	db := testDB(t)
+	mock := &llm.MockClient{Response: &llm.Response{Content: "[]"}}
+	eng := New(db, mock)
+	ctx := context.Background()
+
+	uri := seedAndEmbed(t, eng, "preferences", "doomed-pref",
+		"original preference content for testing the no-resurrection guard",
+		"ORIGINAL body content with enough length to pass validation thresholds.")
+	embedder, _ := NewTFIDFEmbedder(db, 512)
+	eng.SetEmbedder(embedder)
+	n, _ := db.GetNodeByURI(uri)
+	if err := eng.EmbedNode(ctx, n); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.RetractNode(uri, "test retraction", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	before := snapshotNode(t, db, uri)
+
+	// Path 1: write to the same URI — must error, must NOT mutate.
+	_, _, err := eng.Remember(ctx, RememberInput{
+		Category: "preferences", Name: "doomed-pref",
+		Summary:              "different summary text but same URI to test collision",
+		Body:                 "Different body content with enough length to pass validation thresholds.",
+		AcknowledgeRetracted: true, // even with override, URI-collision path must hold
+	})
+	if err == nil {
+		t.Error("Remember at retracted URI should error, did not")
+	}
+	assertNoResurrection(t, db, uri, before)
+
+	// Path 2: write to a different URI with similar content — must trigger
+	// the dedup-against-retracted gate (no row mutation possible since the gate
+	// fires before any write).
+	_, _, err = eng.Remember(ctx, RememberInput{
+		Category: "preferences", Name: "different-slug",
+		Summary: "original preference content for testing the no-resurrection guard",
+		Body:    "Different body content with enough length to pass validation thresholds.",
+	})
+	if err == nil {
+		t.Error("Remember with similar content should hit dedup-against-retracted gate, did not")
+	}
+	assertNoResurrection(t, db, uri, before)
+}

--- a/internal/server/context.go
+++ b/internal/server/context.go
@@ -61,9 +61,14 @@ func (s *Server) buildContext(currentSessionID string) string {
 		}
 	}
 
-	// Relational profile (Working With You) — capped portion of budget
+	// Relational profile (Working With You) — capped portion of budget.
+	// A retracted profile must not be injected: silently injecting retracted
+	// content into every future session would defeat the retraction. No
+	// fallback path fills this section if the profile is retracted; the
+	// session simply lacks a "Working With You" block until the profile is
+	// re-synthesized by a future extraction.
 	relProfile, err := s.db.GetNodeByURI("mem://user/profile/communication")
-	if err == nil && relProfile != nil && relProfile.L1Overview != "" {
+	if err == nil && relProfile != nil && !relProfile.IsRetracted() && relProfile.L1Overview != "" {
 		section := "\n### Working With You\n"
 		content := relProfile.L1Overview
 		if len(content) > maxRelationalContext {

--- a/internal/server/invariant_test.go
+++ b/internal/server/invariant_test.go
@@ -188,6 +188,14 @@ func TestInvariant_HTTPDefaultRoutesExcludeRetracted(t *testing.T) {
 			srv.ServeHTTP(w, req)
 			body := w.Body.String()
 
+			// A failing route would emit an error body that doesn't contain the
+			// markers and would pass the leak assertions for the wrong reason —
+			// false negative on the invariant we're defending. Assert success
+			// status before inspecting content.
+			if w.Code != 200 {
+				t.Fatalf("expected 200, got %d (body: %s)", w.Code, body)
+			}
+
 			assertNoLeak(t, c.name, body)
 			if !c.uriMayAppear {
 				assertURINotPresent(t, c.name, body)
@@ -206,6 +214,10 @@ func TestInvariant_TreeListingMetadataOnlyForRetracted(t *testing.T) {
 	req := newTestRequest("GET", "/api/tree?uri=mem://user/events", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
 
 	var resp struct {
 		Nodes []map[string]any `json:"nodes"`
@@ -248,6 +260,10 @@ func TestInvariant_ShowRetractedRespectsAbsenceContract(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
 	body := w.Body.String()
 	assertNoLeak(t, "show without flag", body)
 
@@ -274,6 +290,10 @@ func TestInvariant_ShowWithFlagRevealsRetracted(t *testing.T) {
 	req := newTestRequest("GET", "/api/memories?uri="+retractedURI+"&include_retracted=true", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
 
 	body := w.Body.String()
 	if !strings.Contains(body, retractedReason) {

--- a/internal/server/invariant_test.go
+++ b/internal/server/invariant_test.go
@@ -1,0 +1,326 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/lazypower/continuity/internal/engine"
+	"github.com/lazypower/continuity/internal/store"
+)
+
+// retractedURI is the canonical retracted node used across the invariant tests.
+// Any code path that returns this URI in a default-read response is a violation
+// of the contract: "default reads must behave as if retracted nodes do not
+// exist, except explicit URI inspection."
+const retractedURI = "mem://user/events/SECRET-MARKER-must-not-leak"
+
+// retractedReason is the reason text. Any response body that contains this
+// substring (outside the explicit `--include-retracted` path) is a leakage.
+const retractedReason = "REASON-MARKER-must-not-leak captured PII accidentally"
+
+// retractedSummary is the L0 abstract of the retracted node. Any response body
+// that contains this substring outside `--include-retracted` is a content leak.
+const retractedSummary = "L0-MARKER-must-not-leak summary content"
+
+// retractedBody is the L1 overview. Same leakage rule applies.
+const retractedBody = "L1-MARKER-must-not-leak body content with enough chars to pass validation thresholds."
+
+// seedInvariantWorld sets up a world with one retracted node + several live
+// nodes + a retracted node that has been embedded (so it can be matched
+// against by similarity search). Returns the configured server.
+func seedInvariantWorld(t *testing.T) *Server {
+	t.Helper()
+	db, err := store.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	eng := engine.New(db, nil)
+
+	// Seed live nodes first so they appear in default reads, embeddings get a corpus.
+	liveNodes := []*store.MemNode{
+		{URI: "mem://user/events/live-1", NodeType: "leaf", Category: "events",
+			L0Abstract: "Live event one summary", L1Overview: "Live event one body content here for validation."},
+		{URI: "mem://user/events/live-2", NodeType: "leaf", Category: "events",
+			L0Abstract: "Live event two summary", L1Overview: "Live event two body content here for validation."},
+		{URI: "mem://user/preferences/live-pref", NodeType: "leaf", Category: "preferences",
+			L0Abstract: "A live preference summary", L1Overview: "A live preference body content here for validation."},
+	}
+	for _, n := range liveNodes {
+		if err := db.CreateNode(n); err != nil {
+			t.Fatalf("seed live: %v", err)
+		}
+	}
+
+	// Seed the retracted node.
+	retracted := &store.MemNode{
+		URI: retractedURI, NodeType: "leaf", Category: "events",
+		L0Abstract: retractedSummary, L1Overview: retractedBody,
+	}
+	if err := db.CreateNode(retracted); err != nil {
+		t.Fatalf("seed retracted: %v", err)
+	}
+
+	// Embed everything so dedup-against-retracted has signal to find.
+	embedder, err := engine.NewTFIDFEmbedder(db, 512)
+	if err != nil {
+		t.Fatalf("embedder: %v", err)
+	}
+	eng.SetEmbedder(embedder)
+	for _, uri := range []string{liveNodes[0].URI, liveNodes[1].URI, liveNodes[2].URI, retractedURI} {
+		n, _ := db.GetNodeByURI(uri)
+		if err := eng.EmbedNode(t.Context(), n); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Now retract.
+	if _, err := db.RetractNode(retractedURI, retractedReason, ""); err != nil {
+		t.Fatalf("retract: %v", err)
+	}
+
+	return New(db, eng, "test-version")
+}
+
+// assertNoLeak runs the leakage assertions against a body of text (response
+// body, log line, etc.). The retracted URI MAY appear when listing direct
+// children, but only as a metadata-only entry; reason text and original
+// content (L0/L1) MUST NOT appear in any default response.
+func assertNoLeak(t *testing.T, where, body string) {
+	t.Helper()
+	if strings.Contains(body, retractedReason) {
+		t.Errorf("[%s] leaked retraction REASON content: %q", where, retractedReason)
+	}
+	if strings.Contains(body, retractedSummary) {
+		t.Errorf("[%s] leaked L0 SUMMARY of retracted node: %q", where, retractedSummary)
+	}
+	if strings.Contains(body, retractedBody) {
+		t.Errorf("[%s] leaked L1 BODY of retracted node: %q", where, retractedBody)
+	}
+}
+
+// assertURINotPresent fails if the retracted URI appears in a context where
+// it should be excluded entirely (search results, context injection, etc.).
+// For tree listings, the URI may appear as a metadata-only entry — use
+// assertNoLeak there instead.
+func assertURINotPresent(t *testing.T, where, body string) {
+	t.Helper()
+	if strings.Contains(body, retractedURI) {
+		t.Errorf("[%s] retracted URI should be absent: %q", where, retractedURI)
+	}
+}
+
+// TestInvariant_StoreLayerReadPathsExcludeRetracted asserts the three
+// default multi-row read methods filter the retracted node out.
+func TestInvariant_StoreLayerReadPathsExcludeRetracted(t *testing.T) {
+	srv := seedInvariantWorld(t)
+
+	t.Run("FindByCategory(events)", func(t *testing.T) {
+		got, err := srv.db.FindByCategory("events")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, n := range got {
+			if n.URI == retractedURI {
+				t.Errorf("FindByCategory returned retracted node %s", n.URI)
+			}
+		}
+	})
+
+	t.Run("ListLeaves", func(t *testing.T) {
+		got, err := srv.db.ListLeaves()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, n := range got {
+			if n.URI == retractedURI {
+				t.Errorf("ListLeaves returned retracted node %s", n.URI)
+			}
+		}
+	})
+
+	t.Run("GetChildren(events)", func(t *testing.T) {
+		got, err := srv.db.GetChildren("mem://user/events")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, n := range got {
+			if n.URI == retractedURI {
+				t.Errorf("GetChildren returned retracted node %s", n.URI)
+			}
+		}
+	})
+}
+
+// TestInvariant_HTTPDefaultRoutesExcludeRetracted asserts that every default
+// HTTP read route excludes retracted content. This is the route-level
+// counterpart to the store-layer test — it catches the case where a route
+// somehow re-derives data without going through the filtered store methods.
+func TestInvariant_HTTPDefaultRoutesExcludeRetracted(t *testing.T) {
+	srv := seedInvariantWorld(t)
+
+	type tt struct {
+		name string
+		path string
+		// useURIPresence: if true, only assert content absence (URI may appear
+		// as a metadata-only entry, e.g. tree listings). If false, the URI
+		// itself must be absent from the response.
+		uriMayAppear bool
+	}
+
+	cases := []tt{
+		{"tree roots", "/api/tree", true /* parent dirs may include retracted's parent */},
+		{"tree under events", "/api/tree?uri=mem://user/events", true /* metadata-only entry allowed */},
+		{"search for retracted summary", "/api/search?q=L0-MARKER-must-not-leak", false},
+		{"search for live data", "/api/search?q=live", false /* retracted URI must not appear in results */},
+		{"profile", "/api/profile", false},
+		{"context injection", "/api/context?session_id=test-session", false},
+		{"timeline", "/api/timeline", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := newTestRequest("GET", c.path, nil)
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, req)
+			body := w.Body.String()
+
+			assertNoLeak(t, c.name, body)
+			if !c.uriMayAppear {
+				assertURINotPresent(t, c.name, body)
+			}
+		})
+	}
+}
+
+// TestInvariant_TreeListingMetadataOnlyForRetracted asserts that when a
+// retracted node appears as a child in a tree listing, it carries the
+// retracted marker but no content fields. This is the "absence-not-empty"
+// check at the tree route — content keys must be absent, not empty/null.
+func TestInvariant_TreeListingMetadataOnlyForRetracted(t *testing.T) {
+	srv := seedInvariantWorld(t)
+
+	req := newTestRequest("GET", "/api/tree?uri=mem://user/events", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	var resp struct {
+		Nodes []map[string]any `json:"nodes"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	var found map[string]any
+	for _, n := range resp.Nodes {
+		if uri, _ := n["uri"].(string); uri == retractedURI {
+			found = n
+			break
+		}
+	}
+	if found == nil {
+		// Default tree listing excludes retracted entirely — that's also a
+		// valid implementation of the invariant (and is what GetChildren does).
+		// Just ensure the URI didn't leak.
+		assertURINotPresent(t, "tree default", w.Body.String())
+		return
+	}
+
+	// If the implementation chose to surface retracted-as-metadata in the
+	// default tree, content fields must be absent.
+	for _, key := range []string{"l0_abstract", "l1_overview", "tombstone_reason"} {
+		if _, ok := found[key]; ok {
+			t.Errorf("retracted tree entry leaks content key %q with value %v", key, found[key])
+		}
+	}
+}
+
+// TestInvariant_ShowRetractedRespectsAbsenceContract asserts that the
+// /api/memories?uri= endpoint, when called without include_retracted, returns
+// the retracted node as metadata-only — content keys absent, not empty.
+func TestInvariant_ShowRetractedRespectsAbsenceContract(t *testing.T) {
+	srv := seedInvariantWorld(t)
+
+	req := newTestRequest("GET", "/api/memories?uri="+retractedURI, nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	assertNoLeak(t, "show without flag", body)
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, key := range []string{"summary", "body", "detail", "tombstone_reason"} {
+		if _, ok := resp[key]; ok {
+			t.Errorf("retracted show without flag leaks key %q with value %v", key, resp[key])
+		}
+	}
+	if r, ok := resp["retracted"]; !ok || r != true {
+		t.Errorf("retracted marker missing or false: %v", resp["retracted"])
+	}
+}
+
+// TestInvariant_ShowWithFlagRevealsRetracted is the inverse — the explicit
+// URI inspection path SHOULD return the reason and content. This is the
+// "explicit URI inspection" exception named in the contract.
+func TestInvariant_ShowWithFlagRevealsRetracted(t *testing.T) {
+	srv := seedInvariantWorld(t)
+
+	req := newTestRequest("GET", "/api/memories?uri="+retractedURI+"&include_retracted=true", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, retractedReason) {
+		t.Errorf("show --include-retracted should reveal reason; got: %s", body)
+	}
+	if !strings.Contains(body, retractedSummary) {
+		t.Errorf("show --include-retracted should reveal L0 summary; got: %s", body)
+	}
+}
+
+// TestInvariant_ContextInjectionExcludesRetracted is the load-bearing
+// regression for the buildContext relational-profile bug. If the relational
+// profile is retracted, it must not appear in the injected context.
+//
+// The public retract verb refuses the relational profile URI (it's system-
+// owned), so this test seeds the retraction state directly via SQL — that's
+// the operator-uses-Beekeeper friction path the spec acknowledges. Defense-
+// in-depth: even if the row gets retracted by that channel, buildContext
+// must hold the line.
+func TestInvariant_ContextInjectionExcludesRetractedRelationalProfile(t *testing.T) {
+	db, err := store.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if err := db.CreateNode(&store.MemNode{
+		URI: "mem://user/profile/communication", NodeType: "leaf", Category: "profile",
+		L0Abstract: "RELATIONAL-PROFILE-MARKER",
+		L1Overview: "RELATIONAL-PROFILE-MARKER long-form profile that should NOT appear post-retraction.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Bypass the public-verb guardrail to simulate an operator SQL edit.
+	if _, err := db.Exec(`UPDATE mem_nodes SET tombstoned_at = ?, tombstone_reason = ? WHERE uri = ?`,
+		1700000000000, "test retraction via direct SQL",
+		"mem://user/profile/communication"); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := New(db, engine.New(db, nil), "test-version")
+	ctx := srv.buildContext("")
+
+	if strings.Contains(ctx, "RELATIONAL-PROFILE-MARKER") {
+		t.Errorf("retracted relational profile leaked into session context:\n%s", ctx)
+	}
+	if strings.Contains(ctx, "Working With You") {
+		t.Errorf("Working With You section emitted despite retracted profile:\n%s", ctx)
+	}
+}

--- a/internal/server/smoke_test.go
+++ b/internal/server/smoke_test.go
@@ -1,0 +1,126 @@
+//go:build smoke
+
+package server
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/lazypower/continuity/internal/engine"
+	"github.com/lazypower/continuity/internal/store"
+)
+
+// TestSmoke_MigrationAndRetractAgainstRealDB exercises the migration and
+// retract pipeline against a copy of the operator's actual database. Skipped
+// unless `-tags smoke` is set AND CONTINUITY_SMOKE_DB points at the copy.
+//
+// Run with:
+//
+//	cp ~/.continuity/continuity.db /tmp/continuity-smoke.db
+//	CONTINUITY_SMOKE_DB=/tmp/continuity-smoke.db go test -tags smoke ./internal/server/ -run TestSmoke -v
+//
+// The smoke test mutates the copy DB. It will not touch the real DB.
+func TestSmoke_MigrationAndRetractAgainstRealDB(t *testing.T) {
+	dbPath := os.Getenv("CONTINUITY_SMOKE_DB")
+	if dbPath == "" {
+		t.Skip("CONTINUITY_SMOKE_DB not set")
+	}
+
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	t.Run("migration applied", func(t *testing.T) {
+		v, err := db.SchemaVersion()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v != 8 {
+			t.Errorf("schema version = %d, want 8", v)
+		}
+	})
+
+	t.Run("retraction columns queryable", func(t *testing.T) {
+		var live, retracted int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM mem_nodes WHERE tombstoned_at IS NULL`).Scan(&live); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.QueryRow(`SELECT COUNT(*) FROM mem_nodes WHERE tombstoned_at IS NOT NULL`).Scan(&retracted); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("live leaves: %d, already-retracted: %d", live, retracted)
+	})
+
+	var victimURI, victimL0, victimCategory string
+	t.Run("pick safe victim", func(t *testing.T) {
+		err := db.QueryRow(`
+			SELECT uri, l0_abstract, category FROM mem_nodes
+			WHERE node_type = 'leaf'
+			  AND tombstoned_at IS NULL
+			  AND uri != 'mem://user/profile/communication'
+			  AND uri NOT LIKE 'mem://user/profile/%'
+			ORDER BY relevance ASC
+			LIMIT 1
+		`).Scan(&victimURI, &victimL0, &victimCategory)
+		if err == sql.ErrNoRows {
+			t.Skip("no eligible leaf found in DB")
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("victim: %s [%s]", victimURI, victimCategory)
+		t.Logf("victim L0: %s", victimL0)
+	})
+
+	t.Run("retract victim via public verb", func(t *testing.T) {
+		newly, err := db.RetractNode(victimURI, "smoke test retraction", "")
+		if err != nil {
+			t.Fatalf("retract: %v", err)
+		}
+		if !newly {
+			t.Error("expected newly=true on first retraction")
+		}
+		check, _ := db.GetNodeByURI(victimURI)
+		if !check.IsRetracted() {
+			t.Error("retraction did not persist")
+		}
+	})
+
+	t.Run("buildContext does not surface retracted L0", func(t *testing.T) {
+		srv := New(db, engine.New(db, nil), "smoke")
+		ctx := srv.buildContext("smoke-session")
+		if victimL0 != "" && strings.Contains(ctx, victimL0) {
+			t.Errorf("retracted victim L0 leaked into session context")
+		}
+	})
+
+	t.Run("dedup-against-retracted fires on similar write", func(t *testing.T) {
+		if victimL0 == "" {
+			t.Skip("victim has no L0")
+		}
+		eng := engine.New(db, nil)
+		embedder, err := engine.NewTFIDFEmbedder(db, 512)
+		if err != nil {
+			t.Fatalf("embedder: %v", err)
+		}
+		eng.SetEmbedder(embedder)
+
+		_, _, err = eng.Remember(context.Background(), engine.RememberInput{
+			Category: victimCategory,
+			Name:     "smoke-test-similar-write-target",
+			Summary:  victimL0,
+			Body:     "smoke test body content with enough length to pass validation thresholds easily.",
+		})
+		if isMatch, _ := engine.IsRetractedMatch(err); isMatch {
+			return
+		}
+		// If the gate didn't fire, log it but don't fail — depends on TFIDF
+		// recall against the live corpus, which is fuzzy on real data.
+		t.Logf("dedup gate did not fire (err=%v); embedder recall on real data is fuzzy — manual confirmation may be needed", err)
+	})
+}

--- a/internal/server/smoke_test.go
+++ b/internal/server/smoke_test.go
@@ -58,17 +58,24 @@ func TestSmoke_MigrationAndRetractAgainstRealDB(t *testing.T) {
 
 	var victimURI, victimL0, victimCategory string
 	t.Run("pick safe victim", func(t *testing.T) {
+		// Pick a victim that buildContext would actually inject — non-empty L0,
+		// relevance >= 0.3 (the buildContext gate), highest relevance first
+		// (most likely to appear in context). Otherwise the absence assertion
+		// below could pass for the wrong reason: the victim never would have
+		// been injected, so its absence post-retraction proves nothing.
 		err := db.QueryRow(`
 			SELECT uri, l0_abstract, category FROM mem_nodes
 			WHERE node_type = 'leaf'
 			  AND tombstoned_at IS NULL
+			  AND l0_abstract != ''
+			  AND relevance >= 0.3
 			  AND uri != 'mem://user/profile/communication'
 			  AND uri NOT LIKE 'mem://user/profile/%'
-			ORDER BY relevance ASC
+			ORDER BY relevance DESC
 			LIMIT 1
 		`).Scan(&victimURI, &victimL0, &victimCategory)
 		if err == sql.ErrNoRows {
-			t.Skip("no eligible leaf found in DB")
+			t.Skip("no eligible leaf found in DB (need non-empty L0 + relevance >= 0.3)")
 		}
 		if err != nil {
 			t.Fatal(err)

--- a/internal/store/retract.go
+++ b/internal/store/retract.go
@@ -6,6 +6,19 @@ import (
 	"time"
 )
 
+// systemOwnedURIs are nodes that continuity synthesizes itself and that
+// participate in invariants beyond user memory (session bootstrap, context
+// injection contracts). They are non-retractable via the public verb —
+// the operator must SQL-edit if they need to be cleared, accepting the
+// friction as the safety mechanism.
+//
+// Rule: any URI synthesized by the system whose absence would silently break
+// downstream contracts belongs here. Add new entries deliberately when
+// synthesizing new system-owned nodes.
+var systemOwnedURIs = map[string]bool{
+	"mem://user/profile/communication": true, // synthesized relational profile; bootstraps session context
+}
+
 // RetractNode marks a memory as retracted. The node remains in the database
 // (tombstone, not delete) but is excluded from default reads.
 //
@@ -15,12 +28,19 @@ import (
 //
 // supersededBy may be empty (pure tombstone) or a URI that supersedes this
 // memory (supersession). When non-empty, the successor URI must already exist.
+//
+// Refuses to retract directory nodes (node_type='dir') and system-owned URIs
+// (see systemOwnedURIs) — both shapes have semantics that retraction would
+// silently corrupt.
 func (db *DB) RetractNode(uri, reason, supersededBy string) (newly bool, err error) {
 	if uri == "" {
 		return false, fmt.Errorf("uri required")
 	}
 	if reason == "" {
 		return false, fmt.Errorf("reason required")
+	}
+	if systemOwnedURIs[uri] {
+		return false, fmt.Errorf("system-owned: %s cannot be retracted via the public verb", uri)
 	}
 
 	target, err := db.GetNodeByURI(uri)
@@ -29,6 +49,9 @@ func (db *DB) RetractNode(uri, reason, supersededBy string) (newly bool, err err
 	}
 	if target == nil {
 		return false, fmt.Errorf("memory not found: %s", uri)
+	}
+	if target.NodeType != "leaf" {
+		return false, fmt.Errorf("cannot retract %s node: %s (only leaf memories are retractable)", target.NodeType, uri)
 	}
 
 	if target.IsRetracted() {

--- a/internal/store/retract_test.go
+++ b/internal/store/retract_test.go
@@ -175,6 +175,50 @@ func TestScanNodes_NoPointerAliasing(t *testing.T) {
 	}
 }
 
+func TestRetractNode_RefusesDirNodes(t *testing.T) {
+	db := testDB(t)
+	// Seed a leaf so the parent dir gets created via EnsureParentDirs.
+	seedNode(t, db, "mem://user/events/some-event", "events", "some event")
+
+	dirURI := "mem://user/events"
+	dir, _ := db.GetNodeByURI(dirURI)
+	if dir == nil || dir.NodeType != "dir" {
+		t.Fatalf("expected dir at %s, got %+v", dirURI, dir)
+	}
+
+	_, err := db.RetractNode(dirURI, "trying to retract a dir", "")
+	if err == nil {
+		t.Fatal("expected error when retracting a dir node")
+	}
+	if !strings.Contains(err.Error(), "cannot retract dir node") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "cannot retract dir node")
+	}
+
+	// Dir state must be unchanged — no tombstone fields written.
+	got, _ := db.GetNodeByURI(dirURI)
+	if got.IsRetracted() {
+		t.Error("dir node was retracted despite refusal — leaked write into the failure path")
+	}
+}
+
+func TestRetractNode_RefusesSystemOwnedURIs(t *testing.T) {
+	db := testDB(t)
+	seedNode(t, db, "mem://user/profile/communication", "profile", "synthesized relational profile content")
+
+	_, err := db.RetractNode("mem://user/profile/communication", "trying to retract synthesized node", "")
+	if err == nil {
+		t.Fatal("expected error when retracting a system-owned URI")
+	}
+	if !strings.Contains(err.Error(), "system-owned") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "system-owned")
+	}
+
+	got, _ := db.GetNodeByURI("mem://user/profile/communication")
+	if got.IsRetracted() {
+		t.Error("system-owned node was retracted despite refusal")
+	}
+}
+
 func TestRetractNode_RejectsSelfSupersession(t *testing.T) {
 	db := testDB(t)
 	seedNode(t, db, "mem://user/preferences/loop", "preferences", "loop test")

--- a/ui/src/components/MemoryCard.svelte
+++ b/ui/src/components/MemoryCard.svelte
@@ -114,6 +114,18 @@
               {score.toFixed(2)}
             </span>
           {/if}
+          <!--
+            Retracted state rendering. The defensive markers + content
+            suppression below are inert today: /api/tree filters retracted
+            nodes server-side by default, so this prop never arrives true via
+            the live API. The code is here so that if upstream behavior changes
+            (an inspection toggle, an alternate data flow), the card doesn't
+            silently render a retracted memory as if it were live.
+
+            Visual regression coverage is deferred to #6 (Playwright harness
+            + API-seeded fixtures). Retraction state is one of the states
+            those fixtures should expose when the harness lands.
+          -->
           {#if retracted}
             <span
               class="inline-block px-1.5 py-0.5 rounded text-[10px] font-mono uppercase tracking-wide opacity-70"

--- a/ui/src/components/MemoryCard.svelte
+++ b/ui/src/components/MemoryCard.svelte
@@ -9,9 +9,14 @@
     l1_overview?: string;
     relevance?: number;
     score?: number;
+    // When true, the memory has been retracted. The card displays a marker
+    // and suppresses content. The API default paths shouldn't deliver
+    // retracted nodes here, but this guard makes the component correct
+    // regardless of upstream filtering — see issue #12.
+    retracted?: boolean;
   }
 
-  let { uri, category, l0_abstract, l1_overview, relevance, score }: Props = $props();
+  let { uri, category, l0_abstract, l1_overview, relevance, score, retracted }: Props = $props();
 
   let expanded = $state(false);
   let copyState = $state<'idle' | 'copied' | 'failed'>('idle');
@@ -109,8 +114,23 @@
               {score.toFixed(2)}
             </span>
           {/if}
+          {#if retracted}
+            <span
+              class="inline-block px-1.5 py-0.5 rounded text-[10px] font-mono uppercase tracking-wide opacity-70"
+              style="border: 1px solid var(--text-secondary); color: var(--text-secondary);"
+              title="This memory was retracted. Reason and original content are hidden by contract — use `continuity show <uri> --include-retracted` to inspect."
+            >
+              retracted
+            </span>
+          {/if}
         </div>
-        <p class="text-sm leading-relaxed">{l0_abstract}</p>
+        {#if retracted}
+          <p class="text-xs italic text-[var(--text-secondary)] opacity-70 leading-relaxed">
+            (retracted — reason and original content hidden by contract)
+          </p>
+        {:else}
+          <p class="text-sm leading-relaxed">{l0_abstract}</p>
+        {/if}
       </div>
       <span class="expand-icon text-[var(--text-secondary)] text-sm shrink-0">
         {expanded ? '\u2212' : '\u002B'}
@@ -132,7 +152,7 @@
       </div>
     {/if}
 
-    {#if expanded && l1_overview}
+    {#if expanded && l1_overview && !retracted}
       <div class="mt-3 pt-3 border-t border-[var(--border)] expand-enter">
         <div class="flex items-start justify-between gap-3">
           <!--

--- a/ui/src/components/ProfilePanel.svelte
+++ b/ui/src/components/ProfilePanel.svelte
@@ -107,6 +107,7 @@
               l0_abstract={node.l0_abstract}
               l1_overview={node.l1_overview}
               relevance={node.relevance}
+              retracted={node.retracted}
             />
           </div>
         {/each}

--- a/ui/src/components/SearchPanel.svelte
+++ b/ui/src/components/SearchPanel.svelte
@@ -109,6 +109,7 @@
           l1_overview={result.l1_overview}
           relevance={result.relevance}
           score={result.score}
+          retracted={result.retracted}
         />
       </div>
     {/each}

--- a/ui/src/components/TreeBrowser.svelte
+++ b/ui/src/components/TreeBrowser.svelte
@@ -137,6 +137,7 @@
                         category={leaf.category}
                         l0_abstract={leaf.l0_abstract || ''}
                         l1_overview={leaf.l1_overview}
+                        retracted={leaf.retracted}
                       />
                     {/each}
                   </div>
@@ -147,6 +148,7 @@
                   category={child.category}
                   l0_abstract={child.l0_abstract || ''}
                   l1_overview={child.l1_overview}
+                  retracted={child.retracted}
                 />
               {/if}
             {/each}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1,3 +1,10 @@
+// `retracted` is set true by the API when a memory has been tombstoned via
+// `continuity retract`. Default-read API paths (search, tree default,
+// context injection) suppress retracted nodes server-side, so this field
+// arriving as `true` indicates either an explicit `?include_retracted=true`
+// inspection request, or a server-side change in default behavior. Renderers
+// MUST handle this field defensively — a retracted node should never display
+// as if it were live, even if upstream filtering changes. See issue #12.
 export interface TreeNode {
   uri: string;
   node_type: string;
@@ -5,6 +12,7 @@ export interface TreeNode {
   l0_abstract?: string;
   l1_overview?: string;
   children?: number;
+  retracted?: boolean;
 }
 
 export interface TreeResponse {
@@ -20,6 +28,7 @@ export interface SearchResult {
   score: number;
   similarity: number;
   relevance: number;
+  retracted?: boolean;
 }
 
 export interface SearchResponse {
@@ -35,6 +44,7 @@ export interface ProfileNode {
   l0_abstract: string;
   l1_overview?: string;
   relevance: number;
+  retracted?: boolean;
 }
 
 export interface ProfileResponse {


### PR DESCRIPTION
Follow-up to #19. Two latent substrate bugs from the original retraction ship + four guardrails to prevent the class. The contract — *default reads behave as if retracted nodes do not exist; no write path mutates a retracted row* — is now defended by two invariant tests.

## Ships

- **`findSimilarNode` retraction filter** (engine/extractor.go) — closed the silent-resurrection path through LLM extraction.
- **`buildContext` relational profile guard** (server/context.go) — closed the silent-injection path on SessionStart.
- **Verb guardrails** (store/retract.go) — refuses `node_type='dir'` and system-owned URIs (whitelist with the rule named in code; v1 entry: `mem://user/profile/communication`).
- **Read-invariant test** (server/invariant_test.go) — iterates every default-read API/route, asserts neither retraction reason nor original content surfaces; show-with-flag inverse confirms explicit inspection still reveals.
- **No-resurrection test** (engine/no_resurrection_test.go) — full-row byte-equal snapshot before/after running findSimilarNode + extractMemories + Remember paths against semantically-similar input.
- **SPA defensive awareness** — `retracted?: boolean` on TreeNode/SearchResult/ProfileNode; MemoryCard renders a marker and suppresses content if the field is true. The SPA was accidentally correct (filtering happened upstream); now it's intentionally correct.
- **Smoke** (server/smoke_test.go, `-tags smoke`) — exercises migration + retract against a copy of a real DB. Validated manually against 147MB / 193-leaf production DB.

## Test plan

- [x] `go test ./...` — green; both invariant tests pass with the fixes, fail without them (TDD-verified).
- [x] `go vet ./...` — clean.
- [x] SPA `npm run build` — clean.
- [x] Smoke against operator's real DB copy — migration applies, retract works, buildContext invariant holds.

## Note for follow-up (not a bug here)

TFIDF embedder rebuilds against the live corpus; cosine vs older stored vectors becomes incoherent when vocabulary shifts. Affects dedup-against-retracted recall on real data with the TFIDF fallback. Ollama/nomic-embed users unaffected. Separate issue if it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)