### PR TITLE
Add feedback and reference categories to memory taxonomy (#24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Continuity gives Claude Code (and eventually any AI agent) memory that persists 
 
 - **Memory Tree**: Hierarchical memory organized as a virtual filesystem with `mem://` URIs. Not a flat vector store — a browsable tree.
 - **L0/L1/L2 Tiering**: Every memory has three representations: ~100 token abstract (search surface), ~2K token overview (context injection), full content (on-demand). Agents get shape without weight.
-- **6-Category Taxonomy**: profile (mergeable), preferences (mergeable), entities (immutable), events (immutable), patterns (mergeable), cases (immutable). Merge rules prevent memory corruption.
+- **8-Category Taxonomy**: profile (mergeable), preferences (mergeable), feedback (mergeable), entities (immutable), events (immutable), patterns (mergeable), cases (immutable), reference (immutable). Merge rules prevent memory corruption. `feedback` holds directional guidance the user gave about how to approach work, shaped as `<rule>. Why: <reason>. How to apply: <when>.`; `reference` holds pointers to external systems and team rituals (Linear, Grafana, Slack, standups). Moments are a separate diversity-sampled category injected into every session.
 - **Relational Profiling**: Extracts *how the user works* (feedback style, autonomy level, corrections given) as a compounding profile. No other tool does this.
 - **Smart Decay**: 90-day half-life without access. Retrieval boosts relevance. Stale memories fade but never disappear.
 - **Signal Keywords**: "remember this", "always use X", "bug was" trigger immediate capture at user-message time, not just session end.

--- a/README.md
+++ b/README.md
@@ -193,16 +193,18 @@ Agents get shape without weight. The right memories surface at the right time.
 
 ## Architecture
 
-**7 memory categories**, each with merge rules:
+**9 memory categories**, each with merge rules:
 
 | Category | Owner | Mergeable | Decay | Example |
 |----------|-------|-----------|-------|---------|
 | `profile` | user | yes | yes | Coding style, skills, identity |
 | `preferences` | user | yes | yes | Tools, workflows, conventions |
+| `feedback` | user | yes | yes | Directional guidance (`<rule>. Why: …. How to apply: ….`) — corrections and confirmations |
 | `entities` | user | no | yes | Projects, people, services |
 | `events` | user | no | yes | Decisions, deployments |
 | `patterns` | agent | yes | yes | Reusable techniques, solutions |
 | `cases` | agent | no | yes | Bug→fix pairs |
+| `reference` | user | no | yes | Pointers to external systems and team rituals (Linear, Grafana, standups) |
 | `moments` | user | no | **no** | Relational anchors — texture, not facts |
 
 **Smart decay**: 90-day half-life without access. Retrieval boosts relevance back to 1.0. Stale memories fade but never disappear — floor of 0.1. Moments and the relational profile are exempt.

--- a/RFC.md
+++ b/RFC.md
@@ -159,16 +159,18 @@ Deterministic access: `continuity tree mem://user/profile/` shows all profile no
 
 ## 5. Memory Taxonomy
 
-Six categories with explicit merge rules. Stolen from OpenViking's insight that profile data should be updated but historical events should be preserved.
+Eight first-class categories with explicit merge rules (plus `moments`, documented separately — a small diversity-sampled pool injected into every session). Stolen from OpenViking's insight that profile data should be updated but historical events should be preserved; the `feedback` and `reference` rows were added in v0.6.0 (issue #24) to give *directional guidance about how to work* and *pointers to external systems* their own home rather than smuggling them into `preferences`.
 
 | Category | Owner | Mergeable | Description |
 |----------|-------|-----------|-------------|
 | **profile** | user | yes | Identity attributes: coding style, tool preferences, communication patterns. Updated as understanding deepens. |
-| **preferences** | user | yes | Changeable choices: "uses bun not npm", "prefers Go over Rust". Overwritten when preferences change. |
+| **preferences** | user | yes | Changeable configurational choices: "uses bun not npm", "prefers Go over Rust". Settings/knobs. Overwritten when preferences change. |
+| **feedback** | user | yes | Directional guidance the user gave about HOW to approach work — corrections AND confirmations, each with a why. L1 carries `<rule>. Why: <reason>. How to apply: <when>.` Boundary: "do/don't X (behavior) + why" → feedback; "X is always Y (setting)" → preference; "the technique for X is Y (knowledge)" → pattern. |
 | **entities** | user | no | People, projects, services, APIs the user works with. Each is a distinct node. Never merged — `acme-api` and `beta-service` stay separate. |
 | **events** | user | no | Completed actions with timestamps: deployments, bug fixes, decisions. Immutable historical record. |
 | **patterns** | agent | yes | Reusable techniques: "this codebase uses X pattern for Y". Merged as understanding refines. |
 | **cases** | agent | no | Problem→solution pairs: "SQLite migration failed because SessionStore has its own chain". Immutable reference. |
+| **reference** | user | no | Pointers to external systems and team rituals: "pipeline bugs tracked in Linear project INGEST", "oncall watches grafana.internal/d/api-latency". Each pointer is distinct; merging across-purpose corrupts the lookup. |
 
 ### 5.1 Extraction Pipeline
 

--- a/internal/cli/remember.go
+++ b/internal/cli/remember.go
@@ -23,7 +23,7 @@ var (
 var validCategorySet = map[string]bool{
 	"profile": true, "preferences": true, "entities": true,
 	"events": true, "patterns": true, "cases": true,
-	"moments": true,
+	"moments": true, "feedback": true, "reference": true,
 }
 
 var rememberCmd = &cobra.Command{
@@ -32,15 +32,23 @@ var rememberCmd = &cobra.Command{
 	Long: `Store a structured memory directly into the memory tree.
 Requires a running server (continuity serve).
 
-Example:
+Examples:
   continuity remember -c preferences -n devbox \
     -s "Always use devbox for development tooling" \
-    -b "The project uses devbox shell to provide Go, SQLite tools, and other dev dependencies."`,
+    -b "The project uses devbox shell to provide Go, SQLite tools, and other dev dependencies."
+
+  continuity remember -c feedback -n terse-summaries \
+    -s "User wants terse responses with no trailing summaries." \
+    -b "Rule: terse responses, no trailing summaries. Why: user reads the diff and the recap is wasted tokens. How to apply: omit closing recap unless the user asks for it."
+
+  continuity remember -c reference -n linear-ingest \
+    -s "Pipeline bugs are tracked in Linear project INGEST." \
+    -b "Linear project 'INGEST' is where the team tracks all pipeline bugs. Check there when filing or referencing pipeline-related tickets."`,
 	RunE: runRemember,
 }
 
 func init() {
-	rememberCmd.Flags().StringVarP(&rememberCategory, "category", "c", "", "Memory category (required: profile, preferences, entities, events, patterns, cases, moments)")
+	rememberCmd.Flags().StringVarP(&rememberCategory, "category", "c", "", "Memory category (required: profile, preferences, feedback, entities, events, patterns, cases, moments, reference)")
 	rememberCmd.Flags().StringVarP(&rememberName, "name", "n", "", "URI slug name (required)")
 	rememberCmd.Flags().StringVarP(&rememberSummary, "summary", "s", "", "L0 abstract — one sentence, max 200 chars (required)")
 	rememberCmd.Flags().StringVarP(&rememberBody, "body", "b", "", "L1 overview — max 2000 chars, compress detail aggressively (required)")

--- a/internal/cli/remember_test.go
+++ b/internal/cli/remember_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import "testing"
+
+// validCategorySet is the client-side guard for `continuity remember`. It must
+// stay in lockstep with the engine's validCategories map and the migration v9
+// CHECK constraint; this test pins the membership so a drift surfaces here
+// before it shows up as a 400 from the server.
+func TestValidCategorySet(t *testing.T) {
+	required := []string{
+		"profile", "preferences", "feedback", "entities",
+		"events", "patterns", "cases", "moments", "reference",
+	}
+	for _, c := range required {
+		if !validCategorySet[c] {
+			t.Errorf("validCategorySet missing %q", c)
+		}
+	}
+	if validCategorySet["session"] {
+		t.Error("validCategorySet must reject 'session' — it's a sentinel, not user-writable")
+	}
+	if validCategorySet["bogus"] {
+		t.Error("validCategorySet accepted 'bogus'")
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -438,20 +438,6 @@ func (e *Engine) evictRedundantMoment(ctx context.Context) (string, error) {
 	return evictURI, nil
 }
 
-// mergeableCategory returns whether the given category supports in-place merging.
-// "feedback" is mergeable: near-duplicate rules ("be terse", "stay concise") should
-// consolidate rather than accrete (issue #24). "reference" is NOT mergeable: each
-// external pointer (a Linear project, a Grafana board, a Slack channel) is a
-// distinct entry, like entities — merging across-purpose corrupts the lookup.
-func mergeableCategory(category string) bool {
-	switch category {
-	case "profile", "preferences", "patterns", "feedback":
-		return true
-	default:
-		return false
-	}
-}
-
 // ExtractSignal processes a user-flagged signal prompt and creates a memory immediately.
 // This is designed to be called asynchronously (in a goroutine).
 func (e *Engine) ExtractSignal(ctx context.Context, sessionID, prompt string) error {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -439,9 +439,13 @@ func (e *Engine) evictRedundantMoment(ctx context.Context) (string, error) {
 }
 
 // mergeableCategory returns whether the given category supports in-place merging.
+// "feedback" is mergeable: near-duplicate rules ("be terse", "stay concise") should
+// consolidate rather than accrete (issue #24). "reference" is NOT mergeable: each
+// external pointer (a Linear project, a Grafana board, a Slack channel) is a
+// distinct entry, like entities — merging across-purpose corrupts the lookup.
 func mergeableCategory(category string) bool {
 	switch category {
-	case "profile", "preferences", "patterns":
+	case "profile", "preferences", "patterns", "feedback":
 		return true
 	default:
 		return false

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -834,3 +834,107 @@ func TestExtractSessionForceBypassesIdempotency(t *testing.T) {
 		t.Error("expected forced extraction to produce memory")
 	}
 }
+
+// TestRememberFeedbackMergesOnUpdate confirms feedback rules consolidate
+// rather than accrete when the same slug is written twice. Issue #24 flagged
+// six near-duplicate "be terse" memories as the failure mode to avoid.
+func TestRememberFeedbackMergesOnUpdate(t *testing.T) {
+	db := testDB(t)
+	eng := New(db, nil)
+	ctx := context.Background()
+
+	uri1, created1, err := eng.Remember(ctx, RememberInput{
+		Category: "feedback",
+		Name:     "terse-summaries",
+		Summary:  "User wants terse responses with no trailing summaries.",
+		Body:     "Rule: terse responses, no trailing summaries. Why: user can read the diff. How to apply: omit closing recap.",
+	})
+	if err != nil {
+		t.Fatalf("first Remember: %v", err)
+	}
+	if !created1 {
+		t.Error("first call should be created=true")
+	}
+	if uri1 != "mem://user/feedback/terse-summaries" {
+		t.Errorf("uri = %q, want mem://user/feedback/terse-summaries", uri1)
+	}
+
+	// Refine the same rule — should merge in place because feedback is mergeable.
+	uri2, created2, err := eng.Remember(ctx, RememberInput{
+		Category: "feedback",
+		Name:     "terse-summaries",
+		Summary:  "User wants terse responses, no recap, no preamble.",
+		Body:     "Rule: terse responses, no recap, no preamble. Why: token cost outweighs scanning cost. How to apply: never add a closing summary.",
+	})
+	if err != nil {
+		t.Fatalf("second Remember: %v", err)
+	}
+	if uri2 != uri1 {
+		t.Errorf("merge expected same URI, got %q vs %q", uri2, uri1)
+	}
+	if created2 {
+		t.Error("second call should be created=false (merge)")
+	}
+
+	node, _ := db.GetNodeByURI(uri1)
+	if node == nil {
+		t.Fatal("expected feedback node to exist after merge")
+	}
+	if !strings.Contains(node.L0Abstract, "no recap") {
+		t.Errorf("expected merged L0 to carry refined content, got %q", node.L0Abstract)
+	}
+}
+
+// TestRememberReferenceImmutable confirms reference category collisions produce
+// a NEW node (timestamp-suffixed slug), not an in-place overwrite. Each external
+// pointer is distinct (Linear board ≠ Grafana dashboard); merging would corrupt
+// the lookup.
+func TestRememberReferenceImmutable(t *testing.T) {
+	db := testDB(t)
+	eng := New(db, nil)
+	ctx := context.Background()
+
+	uri1, created1, err := eng.Remember(ctx, RememberInput{
+		Category: "reference",
+		Name:     "linear-ingest",
+		Summary:  "Pipeline bugs are tracked in Linear project INGEST.",
+		Body:     "Linear project 'INGEST' is where the team tracks all pipeline bugs.",
+	})
+	if err != nil {
+		t.Fatalf("first Remember: %v", err)
+	}
+	if !created1 {
+		t.Error("first call should be created=true")
+	}
+	if uri1 != "mem://user/reference/linear-ingest" {
+		t.Errorf("uri = %q, want mem://user/reference/linear-ingest", uri1)
+	}
+
+	// Write the same slug again — immutable categories must NOT silently
+	// overwrite. UpsertNode appends a timestamp suffix; Remember returns
+	// created=true with the new URI.
+	uri2, created2, err := eng.Remember(ctx, RememberInput{
+		Category: "reference",
+		Name:     "linear-ingest",
+		Summary:  "Different reference info that happens to share a slug.",
+		Body:     "Some other Linear-related reference data that should NOT merge in place over the first entry.",
+	})
+	if err != nil {
+		t.Fatalf("second Remember: %v", err)
+	}
+	if uri2 == uri1 {
+		t.Errorf("immutable collision must produce a NEW URI, got %q for both writes", uri1)
+	}
+	if !created2 {
+		t.Error("immutable collision should report created=true (new node)")
+	}
+
+	// Original node must still be readable and unmodified.
+	original, _ := db.GetNodeByURI(uri1)
+	if original == nil {
+		t.Fatal("original reference node missing after collision")
+	}
+	if !strings.Contains(original.L0Abstract, "Pipeline bugs") {
+		t.Errorf("original L0 was overwritten: %q", original.L0Abstract)
+	}
+}

--- a/internal/engine/extractor.go
+++ b/internal/engine/extractor.go
@@ -28,6 +28,10 @@ type memoryCandidate struct {
 }
 
 // ownerForCategory returns the URI owner for a given category.
+// "feedback" and "reference" intentionally take the default "user" branch:
+// feedback captures guidance the user has given (issue #24), and reference
+// captures pointers to systems the user works in (Linear, dashboards, rituals).
+// An agent-side feedback tree is deferred to a later issue.
 func ownerForCategory(category string) string {
 	switch category {
 	case "patterns", "cases":
@@ -41,7 +45,7 @@ func ownerForCategory(category string) string {
 var validCategories = map[string]bool{
 	"profile": true, "preferences": true, "entities": true,
 	"events": true, "patterns": true, "cases": true,
-	"moments": true,
+	"moments": true, "feedback": true, "reference": true,
 }
 
 // findSimilarNode searches existing nodes for one semantically similar to the given

--- a/internal/engine/search.go
+++ b/internal/engine/search.go
@@ -35,6 +35,10 @@ func (o SearchOpts) limit() int {
 // categoryBoost returns a scoring multiplier for high-signal categories.
 // Moments are permanent relational anchors that passed a triple qualification
 // filter — they deserve a ranking boost to surface when marginally relevant.
+// "feedback" and "reference" deliberately take the default 1.0 multiplier:
+// feedback already ranks above patterns in context injection (server/context.go),
+// and reference is low-signal locator data that should not jump ranking on
+// marginal similarity.
 func categoryBoost(category string) float64 {
 	if category == "moments" {
 		return 1.3

--- a/internal/engine/search_test.go
+++ b/internal/engine/search_test.go
@@ -176,14 +176,29 @@ func TestSearchFallsBackToFind(t *testing.T) {
 }
 
 func TestCategoryBoost(t *testing.T) {
-	if got := categoryBoost("moments"); got != 1.3 {
-		t.Errorf("categoryBoost(moments) = %f, want 1.3", got)
+	// Only moments get the 1.3× boost. feedback already ranks above patterns
+	// via the context-injection ordering (issue #24), so it gets the default
+	// 1.0 here; reference is low-signal locator data and must not jump on
+	// marginal similarity.
+	tests := []struct {
+		category string
+		want     float64
+	}{
+		{"moments", 1.3},
+		{"profile", 1.0},
+		{"preferences", 1.0},
+		{"feedback", 1.0},
+		{"events", 1.0},
+		{"patterns", 1.0},
+		{"cases", 1.0},
+		{"entities", 1.0},
+		{"reference", 1.0},
+		{"", 1.0},
 	}
-	if got := categoryBoost("profile"); got != 1.0 {
-		t.Errorf("categoryBoost(profile) = %f, want 1.0", got)
-	}
-	if got := categoryBoost("events"); got != 1.0 {
-		t.Errorf("categoryBoost(events) = %f, want 1.0", got)
+	for _, tt := range tests {
+		if got := categoryBoost(tt.category); got != tt.want {
+			t.Errorf("categoryBoost(%q) = %f, want %f", tt.category, got, tt.want)
+		}
 	}
 }
 

--- a/internal/engine/taxonomy_test.go
+++ b/internal/engine/taxonomy_test.go
@@ -1,6 +1,10 @@
 package engine
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/lazypower/continuity/internal/store"
+)
 
 // Issue #24 added `feedback` and `reference` as first-class categories. Pin
 // owner routing so neither one ever silently flips to the agent-side tree.
@@ -26,9 +30,10 @@ func TestOwnerForCategory(t *testing.T) {
 	}
 }
 
-// Pin merge rules for every category. feedback is mergeable (consolidate
-// near-duplicate rules); reference is NOT (each pointer is a distinct entry,
-// merging would corrupt the lookup).
+// Pin merge rules for every category, routed through the single source of
+// truth (store.IsMergeable). feedback is mergeable (consolidate near-duplicate
+// rules); reference is NOT (each pointer is a distinct entry, merging would
+// corrupt the lookup).
 func TestMergeableCategory(t *testing.T) {
 	tests := []struct {
 		category string
@@ -46,8 +51,8 @@ func TestMergeableCategory(t *testing.T) {
 		{"bogus", false},
 	}
 	for _, tt := range tests {
-		if got := mergeableCategory(tt.category); got != tt.want {
-			t.Errorf("mergeableCategory(%q) = %v, want %v", tt.category, got, tt.want)
+		if got := store.IsMergeable(tt.category); got != tt.want {
+			t.Errorf("store.IsMergeable(%q) = %v, want %v", tt.category, got, tt.want)
 		}
 	}
 }

--- a/internal/engine/taxonomy_test.go
+++ b/internal/engine/taxonomy_test.go
@@ -1,0 +1,74 @@
+package engine
+
+import "testing"
+
+// Issue #24 added `feedback` and `reference` as first-class categories. Pin
+// owner routing so neither one ever silently flips to the agent-side tree.
+func TestOwnerForCategory(t *testing.T) {
+	tests := []struct {
+		category string
+		want     string
+	}{
+		{"profile", "user"},
+		{"preferences", "user"},
+		{"feedback", "user"},
+		{"entities", "user"},
+		{"events", "user"},
+		{"reference", "user"},
+		{"moments", "user"},
+		{"patterns", "agent"},
+		{"cases", "agent"},
+	}
+	for _, tt := range tests {
+		if got := ownerForCategory(tt.category); got != tt.want {
+			t.Errorf("ownerForCategory(%q) = %q, want %q", tt.category, got, tt.want)
+		}
+	}
+}
+
+// Pin merge rules for every category. feedback is mergeable (consolidate
+// near-duplicate rules); reference is NOT (each pointer is a distinct entry,
+// merging would corrupt the lookup).
+func TestMergeableCategory(t *testing.T) {
+	tests := []struct {
+		category string
+		want     bool
+	}{
+		{"profile", true},
+		{"preferences", true},
+		{"patterns", true},
+		{"feedback", true},
+		{"entities", false},
+		{"events", false},
+		{"cases", false},
+		{"reference", false},
+		{"moments", false},
+		{"bogus", false},
+	}
+	for _, tt := range tests {
+		if got := mergeableCategory(tt.category); got != tt.want {
+			t.Errorf("mergeableCategory(%q) = %v, want %v", tt.category, got, tt.want)
+		}
+	}
+}
+
+// validCategories must include every category the system writes. If a new
+// category is added to the migrations but not to the validator, extraction
+// silently drops it.
+func TestValidCategoriesContainsAll(t *testing.T) {
+	required := []string{
+		"profile", "preferences", "entities", "events",
+		"patterns", "cases", "moments", "feedback", "reference",
+	}
+	for _, c := range required {
+		if !validCategories[c] {
+			t.Errorf("validCategories missing %q", c)
+		}
+	}
+	if validCategories["session"] {
+		t.Error("validCategories must not accept 'session' — it's a sentinel, not a writable category")
+	}
+	if validCategories["bogus"] {
+		t.Error("validCategories accepted 'bogus'")
+	}
+}

--- a/internal/engine/validate_test.go
+++ b/internal/engine/validate_test.go
@@ -159,6 +159,41 @@ func TestValidateCandidate_MomentsCategory(t *testing.T) {
 	}
 }
 
+// Issue #24 added feedback and reference. The validator treats them like any
+// other category — no special structural enforcement at this layer (the
+// rule + Why + How-to-apply shape lives in the extraction prompt, not here).
+func TestValidateCandidate_FeedbackCategory(t *testing.T) {
+	c := memoryCandidate{
+		Category: "feedback",
+		URIHint:  "terse-summaries",
+		L0:       "User wants terse responses with no trailing summaries.",
+		L1:       "Rule: terse responses, no trailing summaries. Why: user can read the diff and the summary is wasted tokens. How to apply: omit closing recap unless user asks.",
+	}
+	vc, err := validateCandidate(c)
+	if err != nil {
+		t.Fatalf("unexpected error for feedback category: %v", err)
+	}
+	if vc.Category != "feedback" {
+		t.Errorf("Category = %q, want feedback", vc.Category)
+	}
+}
+
+func TestValidateCandidate_ReferenceCategory(t *testing.T) {
+	c := memoryCandidate{
+		Category: "reference",
+		URIHint:  "linear-ingest",
+		L0:       "Pipeline bugs are tracked in Linear project INGEST.",
+		L1:       "Linear project 'INGEST' is the canonical home for pipeline bug reports.",
+	}
+	vc, err := validateCandidate(c)
+	if err != nil {
+		t.Fatalf("unexpected error for reference category: %v", err)
+	}
+	if vc.Category != "reference" {
+		t.Errorf("Category = %q, want reference", vc.Category)
+	}
+}
+
 func TestTruncateClean(t *testing.T) {
 	s := "hello world this is a test string"
 	result := truncateClean(s, 15)

--- a/internal/llm/prompts.go
+++ b/internal/llm/prompts.go
@@ -18,14 +18,21 @@ TRANSCRIPT:
 
 Categories:
 - profile: Who the user IS — identity, skills, non-negotiable preferences (e.g., "Senior Go developer, requires spec-first workflow")
-- preferences: Tools, workflows, changeable choices (e.g., "Uses devbox for all development")
+- preferences: Tools, workflows, changeable choices, configurational settings (e.g., "Uses devbox for all development", "use sonnet for eval analysis")
+- feedback: Directional guidance the user gave about HOW TO APPROACH WORK — corrections AND confirmations, with a why grounded in incident or stance. L1 MUST be shaped as: "<rule>. Why: <reason/incident>. How to apply: <when this kicks in>". (e.g., "Don't say 'locked the door' in release notes — say 'dialing in on security'", "Yeah, the bundled PR was the right call here")
 - entities: People, projects, services that will be referenced again (e.g., "Fiona: companion AI agent at /Users/chuck/Code/habitat/")
 - events: Significant decisions or milestones (e.g., "Deployed v2.1 to production") — NOT routine coding actions
 - patterns: Reusable techniques the user has validated (e.g., "Embed Svelte SPA via go:embed for single-binary distribution")
 - cases: Non-obvious problem→solution pairs worth remembering (e.g., "SQLite UNIQUE constraint on session init: query first, reactivate if exists")
+- reference: Pointers to external systems, dashboards, team rituals where information lives (e.g., "Pipeline bugs are tracked in Linear project INGEST", "Oncall watches grafana.internal/d/api-latency")
+
+feedback vs preferences vs patterns — the boundary rule:
+- "do/don't X (behavior)" + a why → feedback
+- "X is always set to Y (configurational knob/setting)" → preferences
+- "the technique for X is Y (transferable knowledge)" → patterns
 
 URI scheme: mem://{owner}/{category}/{slug}
-- owner is "user" for profile, preferences, entities, events
+- owner is "user" for profile, preferences, feedback, entities, events, reference
 - owner is "agent" for patterns, cases
 
 BUDGET: Maximum 3 memories per session. Most sessions produce 0-1.
@@ -52,10 +59,10 @@ Rules:
 
 Return a JSON array:
 [{
-  "category": "profile|preferences|entities|events|patterns|cases",
+  "category": "profile|preferences|feedback|entities|events|patterns|cases|reference",
   "uri_hint": "slug-name",
   "l0": "single sentence abstract",
-  "l1": "structured overview",
+  "l1": "structured overview (for feedback: <rule>. Why: <reason>. How to apply: <when>.)",
   "l2": "full content",
   "merge_target": "mem://... or empty"
 }]
@@ -119,14 +126,21 @@ USER MESSAGE:
 
 Categorize into one of:
 - profile: User identity, skills, coding style
-- preferences: Tools, workflows, changeable choices
+- preferences: Tools, workflows, changeable configurational choices (e.g., "always use devbox")
+- feedback: Directional guidance the user gave about HOW to approach work, with a why (corrections + confirmations). L1 MUST be shaped as: "<rule>. Why: <reason>. How to apply: <when this kicks in>".
 - entities: People, projects, services
 - events: Decisions, deployments, actions
-- patterns: Reusable techniques, solutions
+- patterns: Reusable techniques, transferable solutions
 - cases: Problem→solution pairs
+- reference: Pointers to external systems, dashboards, team rituals (e.g., "bugs tracked in Linear project X")
+
+feedback vs preferences vs patterns — the boundary:
+- "do/don't X (behavior)" + a why → feedback
+- "X is always set to Y (setting)" → preferences
+- "the technique for X is Y (knowledge)" → patterns
 
 URI scheme: mem://{owner}/{category}/{slug}
-- owner is "user" for profile, preferences, entities, events
+- owner is "user" for profile, preferences, feedback, entities, events, reference
 - owner is "agent" for patterns, cases
 
 Rules:
@@ -138,10 +152,10 @@ Rules:
 
 Return a JSON array:
 [{
-  "category": "profile|preferences|entities|events|patterns|cases",
+  "category": "profile|preferences|feedback|entities|events|patterns|cases|reference",
   "uri_hint": "slug-name",
   "l0": "single sentence, max 200 chars",
-  "l1": "structured overview, max 2000 chars",
+  "l1": "structured overview, max 2000 chars (for feedback: <rule>. Why: <reason>. How to apply: <when>.)",
   "l2": "full content, max 40000 chars",
   "merge_target": "mem://... or empty"
 }]`, InternalSentinel, prompt)

--- a/internal/server/context.go
+++ b/internal/server/context.go
@@ -116,7 +116,12 @@ func (s *Server) buildContext(currentSessionID string) string {
 	}
 	var items []rankedItem
 
-	for _, cat := range []string{"profile", "preferences", "patterns", "events", "cases", "entities"} {
+	// Ordering matters: items are scored independently but iterated in this order
+	// before the score-sort. "feedback" ranks above "patterns" because feedback
+	// shapes *action* (do/don't) and patterns are *knowledge*; when they conflict,
+	// feedback wins. "reference" trails because it's low-signal locator data —
+	// useful when surfaced by search but not worth crowding the SessionStart budget.
+	for _, cat := range []string{"profile", "preferences", "feedback", "patterns", "events", "cases", "entities", "reference"} {
 		nodes, err := s.db.FindByCategory(cat)
 		if err != nil {
 			continue
@@ -153,7 +158,12 @@ func (s *Server) buildContext(currentSessionID string) string {
 		}
 
 		var line string
-		if it.category == "profile" || it.category == "preferences" {
+		// Profile, preferences, and feedback collapse into the "Your Profile" block
+		// without a category tag. Feedback rides with profile/preferences because
+		// it's directional guidance that shapes how the agent should act (issue #24)
+		// — not a labelled "memory" you'd browse but identity-shaping context.
+		isProfileSection := it.category == "profile" || it.category == "preferences" || it.category == "feedback"
+		if isProfileSection {
 			line = fmt.Sprintf("- %s\n", l0)
 		} else {
 			line = fmt.Sprintf("- [%s] %s\n", it.category, l0)
@@ -166,7 +176,7 @@ func (s *Server) buildContext(currentSessionID string) string {
 		itemBudget -= len(line)
 		itemsUsed++
 
-		if it.category == "profile" || it.category == "preferences" {
+		if isProfileSection {
 			profileLines = append(profileLines, line)
 		} else {
 			memoryLines = append(memoryLines, line)

--- a/internal/server/context.go
+++ b/internal/server/context.go
@@ -116,11 +116,15 @@ func (s *Server) buildContext(currentSessionID string) string {
 	}
 	var items []rankedItem
 
-	// Ordering matters: items are scored independently but iterated in this order
-	// before the score-sort. "feedback" ranks above "patterns" because feedback
-	// shapes *action* (do/don't) and patterns are *knowledge*; when they conflict,
-	// feedback wins. "reference" trails because it's low-signal locator data —
-	// useful when surfaced by search but not worth crowding the SessionStart budget.
+	// The real "feedback above patterns" guarantee comes from the *section
+	// split* below (feedback rides in "Your Profile", patterns rides in
+	// "Recent Memories" — different sections, rendered in fixed order). The
+	// iteration order here exists for two reasons: (1) documentation of the
+	// intended priority, and (2) as a deterministic tiebreaker for the
+	// stable sort below when scores are equal (common for freshly written
+	// nodes where Relevance=1.0 and AccessCount=0). Don't add a new category
+	// to either end of this list without thinking about which section it
+	// joins downstream.
 	for _, cat := range []string{"profile", "preferences", "feedback", "patterns", "events", "cases", "entities", "reference"} {
 		nodes, err := s.db.FindByCategory(cat)
 		if err != nil {
@@ -138,8 +142,10 @@ func (s *Server) buildContext(currentSessionID string) string {
 		}
 	}
 
-	// Sort by score descending
-	sort.Slice(items, func(i, j int) bool {
+	// Sort by score descending. SliceStable so that when scores tie (every
+	// freshly written node scores 1.0 * accessBoost == 1.0), the iteration
+	// order above survives as the tiebreaker rather than becoming arbitrary.
+	sort.SliceStable(items, func(i, j int) bool {
 		return items[i].score > items[j].score
 	})
 	if len(items) > maxContextItems {

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -209,6 +209,52 @@ func TestRememberRoute(t *testing.T) {
 	}
 }
 
+// TestRememberRouteFeedbackAndReference confirms the POST /api/memories
+// endpoint accepts the categories added in issue #24. Without an end-to-end
+// API test, a regression that breaks one of these categories in extraction
+// or validation could land silently — the CLI would surface it but only
+// after a release.
+func TestRememberRouteFeedbackAndReference(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantURI string
+	}{
+		{
+			name:    "feedback",
+			body:    `{"category":"feedback","name":"terse-summaries","summary":"User wants terse responses with no trailing summaries.","body":"Rule: terse responses, no trailing summaries. Why: diff carries the info. How to apply: never recap."}`,
+			wantURI: "mem://user/feedback/terse-summaries",
+		},
+		{
+			name:    "reference",
+			body:    `{"category":"reference","name":"linear-ingest","summary":"Pipeline bugs tracked in Linear project INGEST.","body":"Linear project INGEST is the canonical home for pipeline bug reports — file there, do not use GitHub Issues."}`,
+			wantURI: "mem://user/reference/linear-ingest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := testServerWithEngine(t)
+
+			req := newTestRequest("POST", "/api/memories", strings.NewReader(tt.body))
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, req)
+
+			if w.Code != http.StatusCreated {
+				t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusCreated, w.Body.String())
+			}
+
+			var resp map[string]string
+			json.Unmarshal(w.Body.Bytes(), &resp)
+			if resp["status"] != "created" {
+				t.Errorf("status = %q, want created", resp["status"])
+			}
+			if resp["uri"] != tt.wantURI {
+				t.Errorf("uri = %q, want %q", resp["uri"], tt.wantURI)
+			}
+		})
+	}
+}
+
 func TestRememberRouteUpdate(t *testing.T) {
 	srv := testServerWithEngine(t)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -260,6 +260,59 @@ func TestBuildContextNoMoments(t *testing.T) {
 	}
 }
 
+// TestBuildContextFeedbackInProfileSection pins the issue #24 rendering rule:
+// feedback memories collapse into the "Your Profile" section (no [category]
+// tag), because they shape *action* — not labelled memory you'd browse, but
+// identity-shaping guidance. Reference memories land in "Recent Memories"
+// with their tag, like other locator data.
+func TestBuildContextFeedbackInProfileSection(t *testing.T) {
+	srv := testServer(t)
+
+	err := srv.db.UpsertNode(&store.MemNode{
+		URI:        "mem://user/feedback/terse-summaries",
+		NodeType:   "leaf",
+		Category:   "feedback",
+		L0Abstract: "Terse responses, no trailing summaries.",
+		L1Overview: "Rule: terse responses, no trailing summaries. Why: diff carries the info. How to apply: never recap.",
+		Relevance:  0.95,
+	})
+	if err != nil {
+		t.Fatalf("upsert feedback: %v", err)
+	}
+
+	err = srv.db.UpsertNode(&store.MemNode{
+		URI:        "mem://user/reference/linear-ingest",
+		NodeType:   "leaf",
+		Category:   "reference",
+		L0Abstract: "Pipeline bugs tracked in Linear INGEST project.",
+		L1Overview: "Linear project INGEST is canonical for pipeline bug reports.",
+		Relevance:  0.95,
+	})
+	if err != nil {
+		t.Fatalf("upsert reference: %v", err)
+	}
+
+	ctx := srv.buildContext("")
+
+	if !strings.Contains(ctx, "Terse responses, no trailing summaries.") {
+		t.Errorf("feedback L0 missing from context:\n%s", ctx)
+	}
+	// Feedback must not carry a [feedback] tag — it rides with profile.
+	if strings.Contains(ctx, "[feedback]") {
+		t.Errorf("feedback should NOT carry a category tag in context — it rides with profile:\n%s", ctx)
+	}
+
+	// Reference SHOULD carry a [reference] tag; it's in the Recent Memories block.
+	if !strings.Contains(ctx, "[reference]") {
+		t.Errorf("reference should carry [reference] tag in Recent Memories:\n%s", ctx)
+	}
+
+	// The Your Profile section must appear since at least one feedback item is present.
+	if !strings.Contains(ctx, "### Your Profile") {
+		t.Errorf("Your Profile section missing despite feedback item:\n%s", ctx)
+	}
+}
+
 func TestBuildContextSessionTone(t *testing.T) {
 	srv := testServer(t)
 

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -27,8 +27,8 @@ func TestSchemaVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SchemaVersion: %v", err)
 	}
-	if v != 8 {
-		t.Errorf("SchemaVersion = %d, want 8", v)
+	if v != 9 {
+		t.Errorf("SchemaVersion = %d, want 9", v)
 	}
 }
 
@@ -128,8 +128,8 @@ func TestMigrationsIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SchemaVersion: %v", err)
 	}
-	if v != 8 {
-		t.Errorf("SchemaVersion after re-migrate = %d, want 8", v)
+	if v != 9 {
+		t.Errorf("SchemaVersion after re-migrate = %d, want 9", v)
 	}
 }
 
@@ -147,6 +147,85 @@ func TestMomentsCategory(t *testing.T) {
 	`)
 	if err != nil {
 		t.Fatalf("moments category insert failed: %v", err)
+	}
+}
+
+// Migration 9 (issue #24) added feedback and reference as first-class categories.
+// These tests pin the CHECK constraint behavior so a future rewrite of the table
+// can't silently drop them.
+func TestFeedbackCategory(t *testing.T) {
+	db, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(`
+		INSERT INTO mem_nodes (uri, node_type, category, created_at, updated_at)
+		VALUES ('mem://user/feedback/terse-summaries', 'leaf', 'feedback', 1000, 1000)
+	`)
+	if err != nil {
+		t.Fatalf("feedback category insert failed: %v", err)
+	}
+}
+
+func TestReferenceCategory(t *testing.T) {
+	db, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(`
+		INSERT INTO mem_nodes (uri, node_type, category, created_at, updated_at)
+		VALUES ('mem://user/reference/linear-ingest', 'leaf', 'reference', 1000, 1000)
+	`)
+	if err != nil {
+		t.Fatalf("reference category insert failed: %v", err)
+	}
+}
+
+// TestMigration9PreservesRetractionColumns confirms the v9 table swap carries
+// the v8 retraction columns through without data loss. If the v9 schema ever
+// drifts from the column list in CREATE TABLE, this catches it.
+func TestMigration9PreservesRetractionColumns(t *testing.T) {
+	db, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	defer db.Close()
+
+	// Write a retracted-style row to exercise all v8 columns and the new categories
+	// in one shot.
+	_, err = db.Exec(`
+		INSERT INTO mem_nodes (
+			uri, node_type, category,
+			tombstoned_at, tombstone_reason, superseded_by,
+			created_at, updated_at
+		) VALUES (
+			'mem://user/feedback/retracted-rule', 'leaf', 'feedback',
+			2000, 'wrong write', 'mem://user/feedback/replacement',
+			1000, 1000
+		)
+	`)
+	if err != nil {
+		t.Fatalf("insert with v8 retraction columns failed: %v", err)
+	}
+
+	var (
+		tombstonedAt    int64
+		tombstoneReason string
+		supersededBy    string
+	)
+	err = db.QueryRow(`
+		SELECT tombstoned_at, tombstone_reason, superseded_by
+		FROM mem_nodes WHERE uri = 'mem://user/feedback/retracted-rule'
+	`).Scan(&tombstonedAt, &tombstoneReason, &supersededBy)
+	if err != nil {
+		t.Fatalf("read back retraction columns: %v", err)
+	}
+	if tombstonedAt != 2000 || tombstoneReason != "wrong write" || supersededBy != "mem://user/feedback/replacement" {
+		t.Errorf("retraction columns mangled: got (%d, %q, %q)", tombstonedAt, tombstoneReason, supersededBy)
 	}
 }
 

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -168,6 +168,57 @@ ALTER TABLE mem_nodes ADD COLUMN tombstone_reason TEXT;
 ALTER TABLE mem_nodes ADD COLUMN superseded_by TEXT;
 `,
 	},
+	{
+		Version:     9,
+		Description: "mem_nodes: add feedback and reference categories (issue #24)",
+		SQL: `
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE mem_nodes_new (
+    id             INTEGER PRIMARY KEY,
+    uri            TEXT NOT NULL UNIQUE,
+    parent_uri     TEXT,
+    node_type      TEXT NOT NULL CHECK (node_type IN ('dir', 'leaf')),
+    category       TEXT NOT NULL CHECK (category IN ('profile', 'preferences', 'entities', 'events', 'patterns', 'cases', 'moments', 'feedback', 'reference', 'session')),
+
+    -- Three-tier content
+    l0_abstract    TEXT,
+    l1_overview    TEXT,
+    l2_content     TEXT,
+
+    -- Merge control
+    mergeable      INTEGER NOT NULL DEFAULT 0,
+    merged_from    TEXT,
+
+    -- Decay
+    relevance      REAL NOT NULL DEFAULT 1.0,
+    last_access    INTEGER,
+    access_count   INTEGER NOT NULL DEFAULT 0,
+
+    -- Metadata
+    source_session TEXT,
+    created_at     INTEGER NOT NULL,
+    updated_at     INTEGER NOT NULL,
+
+    -- Retraction (added in v8)
+    tombstoned_at    INTEGER,
+    tombstone_reason TEXT,
+    superseded_by    TEXT,
+
+    FOREIGN KEY (parent_uri) REFERENCES mem_nodes_new(uri)
+);
+
+INSERT INTO mem_nodes_new SELECT * FROM mem_nodes;
+DROP TABLE mem_nodes;
+ALTER TABLE mem_nodes_new RENAME TO mem_nodes;
+
+CREATE INDEX idx_nodes_parent    ON mem_nodes(parent_uri);
+CREATE INDEX idx_nodes_category  ON mem_nodes(category);
+CREATE INDEX idx_nodes_relevance ON mem_nodes(relevance DESC);
+
+PRAGMA foreign_keys=ON;
+`,
+	},
 }
 
 func (db *DB) migrate() error {

--- a/internal/store/nodes.go
+++ b/internal/store/nodes.go
@@ -85,10 +85,16 @@ func (n *MemNode) IsRetracted() bool {
 }
 
 // mergeableCategories defines which categories support in-place merging.
+// Must stay in lockstep with engine.mergeableCategory; the store layer reads
+// this when deciding whether UpsertNode should merge or create a new node.
+// feedback joined v0.6.0 (issue #24) — near-duplicate rules ("be terse" /
+// "stay concise") should consolidate, not accrete. reference deliberately
+// stays out: each external pointer is distinct, like entities.
 var mergeableCategories = map[string]bool{
 	"profile":     true,
 	"preferences": true,
 	"patterns":    true,
+	"feedback":    true,
 }
 
 // CreateNode inserts a new mem_node. Sets mergeable based on category.

--- a/internal/store/nodes.go
+++ b/internal/store/nodes.go
@@ -85,8 +85,8 @@ func (n *MemNode) IsRetracted() bool {
 }
 
 // mergeableCategories defines which categories support in-place merging.
-// Must stay in lockstep with engine.mergeableCategory; the store layer reads
-// this when deciding whether UpsertNode should merge or create a new node.
+// This is the single source of truth — read it via IsMergeable. The
+// previous engine.mergeableCategory mirror is gone; do not reintroduce it.
 // feedback joined v0.6.0 (issue #24) — near-duplicate rules ("be terse" /
 // "stay concise") should consolidate, not accrete. reference deliberately
 // stays out: each external pointer is distinct, like entities.
@@ -97,12 +97,20 @@ var mergeableCategories = map[string]bool{
 	"feedback":    true,
 }
 
+// IsMergeable reports whether the given category supports in-place merging.
+// This is the single source of truth consulted by UpsertNode and any
+// upstream policy checks; the map itself stays unexported so callers can
+// neither mutate it nor diverge from it.
+func IsMergeable(category string) bool {
+	return mergeableCategories[category]
+}
+
 // CreateNode inserts a new mem_node. Sets mergeable based on category.
 // Automatically ensures parent directory nodes exist.
 func (db *DB) CreateNode(node *MemNode) error {
 	now := time.Now().UnixMilli()
 	mergeable := 0
-	if mergeableCategories[node.Category] {
+	if IsMergeable(node.Category) {
 		mergeable = 1
 	}
 
@@ -128,7 +136,7 @@ func (db *DB) CreateNode(node *MemNode) error {
 
 	id, _ := result.LastInsertId()
 	node.ID = id
-	node.Mergeable = mergeableCategories[node.Category]
+	node.Mergeable = IsMergeable(node.Category)
 	node.Relevance = 1.0
 	node.CreatedAt = now
 	node.UpdatedAt = now

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -4,10 +4,12 @@
   /* Category colors — saturated neons matching hero image */
   --color-profile: #60a5fa;     /* bright blue — top-left branches */
   --color-preferences: #34d399;  /* emerald green — left branches */
+  --color-feedback: #f97316;     /* warm coral — directional guidance */
   --color-entities: #c084fc;     /* vivid purple — right branches */
   --color-events: #fbbf24;       /* warm amber — lower-left branches */
   --color-patterns: #2dd4bf;     /* bright teal — top-right branches */
   --color-cases: #fb7185;        /* rose pink — lower-right branches */
+  --color-reference: #94a3b8;    /* cool slate — locator data, low-key */
 
   /* Golden accent — the tree trunk */
   --color-accent: #d4a843;
@@ -90,10 +92,12 @@ button, input, select {
 /* Utility: category glow effect */
 .glow-profile { box-shadow: 0 0 12px rgba(96, 165, 250, var(--glow-opacity)); }
 .glow-preferences { box-shadow: 0 0 12px rgba(52, 211, 153, var(--glow-opacity)); }
+.glow-feedback { box-shadow: 0 0 12px rgba(249, 115, 22, var(--glow-opacity)); }
 .glow-entities { box-shadow: 0 0 12px rgba(192, 132, 252, var(--glow-opacity)); }
 .glow-events { box-shadow: 0 0 12px rgba(251, 191, 36, var(--glow-opacity)); }
 .glow-patterns { box-shadow: 0 0 12px rgba(45, 212, 191, var(--glow-opacity)); }
 .glow-cases { box-shadow: 0 0 12px rgba(251, 113, 133, var(--glow-opacity)); }
+.glow-reference { box-shadow: 0 0 12px rgba(148, 163, 184, var(--glow-opacity)); }
 
 /* Expand/collapse animation */
 .expand-enter {

--- a/ui/src/components/MemoryCard.svelte
+++ b/ui/src/components/MemoryCard.svelte
@@ -72,10 +72,12 @@
     const map: Record<string, string> = {
       profile: 'glow-profile',
       preferences: 'glow-preferences',
+      feedback: 'glow-feedback',
       entities: 'glow-entities',
       events: 'glow-events',
       patterns: 'glow-patterns',
       cases: 'glow-cases',
+      reference: 'glow-reference',
     };
     return map[cat] || '';
   }

--- a/ui/src/components/SearchPanel.svelte
+++ b/ui/src/components/SearchPanel.svelte
@@ -34,7 +34,7 @@
     if (e.key === 'Enter') doSearch();
   }
 
-  const categories = ['', 'profile', 'preferences', 'entities', 'events', 'patterns', 'cases'];
+  const categories = ['', 'profile', 'preferences', 'feedback', 'entities', 'events', 'patterns', 'cases', 'reference'];
 </script>
 
 <div class="p-6 max-w-4xl mx-auto">

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -59,13 +59,15 @@ export interface HealthResponse {
   db: boolean;
 }
 
-export type Category = 'profile' | 'preferences' | 'entities' | 'events' | 'patterns' | 'cases';
+export type Category = 'profile' | 'preferences' | 'feedback' | 'entities' | 'events' | 'patterns' | 'cases' | 'reference';
 
 export const categoryColors: Record<Category, string> = {
   profile: 'var(--color-profile)',
   preferences: 'var(--color-preferences)',
+  feedback: 'var(--color-feedback)',
   entities: 'var(--color-entities)',
   events: 'var(--color-events)',
   patterns: 'var(--color-patterns)',
   cases: 'var(--color-cases)',
+  reference: 'var(--color-reference)',
 };


### PR DESCRIPTION
## Summary

Closes #24.

Adds two new first-class categories to the memory taxonomy: **feedback** (directional guidance the user gave about how to approach work — corrections AND confirmations) and **reference** (pointers to external systems and team rituals: Linear, Grafana, Slack, standups).

The issue documented a recurring imprecision: three independent Claude instances (work-Claude, operator-Claude, reviews-Claude) all reported the same default-into-`preferences` behavior when no better home existed. The third-Claude comment supplied the boundary rule that's now encoded in the extraction prompts; this PR ships it end-to-end.

## The rule (per the issue)

- "do/don't X (behavior)" + a why → **feedback**
- "X is always set to Y (configurational knob)" → **preferences**
- "the technique for X is Y (transferable knowledge)" → **patterns**

Feedback L1 carries a structured shape — `<rule>. Why: <reason>. How to apply: <when>.` — to keep the audit trail load-bearing. The shape lives in the prompt; the validator is intentionally permissive (regex enforcement of structure is too brittle for the variability the LLM produces).

## Design decisions

| | feedback | reference |
|---|---|---|
| Owner | `mem://user/feedback/...` | `mem://user/reference/...` |
| Mergeable | yes (consolidate near-duplicate rules — the "six be-terse memories" failure mode) | no (each pointer is distinct; Linear board ≠ Grafana dashboard) |
| Context injection | rides with "Your Profile" (no tag — shapes *action*) | "Recent Memories" tail with `[reference]` tag |
| Search boost | 1.0× (already ranks above patterns via section split) | 1.0× (must not jump on marginal similarity) |
| Decay | standard 90-day half-life | standard 90-day half-life |

Agent-side feedback (`mem://agent/feedback/...`) is **out of scope** per the issue — different beast, future issue.

## Schema

Migration v9 rebuilds `mem_nodes` with the v6 table-swap pattern to extend the `category` CHECK constraint. The v8 retraction columns round-trip unchanged; pinned by `TestMigration9PreservesRetractionColumns`.

## Single-source-of-truth for mergeable categories (resolved in d37a078)

The first pass kept two parallel definitions — `engine.mergeableCategory` and `store.mergeableCategories` — that had to stay in lockstep. `TestRememberFeedbackMergesOnUpdate` caught the drift on the first test run before commit (the engine map was updated, the store map wasn't, and `UpsertNode` was creating timestamp-suffixed slugs instead of merging).

Closer inspection showed the engine function had no production callers — only its own taxonomy test. The store map was the sole runtime enforcer (consulted by `CreateNode`, which stamps the bit on each node at write time; `UpsertNode` then reads `node.Mergeable` to pick merge-vs-create). The engine function was a misleading policy mirror that made silent drift possible.

`d37a078` consolidates: `store.IsMergeable` is the single source of truth (backing map stays unexported so no caller can mutate it), `engine.mergeableCategory` is gone, and `TestMergeableCategory` routes through `store.IsMergeable` so the policy pin lives in one place.

## Tests

**230 → 242 passing (+12 net)**. Coverage preserved across every package (server +0.1%, others flat).

New coverage:
- `internal/store/db_test.go` — `TestFeedbackCategory`, `TestReferenceCategory`, `TestMigration9PreservesRetractionColumns` + version-pin bumps
- `internal/engine/taxonomy_test.go` (new) — `TestOwnerForCategory`, `TestMergeableCategory`, `TestValidCategoriesContainsAll`
- `internal/engine/search_test.go` — `TestCategoryBoost` extended to cover every category
- `internal/engine/validate_test.go` — `TestValidateCandidate_FeedbackCategory`, `TestValidateCandidate_ReferenceCategory`
- `internal/engine/engine_test.go` — `TestRememberFeedbackMergesOnUpdate`, `TestRememberReferenceImmutable`
- `internal/server/server_test.go` — `TestBuildContextFeedbackInProfileSection` (pins the no-tag rendering for feedback, the tag rendering for reference)
- `internal/server/routes_test.go` — `TestRememberRouteFeedbackAndReference` (POST /api/memories acceptance)
- `internal/cli/remember_test.go` (new) — `TestValidCategorySet` membership pin

## Test plan

- [x] `go test ./internal/... -count=1` all green
- [x] `go vet ./internal/...` clean
- [x] `gofmt` clean on changed files
- [x] Coverage delta non-regressive (see numbers above)
- [x] Smoke run: `continuity remember -c feedback ...` and `continuity remember -c reference ...` against a running server, confirm the writes succeed and `continuity search` surfaces them
- [ ] Smoke run: hit `/api/context` with feedback + reference seeded, confirm feedback in "Your Profile" block (no tag), reference in "Recent Memories" with tag
- [ ] UI build (`cd ui && npm run build`) and viewer sanity — confirm the two new colors render and the new categories appear in the SearchPanel dropdown
- [ ] Migrate an existing `~/.continuity/continuity.db` (built on main) under the new binary; confirm `schema_versions` shows v9 and pre-existing rows are intact

## Out of scope (explicit)

- Re-classifying existing memories. Per the issue, the rule applies to future writes only.
- Validator-layer enforcement of the "rule + Why + How to apply" L1 shape.
- Pool-cap / eviction strategies (both categories use standard decay).
- `RelationalPrompt` and `mem://user/profile/communication` (the relational profile keeps its compounding role; feedback nodes complement it).

## Suggested follow-ups (not in this PR)

- Add a Playwright visual regression for the new category colors when the harness from #6 lands.
- Once a few feedback memories accrue, evaluate whether a categoryBoost or dedicated section header is warranted (likely not — section placement already does the work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
