### PR TITLE
Refuse to open a DB stamped at a future schema version

### DIFF
--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -1,7 +1,13 @@
 package store
 
 import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	_ "modernc.org/sqlite"
 )
 
 func TestOpenMemory(t *testing.T) {
@@ -109,6 +115,113 @@ func TestSessionsConstraints(t *testing.T) {
 	`)
 	if err == nil {
 		t.Error("expected error for invalid status, got nil")
+	}
+}
+
+// TestMigrate_RejectsFutureSchemaVersion pins the forward-compat guard. A
+// continuity binary built at schema head H must refuse to operate against a
+// DB whose schema_versions table records a version > H — a newer binary
+// previously migrated that DB, and silently ignoring the newer invariants
+// would risk on-disk corruption (CHECK constraints we don't understand,
+// foreign-key shapes that may have changed, etc.).
+//
+// The scenario this test reproduces: user upgrades continuity, runs `serve`
+// once (which applies a future migration), then downgrades to the older
+// binary. Without the guard, the older binary would proceed quietly; with
+// the guard, the older binary fails fast with a clear remediation message.
+func TestMigrate_RejectsFutureSchemaVersion(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "future.db")
+
+	// Step 1: produce a DB at current head so subsequent reopens are valid.
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("initial open: %v", err)
+	}
+	current, err := db.SchemaVersion()
+	if err != nil {
+		t.Fatalf("SchemaVersion: %v", err)
+	}
+	if current != headVersion() {
+		t.Fatalf("initial schema version = %d, want head %d", current, headVersion())
+	}
+	db.Close()
+
+	// Step 2: stamp a fake "future" migration into schema_versions. This is
+	// what a newer binary would have left behind after applying its own
+	// migrations.
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	const futureVersion = 9999
+	_, err = raw.Exec(
+		`INSERT INTO schema_versions (version, description) VALUES (?, ?)`,
+		futureVersion, "from a future continuity build",
+	)
+	if err != nil {
+		raw.Close()
+		t.Fatalf("stamp future version: %v", err)
+	}
+	raw.Close()
+
+	// Step 3: reopen with the current binary. The guard MUST fire.
+	_, err = Open(dbPath)
+	if err == nil {
+		t.Fatal("Open succeeded; the guard must refuse a future schema version")
+	}
+
+	var typed *ErrSchemaTooNew
+	if !errors.As(err, &typed) {
+		t.Fatalf("error is not *ErrSchemaTooNew: %v", err)
+	}
+	if typed.Found != futureVersion {
+		t.Errorf("ErrSchemaTooNew.Found = %d, want %d", typed.Found, futureVersion)
+	}
+	if typed.Supported != headVersion() {
+		t.Errorf("ErrSchemaTooNew.Supported = %d, want head %d", typed.Supported, headVersion())
+	}
+
+	// Operator-facing message: must name both versions and offer a path
+	// forward. This contract drives what shows up on stderr when serve
+	// fails to start, and agents/operators read it. Pin the substrings
+	// rather than the exact text so phrasing tweaks remain frictionless.
+	msg := err.Error()
+	for _, substr := range []string{
+		"9999",                // the version we found
+		"max 9",               // the version we support (head is 9 today)
+		"upgrade continuity",  // explicit remediation
+		"restore a backup",    // alternative remediation
+	} {
+		if !strings.Contains(msg, substr) {
+			t.Errorf("error message missing %q\nfull message: %s", substr, msg)
+		}
+	}
+}
+
+// TestMigrate_AcceptsHeadVersion is the regression guard for the
+// forward-compat check: a DB at exactly head must NOT be rejected. The guard
+// uses `> head` rather than `>= head` — this test pins that boundary.
+func TestMigrate_AcceptsHeadVersion(t *testing.T) {
+	db, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	defer db.Close()
+
+	v, err := db.SchemaVersion()
+	if err != nil {
+		t.Fatalf("SchemaVersion: %v", err)
+	}
+	if v != headVersion() {
+		t.Fatalf("schema version = %d, want head %d (test setup bug)", v, headVersion())
+	}
+
+	// A second migrate against the head-version DB is exactly the path
+	// every restart of `continuity serve` takes. Must be a no-op, not a
+	// "too new" rejection.
+	if err := db.migrate(); err != nil {
+		t.Errorf("migrate against head-version DB should succeed; got %v", err)
 	}
 }
 

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -221,6 +221,36 @@ PRAGMA foreign_keys=ON;
 	},
 }
 
+// headVersion is the highest schema version this binary knows how to apply.
+// Computed lazily; callable from tests for the forward-compat guard.
+func headVersion() int {
+	if len(migrations) == 0 {
+		return 0
+	}
+	return migrations[len(migrations)-1].Version
+}
+
+// ErrSchemaTooNew signals that the database has been migrated by a newer
+// continuity binary than the one currently running. Treated as a fast-fail
+// at startup so the operator sees a clear remediation message instead of
+// the binary silently ignoring invariants it does not understand.
+//
+// Typed error so callers (e.g. a future `continuity doctor` command or a
+// recovery flow) can branch on it without parsing the message string.
+type ErrSchemaTooNew struct {
+	Found    int
+	Supported int
+}
+
+func (e *ErrSchemaTooNew) Error() string {
+	return fmt.Sprintf(
+		"database schema version %d is newer than this binary supports "+
+			"(max %d); upgrade continuity, or restore a backup of the database "+
+			"from before that migration ran",
+		e.Found, e.Supported,
+	)
+}
+
 func (db *DB) migrate() error {
 	// Create schema_versions table if it doesn't exist
 	_, err := db.Exec(`
@@ -232,6 +262,22 @@ func (db *DB) migrate() error {
 	`)
 	if err != nil {
 		return fmt.Errorf("create schema_versions: %w", err)
+	}
+
+	// Forward-compat guard: refuse to operate against a DB that has been
+	// stamped with a schema version this binary does not know. The newer
+	// version may carry invariants we cannot uphold (CHECK constraints,
+	// triggers, foreign-key relationships), and silently ignoring them
+	// would risk corrupting the on-disk state. Fail fast with a clear
+	// operator-facing message instead.
+	var maxApplied int
+	if err := db.QueryRow(
+		`SELECT COALESCE(MAX(version), 0) FROM schema_versions`,
+	).Scan(&maxApplied); err != nil {
+		return fmt.Errorf("read schema_versions: %w", err)
+	}
+	if head := headVersion(); maxApplied > head {
+		return &ErrSchemaTooNew{Found: maxApplied, Supported: head}
 	}
 
 	for _, m := range migrations {


### PR DESCRIPTION
## Summary

Production-behavior follow-up surfaced during PR #29's planning. Per the decision: a current continuity binary must NOT silently operate against a DB whose `schema_versions` table records a version newer than the binary knows. Fail fast with a clear operator-facing error instead.

Independent of the test stack (#27/#28/#29) — bases on main, can merge in any order.

## The bug class

Before this change: a user upgrades continuity → runs `serve` once (which applies the upgrade's new migrations) → downgrades to the older binary. The older binary's `migrate()` sees `schema_versions` rows 1..head_old already applied, has no work to do, and proceeds quietly. But the newer migration may have added CHECK constraints, foreign keys, or other invariants this binary cannot uphold — the next write attempt would corrupt state or fail with an inscrutable SQLite error nobody can act on.

The failure mode is silent until the first downstream symptom. The leverage rubric: clear silent-failure class.

## What ships

`internal/store/migrations.go`:

- New `headVersion()` helper — the highest schema version this binary knows
- New typed `*ErrSchemaTooNew` error carrying `Found` and `Supported` fields. Typed so future paths (`continuity doctor`, on-startup recovery) can branch on it without string parsing.
- `migrate()` now checks `SELECT MAX(version)` after creating `schema_versions` but before iterating migrations. If `MAX > head`, returns `*ErrSchemaTooNew`.

Operator message (wrapped by db.go's `fmt.Errorf("migrate: %w", err)`):

```
migrate: database schema version 9999 is newer than this binary supports
(max 9); upgrade continuity, or restore a backup of the database from
before that migration ran
```

Names both versions, offers two remediations.

## Tests

`internal/store/db_test.go`:

- **`TestMigrate_RejectsFutureSchemaVersion`** — produce a v9 DB, stamp version 9999 directly into `schema_versions`, reopen, assert `*ErrSchemaTooNew` with correct field values and the operator message contains all load-bearing substrings (version numbers, both remediation paths).
- **`TestMigrate_AcceptsHeadVersion`** — boundary test. The guard uses `> head`, not `>= head`. This pins that boundary so a future refactor cannot tighten the guard to reject head-version DBs (the normal-case every restart walks).

In-process only. The subprocess equivalent (binary fails to start, stderr shows the message, exit non-zero) is implied by the existing migration-e2e tests in #29 once they merge — those tests assert successful boot, so a regression that broke ordinary boots would fail there.

## Test plan

- [x] `go test -count=1 ./internal/...` — full suite green
- [x] `go vet ./internal/...` — clean
- [x] New tests pass and exercise the load-bearing assertions (both typed-error matching and operator-message contract)
- [ ] Manual: build, stamp a fake future row into a real DB, confirm the stderr message reads cleanly to a human

## Design notes

- **Why typed error.** A future `continuity doctor` subcommand will want to detect this specific failure and offer guided recovery (download newer binary, restore backup). String matching on error text is fragile; typed error is the right primitive even if no consumer needs it today.
- **Why `> head`, not `>= head`.** The normal case — every restart of `continuity serve` against an up-to-date DB — has `MAX(version) == head`. That must continue to work. `TestMigrate_AcceptsHeadVersion` pins this.
- **Why no `continuity rollback` or auto-downgrade path.** Downgrade migrations are out of scope for v1. Continuity does not (yet) ship inverse migrations, so the only safe paths for an operator who hits this are: forward (upgrade the binary) or backward (restore a backup). Both are surfaced in the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)