### PR TITLE
Anchor release artifact glob to per-matrix binary name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: continuity-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: continuity-*
+          # Anchor to the per-matrix binary name (with optional .exe for windows).
+          # An unanchored continuity-* glob also matches committed root-level
+          # docs like continuity-moments-spec.md and ships them as release
+          # assets — see the unwanted asset cleanup on v0.5.0 for the visible
+          # symptom.
+          path: continuity-${{ matrix.goos }}-${{ matrix.goarch }}*
 
   release:
     needs: build


### PR DESCRIPTION
## Summary

\`upload-artifact\` step in \`release.yml\` used \`path: continuity-*\` which matched any file starting with \`continuity-\` in the checkout — including the committed \`continuity-moments-spec.md\`. Every release page since v0.4.0 shipped the spec doc as a download asset alongside the binaries.

(The 0.4.0 ship was rationalized at the time as intentional. Looking at it now: it isn't. The glob is wrong, the symptom is consistent, and Chuck has flagged it on multiple releases now.)

## Fix

Anchor the glob to the per-matrix binary name with an optional suffix for the Windows \`.exe\`:

\`\`\`yaml
path: continuity-\${{ matrix.goos }}-\${{ matrix.goarch }}*
\`\`\`

The downstream \`files: artifacts/continuity-*\` in the release job becomes safe by transitivity — only binaries land in the artifacts dir, so the unanchored glob there can't match doc files anymore.

## v0.5.0 cleanup

The unwanted asset was removed manually via \`gh release delete-asset v0.5.0 continuity-moments-spec.md\`. Future releases won't need this cleanup once this PR lands.

## Test plan

- [x] \`actionlint\` / yaml syntax: file parses cleanly
- [ ] Manual: next release tag (v0.5.1+) ships only the five binaries, no spec docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)