### PR TITLE
Migration safety snapshots (narrowly-scoped, automatic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ The verb exists for the agent to curate its own substrate. Operators don't run i
 
 Migrations are the one place Continuity knowingly performs potentially destructive operations against the user's substrate. SQLite's transaction guarantees catch most failure modes (power loss, disk full, syntax errors all abort cleanly), but they cannot catch a buggy migration that successfully commits the wrong state — a column-order misalignment in an `INSERT SELECT *` rebuild, say.
 
-For that narrow class of failure, Continuity takes an automatic safety snapshot immediately before each migration explicitly marked risky (currently the two full-table rebuilds, v6 and v9). The snapshot is an atomic copy of the live database written via `VACUUM INTO`, named `continuity-pre-vN-<RFC3339>.db`, and lives in `~/.continuity/snapshots/`.
+For that narrow class of failure, Continuity takes an automatic safety snapshot immediately before each migration explicitly marked risky (currently the two full-table rebuilds, v6 and v9). The snapshot is an atomic copy of the live database written via `VACUUM INTO`, named `continuity-pre-vN-<RFC3339>.db`, and lives in a per-database directory, `~/.continuity/snapshots/<db-filename>/` (e.g. `~/.continuity/snapshots/continuity.db/`). Namespacing by database filename keeps two databases that share a parent directory — for instance a `CONTINUITY_DB` scratch copy beside the default — from ever touching each other's snapshots when pruned.
 
 **This is not a backup system.** It is a one-shot safety net during the upgrade window. The policy is intentionally narrow:
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ continuity retract     Retract a memory you wrote (tombstone or supersession)
 continuity profile     Show relational profile
 continuity tree        Browse the memory tree
 continuity dedup       Deduplicate similar memory nodes
+continuity snapshot list      List retained migration safety snapshots
+continuity snapshot prune     Remove retained migration safety snapshots
 continuity version     Print version information
 ```
 
@@ -283,6 +285,29 @@ continuity retract mem://user/preferences/old-style \
 Retracted memories stay in the tree — nothing is silently erased. Pass `--include-retracted` to `show` or `tree` to inspect them. The reason text is sequestered behind that flag (absent from default responses, not empty or redacted), so confronting your own past retraction is a deliberate act.
 
 The verb exists for the agent to curate its own substrate. Operators don't run it. The trust contract is what governs the substrate, not architectural enforcement.
+
+### Migration safety snapshots
+
+Migrations are the one place Continuity knowingly performs potentially destructive operations against the user's substrate. SQLite's transaction guarantees catch most failure modes (power loss, disk full, syntax errors all abort cleanly), but they cannot catch a buggy migration that successfully commits the wrong state — a column-order misalignment in an `INSERT SELECT *` rebuild, say.
+
+For that narrow class of failure, Continuity takes an automatic safety snapshot immediately before each migration explicitly marked risky (currently the two full-table rebuilds, v6 and v9). The snapshot is an atomic copy of the live database written via `VACUUM INTO`, named `continuity-pre-vN-<RFC3339>.db`, and lives in `~/.continuity/snapshots/`.
+
+**This is not a backup system.** It is a one-shot safety net during the upgrade window. The policy is intentionally narrow:
+
+- Only migrations marked `Risky` in the source trigger snapshots. Additive migrations (`ALTER TABLE ADD COLUMN`) do not.
+- Only the **most recent** risky-migration snapshot is retained. A newer risky migration replaces the older snapshot.
+- Snapshots **auto-delete** after a small number of successful `continuity serve` boots (default: 3). The presumption is that if the new schema were going to break, it would have broken by then.
+- If snapshot creation fails for any reason (disk full, permission denied, etc.), the migration **does not proceed**. The operator can set `CONTINUITY_NO_MIGRATION_SNAPSHOT=1` to skip — a deliberate, knowing tradeoff.
+- There is **no automated restore**. Restoration is manual: stop the server, `cp` the snapshot file over `~/.continuity/continuity.db`, restart.
+
+Inspect or remove snapshots:
+
+```bash
+continuity snapshot list   # show retained snapshots, auto-delete countdown
+continuity snapshot prune  # remove all retained snapshots immediately
+```
+
+Operators are still expected to maintain their own backup strategy (e.g., `restic`, `tar`, filesystem snapshots) — this safety net does not relieve that responsibility, and the lifecycle bounds are tight enough that it should not lull anyone into thinking otherwise.
 
 ## API
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -31,4 +31,5 @@ func init() {
 	rootCmd.AddCommand(installServiceCmd)
 	rootCmd.AddCommand(uninstallServiceCmd)
 	rootCmd.AddCommand(extractCmd)
+	rootCmd.AddCommand(snapshotCmd)
 }

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -71,23 +72,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("open database: %w", err)
 	}
 	defer db.Close()
-
-	// Tick the migration-snapshot retention counter. Each `continuity serve`
-	// start counts as one boot against any retained safety snapshots; after
-	// SnapshotRetentionBoots successful boots, snapshots auto-delete.
-	// Deliberately NOT in store.Open so CLI subcommands that inspect or
-	// prune snapshots don't advance the counter.
-	if err := db.TickSnapshotRetention(); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: snapshot retention tick failed: %v\n", err)
-	}
-	if snaps, _ := db.ListMigrationSnapshots(); len(snaps) > 0 {
-		for _, s := range snaps {
-			fmt.Fprintf(os.Stderr,
-				"migration safety snapshot retained: %s (auto-deletes after %d more successful boots)\n",
-				s.Path, store.SnapshotRetentionBoots-s.BootsSince,
-			)
-		}
-	}
 
 	// Create LLM client and engine
 	var eng *engine.Engine
@@ -181,6 +165,33 @@ func runServe(cmd *cobra.Command, args []string) error {
 		MaxHeaderBytes: 1 << 20, // 1MB
 	}
 
+	// Bind the listener explicitly BEFORE advancing the snapshot retention
+	// counter. net.Listen surfaces a bind failure (e.g. the port is already
+	// in use) synchronously — a failed start must NOT count as a boot.
+	// Otherwise SnapshotRetentionBoots failed `serve` attempts in a row would
+	// auto-delete the migration safety snapshot without the migrated schema
+	// ever having served a single request: the exact case the snapshot guards.
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", addr, err)
+	}
+
+	// The listener is bound: this is a genuine "the new schema boots and
+	// serves" signal. Tick retention now, then surface what's still retained.
+	// Deliberately not in store.Open, so CLI subcommands that inspect or prune
+	// snapshots don't advance the counter — only a real serve boot does.
+	if err := db.TickSnapshotRetention(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: snapshot retention tick failed: %v\n", err)
+	}
+	if snaps, _ := db.ListMigrationSnapshots(); len(snaps) > 0 {
+		for _, s := range snaps {
+			fmt.Fprintf(os.Stderr,
+				"migration safety snapshot retained: %s (auto-deletes after %d more successful boots)\n",
+				s.Path, store.SnapshotRetentionBoots-s.BootsSince,
+			)
+		}
+	}
+
 	// Graceful shutdown
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
@@ -188,7 +199,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	go func() {
 		fmt.Fprintf(os.Stderr, "continuity serving on %s\n", addr)
 		fmt.Fprintf(os.Stderr, "  db: %s\n", dbPath)
-		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
 			fmt.Fprintf(os.Stderr, "server error: %v\n", err)
 			os.Exit(1)
 		}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -72,6 +72,23 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	defer db.Close()
 
+	// Tick the migration-snapshot retention counter. Each `continuity serve`
+	// start counts as one boot against any retained safety snapshots; after
+	// SnapshotRetentionBoots successful boots, snapshots auto-delete.
+	// Deliberately NOT in store.Open so CLI subcommands that inspect or
+	// prune snapshots don't advance the counter.
+	if err := db.TickSnapshotRetention(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: snapshot retention tick failed: %v\n", err)
+	}
+	if snaps, _ := db.ListMigrationSnapshots(); len(snaps) > 0 {
+		for _, s := range snaps {
+			fmt.Fprintf(os.Stderr,
+				"migration safety snapshot retained: %s (auto-deletes after %d more successful boots)\n",
+				s.Path, store.SnapshotRetentionBoots-s.BootsSince,
+			)
+		}
+	}
+
 	// Create LLM client and engine
 	var eng *engine.Engine
 	llmClient, err := llm.NewClient(cfg.LLM)

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lazypower/continuity/internal/store"
+)
+
+// snapshotCmd is the parent for `continuity snapshot list / prune`. There is
+// NO `restore` subcommand by design — restoration is a manual `cp` and the
+// operator must own that decision. The CLI surface exists to make snapshots
+// visible and disposable, not to manage them.
+var snapshotCmd = &cobra.Command{
+	Use:   "snapshot",
+	Short: "Inspect or remove migration safety snapshots",
+	Long: `Migration safety snapshots are atomic copies of the database taken just
+before a risky schema migration runs (e.g., a full-table rebuild). They
+exist as a one-shot safety net during the upgrade window — NOT as a
+backup system.
+
+Snapshots auto-delete after a small number of successful serve boots;
+this command lets you inspect what's currently retained or prune it
+explicitly. To restore from a snapshot, stop the server and copy the
+snapshot file over the live database manually.`,
+}
+
+var snapshotListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List retained migration safety snapshots",
+	RunE:  runSnapshotList,
+}
+
+var snapshotPruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Remove all retained migration safety snapshots",
+	Long: `Removes every retained migration safety snapshot, deleting the snapshot
+files and clearing the tracking table. This is destructive — once pruned,
+there is no automated way to roll back the most recent risky migration.`,
+	RunE: runSnapshotPrune,
+}
+
+func init() {
+	snapshotCmd.AddCommand(snapshotListCmd)
+	snapshotCmd.AddCommand(snapshotPruneCmd)
+}
+
+func openDBForSnapshot() (*store.DB, error) {
+	dbPath, err := store.DefaultDBPath()
+	if err != nil {
+		return nil, fmt.Errorf("resolve db path: %w", err)
+	}
+	return store.Open(dbPath)
+}
+
+func runSnapshotList(cmd *cobra.Command, args []string) error {
+	db, err := openDBForSnapshot()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	snaps, err := db.ListMigrationSnapshots()
+	if err != nil {
+		return err
+	}
+	if len(snaps) == 0 {
+		fmt.Println("no migration safety snapshots retained")
+		return nil
+	}
+	fmt.Printf("%d migration safety snapshot(s) retained:\n", len(snaps))
+	for _, s := range snaps {
+		fmt.Printf("\n  %s\n", s.Path)
+		fmt.Printf("    pre-version:    %d\n", s.PreVersion)
+		fmt.Printf("    target-version: %d\n", s.TargetVersion)
+		fmt.Printf("    created:        %s\n", s.CreatedAt.Format("2006-01-02 15:04:05 MST"))
+		fmt.Printf("    boots since:    %d (auto-deletes after %d)\n",
+			s.BootsSince, store.SnapshotRetentionBoots)
+	}
+	fmt.Println()
+	fmt.Println("To restore from a snapshot, stop the server and:")
+	fmt.Println("  cp <snapshot-path> ~/.continuity/continuity.db")
+	return nil
+}
+
+func runSnapshotPrune(cmd *cobra.Command, args []string) error {
+	db, err := openDBForSnapshot()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	n, err := db.PruneMigrationSnapshots()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		fmt.Println("no snapshots to prune")
+		return nil
+	}
+	fmt.Fprintf(os.Stdout, "removed %d migration safety snapshot(s)\n", n)
+	return nil
+}

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -47,16 +47,8 @@ func init() {
 	snapshotCmd.AddCommand(snapshotPruneCmd)
 }
 
-func openDBForSnapshot() (*store.DB, error) {
-	dbPath, err := store.DefaultDBPath()
-	if err != nil {
-		return nil, fmt.Errorf("resolve db path: %w", err)
-	}
-	return store.Open(dbPath)
-}
-
 func runSnapshotList(cmd *cobra.Command, args []string) error {
-	db, err := openDBForSnapshot()
+	db, err := openDB()
 	if err != nil {
 		return err
 	}
@@ -86,7 +78,7 @@ func runSnapshotList(cmd *cobra.Command, args []string) error {
 }
 
 func runSnapshotPrune(cmd *cobra.Command, args []string) error {
-	db, err := openDBForSnapshot()
+	db, err := openDB()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -47,8 +47,23 @@ func init() {
 	snapshotCmd.AddCommand(snapshotPruneCmd)
 }
 
+// openDBForSnapshot opens the configured database (honoring CONTINUITY_DB, like
+// openDB) but WITHOUT running migrations. Inspecting or pruning snapshots must
+// not trigger a schema upgrade — see store.OpenNoMigrate for why.
+func openDBForSnapshot() (*store.DB, error) {
+	dbPath := os.Getenv("CONTINUITY_DB")
+	if dbPath == "" {
+		var err error
+		dbPath, err = store.DefaultDBPath()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return store.OpenNoMigrate(dbPath)
+}
+
 func runSnapshotList(cmd *cobra.Command, args []string) error {
-	db, err := openDB()
+	db, err := openDBForSnapshot()
 	if err != nil {
 		return err
 	}
@@ -73,12 +88,15 @@ func runSnapshotList(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println()
 	fmt.Println("To restore from a snapshot, stop the server and:")
-	fmt.Println("  cp <snapshot-path> ~/.continuity/continuity.db")
+	// Print the DB actually opened, not a hardcoded default — with
+	// CONTINUITY_DB set, the default path would point the operator at the
+	// wrong file and risk overwriting an unrelated database.
+	fmt.Printf("  cp <snapshot-path> %s\n", db.Path)
 	return nil
 }
 
 func runSnapshotPrune(cmd *cobra.Command, args []string) error {
-	db, err := openDB()
+	db, err := openDBForSnapshot()
 	if err != nil {
 		return err
 	}

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -53,6 +53,36 @@ func Open(path string) (*DB, error) {
 	return db, nil
 }
 
+// OpenNoMigrate opens the database WITHOUT running migrations. It is for
+// inspection/cleanup commands (`snapshot list`, `snapshot prune`) that must not
+// mutate schema as a side effect of being run. Opening with Open() would apply
+// any pending risky migration — which creates a safety snapshot — so a `prune`
+// against a not-yet-migrated DB would manufacture a snapshot and immediately
+// delete it, silently discarding the only rollback point. Managing snapshot
+// files is not a reason to upgrade the operator's schema.
+//
+// Callers that read sidecar tables (e.g. migration_snapshots) must tolerate
+// those tables being absent — a never-migrated DB has none.
+func OpenNoMigrate(path string) (*DB, error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("create db dir: %w", err)
+	}
+	hardenPermissions(dir, path)
+
+	sqlDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite: %w", err)
+	}
+
+	db := &DB{DB: sqlDB, Path: path}
+	if err := db.configurePragmas(); err != nil {
+		sqlDB.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
 // OpenMemory opens an in-memory SQLite database for testing.
 func OpenMemory() (*DB, error) {
 	sqlDB, err := sql.Open("sqlite", ":memory:")

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -2,12 +2,22 @@ package store
 
 import (
 	"fmt"
+	"os"
 )
 
 type migration struct {
 	Version     int
 	Description string
 	SQL         string
+
+	// Risky marks a migration as one that rebuilds or transforms user data
+	// in ways SQLite's transactional guarantees cannot recover from on
+	// developer error. Triggers an automatic safety snapshot before the
+	// migration runs (see snapshot.go). Set true for full-table rebuilds
+	// (CREATE _new + INSERT SELECT * + DROP + RENAME). Leave false for
+	// additive migrations (CREATE TABLE / ALTER TABLE ADD COLUMN) — those
+	// are reversible enough that the snapshot cost is unjustified.
+	Risky bool
 }
 
 var migrations = []migration{
@@ -111,6 +121,7 @@ CREATE TABLE mem_vectors (
 	{
 		Version:     6,
 		Description: "mem_nodes: add moments category",
+		Risky:       true, // full-table rebuild via INSERT SELECT *; column-order parity is by developer discipline
 		SQL: `
 PRAGMA foreign_keys=OFF;
 
@@ -171,6 +182,7 @@ ALTER TABLE mem_nodes ADD COLUMN superseded_by TEXT;
 	{
 		Version:     9,
 		Description: "mem_nodes: add feedback and reference categories (issue #24)",
+		Risky:       true, // full-table rebuild via INSERT SELECT *; column-order parity is by developer discipline
 		SQL: `
 PRAGMA foreign_keys=OFF;
 
@@ -269,7 +281,8 @@ func (db *DB) migrate() error {
 	// version may carry invariants we cannot uphold (CHECK constraints,
 	// triggers, foreign-key relationships), and silently ignoring them
 	// would risk corrupting the on-disk state. Fail fast with a clear
-	// operator-facing message instead.
+	// operator-facing message instead. Runs before any other setup so a
+	// too-new DB short-circuits before we touch snapshot bookkeeping.
 	var maxApplied int
 	if err := db.QueryRow(
 		`SELECT COALESCE(MAX(version), 0) FROM schema_versions`,
@@ -278,6 +291,13 @@ func (db *DB) migrate() error {
 	}
 	if head := headVersion(); maxApplied > head {
 		return &ErrSchemaTooNew{Found: maxApplied, Supported: head}
+	}
+
+	// Sidecar table for migration-snapshot bookkeeping. Lives outside the
+	// schema_versions migration system because we need it to exist before
+	// any risky migration runs (including v6, the first risky one).
+	if err := db.ensureSnapshotStateTable(); err != nil {
+		return err
 	}
 
 	for _, m := range migrations {
@@ -290,13 +310,41 @@ func (db *DB) migrate() error {
 			continue
 		}
 
+		// Capture the pre-migration schema version BEFORE taking the
+		// snapshot; we need this to record what the snapshot represents.
+		var preVersion int
+		if err := db.QueryRow(
+			`SELECT COALESCE(MAX(version), 0) FROM schema_versions`,
+		).Scan(&preVersion); err != nil {
+			return fmt.Errorf("read pre-version for migration %d: %w", m.Version, err)
+		}
+
+		// Snapshot BEFORE applying a risky migration. If snapshot creation
+		// fails, the migration MUST NOT proceed — that's the safety net
+		// contract. The operator can set CONTINUITY_NO_MIGRATION_SNAPSHOT
+		// to bypass when they've made an explicit decision to.
+		snapPath, err := db.snapshotBeforeRiskyMigration(m)
+		if err != nil {
+			return fmt.Errorf(
+				"snapshot before migration %d: %w "+
+					"(set %s=1 to skip snapshots, knowing you accept the risk)",
+				m.Version, err, EnvNoMigrationSnapshot,
+			)
+		}
+
 		tx, err := db.Begin()
 		if err != nil {
+			if snapPath != "" {
+				_ = os.Remove(snapPath) // migration won't run; snapshot is dead weight
+			}
 			return fmt.Errorf("begin migration %d: %w", m.Version, err)
 		}
 
 		if _, err := tx.Exec(m.SQL); err != nil {
 			tx.Rollback()
+			if snapPath != "" {
+				_ = os.Remove(snapPath)
+			}
 			return fmt.Errorf("migration %d (%s): %w", m.Version, m.Description, err)
 		}
 
@@ -305,11 +353,30 @@ func (db *DB) migrate() error {
 			m.Version, m.Description,
 		); err != nil {
 			tx.Rollback()
+			if snapPath != "" {
+				_ = os.Remove(snapPath)
+			}
 			return fmt.Errorf("record migration %d: %w", m.Version, err)
 		}
 
 		if err := tx.Commit(); err != nil {
+			if snapPath != "" {
+				_ = os.Remove(snapPath)
+			}
 			return fmt.Errorf("commit migration %d: %w", m.Version, err)
+		}
+
+		// Migration committed. Now enroll the snapshot in the tracking
+		// table and prune any older one. A failure here leaves the
+		// snapshot file on disk but unrecorded — `continuity snapshot
+		// prune` can mop up later, and the migration's success is the
+		// load-bearing outcome.
+		if snapPath != "" {
+			if err := db.recordSnapshotAndPruneOlder(snapPath, preVersion, m.Version); err != nil {
+				fmt.Fprintf(os.Stderr,
+					"warning: migration %d succeeded but snapshot %s could not be recorded: %v\n",
+					m.Version, snapPath, err)
+			}
 		}
 	}
 

--- a/internal/store/snapshot.go
+++ b/internal/store/snapshot.go
@@ -47,6 +47,18 @@ func snapshotDirForDB(dbPath string) string {
 	return filepath.Join(filepath.Dir(dbPath), "snapshots", filepath.Base(dbPath))
 }
 
+// ownsSnapshotPath reports whether a tracked snapshot path actually belongs to
+// THIS database — i.e. it sits directly in this DB's namespaced snapshot dir.
+// Tracking rows store absolute paths, so a database that was copied or renamed
+// (e.g. `cp continuity.db scratch.db`, then CONTINUITY_DB=scratch.db) inherits
+// rows pointing at the ORIGINAL DB's snapshot files. Unlinking those during
+// prune or retention would destroy another database's rollback point. This is
+// the deletion-side complement to namespaced creation: never unlink a file we
+// can't prove is ours, no matter what a stale row claims.
+func (db *DB) ownsSnapshotPath(p string) bool {
+	return filepath.Dir(p) == snapshotDirForDB(db.Path)
+}
+
 // ensureSnapshotStateTable creates the sidecar tracking table. Called from
 // migrate() before the migration loop so the table is available whether or
 // not any prior migration has touched it. Deliberately NOT part of the
@@ -239,14 +251,19 @@ func (db *DB) TickSnapshotRetention() error {
 	rows.Close()
 
 	for _, p := range expired {
-		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
-			// Removal genuinely failed (permission denied, a snapshot DB held
-			// open on Windows, etc.). Keep the tracking row so the file stays
-			// visible to `snapshot list/prune` and a future retention tick can
-			// retry the delete. Dropping the row here would strand the file on
-			// disk, untracked and unreclaimable.
-			fmt.Fprintf(os.Stderr, "warning: could not delete expired snapshot %s: %v (will retry next boot)\n", p, err)
-			continue
+		// Only unlink files that are genuinely ours. An out-of-namespace path
+		// is a stale pointer inherited from a copied/renamed DB; clear the row
+		// (it is meaningless for this DB) but never touch the foreign file.
+		if db.ownsSnapshotPath(p) {
+			if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+				// Removal genuinely failed (permission denied, a snapshot DB held
+				// open on Windows, etc.). Keep the tracking row so the file stays
+				// visible to `snapshot list/prune` and a future retention tick can
+				// retry the delete. Dropping the row here would strand the file on
+				// disk, untracked and unreclaimable.
+				fmt.Fprintf(os.Stderr, "warning: could not delete expired snapshot %s: %v (will retry next boot)\n", p, err)
+				continue
+			}
 		}
 		if _, err := db.Exec(`DELETE FROM migration_snapshots WHERE snapshot_path = ?`, p); err != nil {
 			return fmt.Errorf("remove expired row: %w", err)
@@ -318,6 +335,13 @@ func (db *DB) PruneMigrationSnapshots() (int, error) {
 		return 0, err
 	}
 	for _, s := range snaps {
+		// Never unlink a file outside this DB's namespace: the row may be a
+		// stale pointer carried in from a copied/renamed DB and the file may be
+		// another database's live rollback point. The row is still cleared by
+		// the table wipe below — this DB has no business retaining it.
+		if !db.ownsSnapshotPath(s.Path) {
+			continue
+		}
 		if err := os.Remove(s.Path); err != nil && !os.IsNotExist(err) {
 			return len(removed), fmt.Errorf("remove snapshot %s: %w", s.Path, err)
 		}

--- a/internal/store/snapshot.go
+++ b/internal/store/snapshot.go
@@ -1,0 +1,267 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// SnapshotRetentionBoots is how many successful boots pass before a retained
+// migration safety snapshot is auto-deleted. Three is the smallest defensible
+// value: enough for "ran the binary, the new schema works, ran it a couple
+// more times to be sure," not so many that snapshots linger indefinitely.
+const SnapshotRetentionBoots = 3
+
+// EnvNoMigrationSnapshot is the opt-out: when set to any non-empty value,
+// migrate() will skip the snapshot step for risky migrations. Intended for
+// CI runs against ephemeral DBs, power users with their own backup story,
+// and the rare case where the snapshot would not fit on disk.
+//
+// Setting this is a deliberate choice — the developer or operator is saying
+// "I accept that a buggy table-rebuild migration would be unrecoverable in
+// this run." It is NOT a default and we do not encourage it.
+const EnvNoMigrationSnapshot = "CONTINUITY_NO_MIGRATION_SNAPSHOT"
+
+// MigrationSnapshot describes a retained snapshot row. Returned by
+// ListMigrationSnapshots for the `continuity snapshot list` command and used
+// internally by the retention tick.
+type MigrationSnapshot struct {
+	Path          string
+	PreVersion    int
+	TargetVersion int
+	CreatedAt     time.Time
+	BootsSince    int
+}
+
+// ensureSnapshotStateTable creates the sidecar tracking table. Called from
+// migrate() before the migration loop so the table is available whether or
+// not any prior migration has touched it. Deliberately NOT part of the
+// schema_versions migration system — this is metadata about migration runs,
+// not user data.
+func (db *DB) ensureSnapshotStateTable() error {
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS migration_snapshots (
+			snapshot_path  TEXT PRIMARY KEY,
+			pre_version    INTEGER NOT NULL,
+			target_version INTEGER NOT NULL,
+			created_at     INTEGER NOT NULL,
+			boots_since    INTEGER NOT NULL DEFAULT 0
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("create migration_snapshots: %w", err)
+	}
+	return nil
+}
+
+// snapshotBeforeRiskyMigration is called from migrate() before applying each
+// pending migration. If the migration is Risky and snapshots aren't opted
+// out, it creates an atomic copy of the current DB via VACUUM INTO, returns
+// the snapshot path, and leaves the recording of that path to the caller
+// (after the migration successfully commits).
+//
+// Returns ("", nil) when no snapshot was taken (migration isn't risky, opt-out
+// set, or DB is :memory:). Returns ("", err) when a snapshot SHOULD have been
+// taken but couldn't be — the caller MUST treat this as fatal and abort the
+// migration. Returns (path, nil) on success.
+func (db *DB) snapshotBeforeRiskyMigration(m migration) (string, error) {
+	if !m.Risky {
+		return "", nil
+	}
+	if v := os.Getenv(EnvNoMigrationSnapshot); v != "" {
+		// Opt-out path. We deliberately do not warn here — the operator
+		// who set the env var knows what they chose.
+		return "", nil
+	}
+	if db.Path == "" || db.Path == ":memory:" {
+		// No on-disk file to snapshot. In-memory DBs are by definition
+		// throwaway; tests that use them have other safety nets.
+		return "", nil
+	}
+
+	dbDir := filepath.Dir(db.Path)
+	snapDir := filepath.Join(dbDir, "snapshots")
+	if err := os.MkdirAll(snapDir, 0o700); err != nil {
+		return "", fmt.Errorf("create snapshot dir %s: %w", snapDir, err)
+	}
+
+	// Timestamp uses RFC3339 with dashes instead of colons so the filename
+	// is safe on every filesystem (Windows in particular rejects colons).
+	timestamp := time.Now().UTC().Format("2006-01-02T15-04-05Z")
+	snapName := fmt.Sprintf("continuity-pre-v%d-%s.db", m.Version, timestamp)
+	snapPath := filepath.Join(snapDir, snapName)
+
+	// VACUUM INTO is the SQLite-blessed atomic copy. It produces a complete,
+	// self-contained DB file in one statement, page-by-page from a consistent
+	// snapshot, while the source DB stays open and readable.
+	if _, err := db.Exec("VACUUM INTO ?", snapPath); err != nil {
+		return "", fmt.Errorf("vacuum into %s: %w", snapPath, err)
+	}
+
+	if err := os.Chmod(snapPath, 0o600); err != nil {
+		// Best-effort: a permission set failure isn't worth aborting the
+		// migration over, but it IS worth telling the operator.
+		fmt.Fprintf(os.Stderr, "warning: could not tighten permissions on snapshot %s: %v\n", snapPath, err)
+	}
+
+	return snapPath, nil
+}
+
+// recordSnapshotAndPruneOlder is called from migrate() AFTER a risky migration
+// has successfully committed. It does two things atomically: enrolls the new
+// snapshot in the tracking table, and removes any older snapshot records so
+// only the most-recent risky migration's safety net is retained. The actual
+// file deletion of older snapshots happens after the transaction commits so
+// a failed DB write doesn't leave us with no record AND no file.
+func (db *DB) recordSnapshotAndPruneOlder(snapPath string, preVersion, targetVersion int) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin snapshot record tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			tx.Rollback()
+		}
+	}()
+
+	rows, err := tx.Query(`SELECT snapshot_path FROM migration_snapshots WHERE snapshot_path != ?`, snapPath)
+	if err != nil {
+		return fmt.Errorf("scan old snapshots: %w", err)
+	}
+	var oldPaths []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan old snapshot path: %w", err)
+		}
+		oldPaths = append(oldPaths, p)
+	}
+	rows.Close()
+
+	if _, err := tx.Exec(`DELETE FROM migration_snapshots WHERE snapshot_path != ?`, snapPath); err != nil {
+		return fmt.Errorf("clear old snapshot rows: %w", err)
+	}
+
+	now := time.Now().UnixMilli()
+	_, err = tx.Exec(
+		`INSERT INTO migration_snapshots (snapshot_path, pre_version, target_version, created_at, boots_since) VALUES (?, ?, ?, ?, 0)`,
+		snapPath, preVersion, targetVersion, now,
+	)
+	if err != nil {
+		return fmt.Errorf("insert snapshot row: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit snapshot record: %w", err)
+	}
+	committed = true
+
+	// DB commit succeeded — now best-effort delete the old files. A failure
+	// here is a leaked file on disk; not fatal, and `continuity snapshot
+	// prune` can clean it up later.
+	for _, p := range oldPaths {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "warning: could not delete superseded snapshot %s: %v\n", p, err)
+		}
+	}
+	return nil
+}
+
+// TickSnapshotRetention is called once per successful `continuity serve`
+// startup (from runServe, after Open). It increments boots_since on every
+// retained snapshot row, then deletes any whose counter has reached the
+// retention threshold.
+//
+// Deliberately NOT called from Open() itself: CLI subcommands that open the
+// DB to inspect or prune snapshots should NOT advance the retention counter.
+// Only the long-running serve process represents a real "the new schema
+// works" boot.
+func (db *DB) TickSnapshotRetention() error {
+	if _, err := db.Exec(`UPDATE migration_snapshots SET boots_since = boots_since + 1`); err != nil {
+		return fmt.Errorf("increment boots_since: %w", err)
+	}
+
+	rows, err := db.Query(`SELECT snapshot_path FROM migration_snapshots WHERE boots_since >= ?`, SnapshotRetentionBoots)
+	if err != nil {
+		return fmt.Errorf("scan expired snapshots: %w", err)
+	}
+	var expired []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan expired path: %w", err)
+		}
+		expired = append(expired, p)
+	}
+	rows.Close()
+
+	for _, p := range expired {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "warning: could not delete expired snapshot %s: %v\n", p, err)
+		}
+		if _, err := db.Exec(`DELETE FROM migration_snapshots WHERE snapshot_path = ?`, p); err != nil {
+			return fmt.Errorf("remove expired row: %w", err)
+		}
+	}
+	return nil
+}
+
+// ListMigrationSnapshots returns all retained snapshot rows. Empty slice
+// (not nil) when no snapshots are retained. Used by both the boot-time
+// surfacing log and the `continuity snapshot list` command.
+func (db *DB) ListMigrationSnapshots() ([]MigrationSnapshot, error) {
+	rows, err := db.Query(`
+		SELECT snapshot_path, pre_version, target_version, created_at, boots_since
+		FROM migration_snapshots
+		ORDER BY created_at DESC
+	`)
+	if err != nil {
+		// migration_snapshots may not exist yet on a fresh install that
+		// hasn't been through migrate() — treat that as empty.
+		return []MigrationSnapshot{}, nil
+	}
+	defer rows.Close()
+
+	var out []MigrationSnapshot
+	for rows.Next() {
+		var (
+			s         MigrationSnapshot
+			createdMs int64
+		)
+		if err := rows.Scan(&s.Path, &s.PreVersion, &s.TargetVersion, &createdMs, &s.BootsSince); err != nil {
+			return nil, fmt.Errorf("scan snapshot: %w", err)
+		}
+		s.CreatedAt = time.UnixMilli(createdMs)
+		out = append(out, s)
+	}
+	if out == nil {
+		out = []MigrationSnapshot{}
+	}
+	return out, nil
+}
+
+// PruneMigrationSnapshots removes all retained snapshot files and clears
+// the tracking table. Returns the number of snapshots removed.
+//
+// This is what `continuity snapshot prune` calls. It is destructive — the
+// safety net is gone after this — so the CLI surface should make that clear
+// to the operator.
+func (db *DB) PruneMigrationSnapshots() (int, error) {
+	snaps, err := db.ListMigrationSnapshots()
+	if err != nil {
+		return 0, err
+	}
+	for _, s := range snaps {
+		if err := os.Remove(s.Path); err != nil && !os.IsNotExist(err) {
+			return 0, fmt.Errorf("remove snapshot %s: %w", s.Path, err)
+		}
+	}
+	if _, err := db.Exec(`DELETE FROM migration_snapshots`); err != nil {
+		return 0, fmt.Errorf("clear migration_snapshots: %w", err)
+	}
+	return len(snaps), nil
+}

--- a/internal/store/snapshot.go
+++ b/internal/store/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -284,17 +285,64 @@ func (db *DB) ListMigrationSnapshots() ([]MigrationSnapshot, error) {
 // safety net is gone after this — so the CLI surface should make that clear
 // to the operator.
 func (db *DB) PruneMigrationSnapshots() (int, error) {
+	removed := make(map[string]bool)
+
+	// 1. Tracked snapshots: delete the file for every row we know about.
 	snaps, err := db.ListMigrationSnapshots()
 	if err != nil {
 		return 0, err
 	}
 	for _, s := range snaps {
 		if err := os.Remove(s.Path); err != nil && !os.IsNotExist(err) {
-			return 0, fmt.Errorf("remove snapshot %s: %w", s.Path, err)
+			return len(removed), fmt.Errorf("remove snapshot %s: %w", s.Path, err)
+		}
+		removed[s.Path] = true
+	}
+
+	// 2. Untracked snapshot files: scan the snapshots/ directory for full DB
+	//    copies that have no tracking row. These get stranded when recording a
+	//    snapshot fails after its migration commits, or when a superseded-file
+	//    delete fails — paths that leave the file on disk with no row. Pruning
+	//    only tracked rows would leave these large copies to leak forever,
+	//    contradicting this command's promise to reclaim the safety net fully.
+	if db.Path != "" && db.Path != ":memory:" {
+		snapDir := filepath.Join(filepath.Dir(db.Path), "snapshots")
+		entries, dirErr := os.ReadDir(snapDir)
+		if dirErr != nil && !os.IsNotExist(dirErr) {
+			return len(removed), fmt.Errorf("scan snapshot dir %s: %w", snapDir, dirErr)
+		}
+		for _, e := range entries {
+			// Only touch our own snapshot files; never anything else that
+			// happens to share the directory.
+			name := e.Name()
+			if e.IsDir() || !strings.HasPrefix(name, "continuity-pre-v") || !strings.HasSuffix(name, ".db") {
+				continue
+			}
+			p := filepath.Join(snapDir, name)
+			if removed[p] {
+				continue
+			}
+			if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+				return len(removed), fmt.Errorf("remove untracked snapshot %s: %w", p, err)
+			}
+			removed[p] = true
 		}
 	}
-	if _, err := db.Exec(`DELETE FROM migration_snapshots`); err != nil {
-		return 0, fmt.Errorf("clear migration_snapshots: %w", err)
+
+	// 3. Clear tracking rows. Tolerate a missing table: a never-migrated DB
+	//    opened via OpenNoMigrate has no migration_snapshots table, and there
+	//    is nothing to clear in that case.
+	var hasTable int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='migration_snapshots'`,
+	).Scan(&hasTable); err != nil {
+		return len(removed), fmt.Errorf("check migration_snapshots table: %w", err)
 	}
-	return len(snaps), nil
+	if hasTable > 0 {
+		if _, err := db.Exec(`DELETE FROM migration_snapshots`); err != nil {
+			return len(removed), fmt.Errorf("clear migration_snapshots: %w", err)
+		}
+	}
+
+	return len(removed), nil
 }

--- a/internal/store/snapshot.go
+++ b/internal/store/snapshot.go
@@ -228,7 +228,13 @@ func (db *DB) TickSnapshotRetention() error {
 
 	for _, p := range expired {
 		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "warning: could not delete expired snapshot %s: %v\n", p, err)
+			// Removal genuinely failed (permission denied, a snapshot DB held
+			// open on Windows, etc.). Keep the tracking row so the file stays
+			// visible to `snapshot list/prune` and a future retention tick can
+			// retry the delete. Dropping the row here would strand the file on
+			// disk, untracked and unreclaimable.
+			fmt.Fprintf(os.Stderr, "warning: could not delete expired snapshot %s: %v (will retry next boot)\n", p, err)
+			continue
 		}
 		if _, err := db.Exec(`DELETE FROM migration_snapshots WHERE snapshot_path = ?`, p); err != nil {
 			return fmt.Errorf("remove expired row: %w", err)

--- a/internal/store/snapshot.go
+++ b/internal/store/snapshot.go
@@ -92,9 +92,36 @@ func (db *DB) snapshotBeforeRiskyMigration(m migration) (string, error) {
 	snapName := fmt.Sprintf("continuity-pre-v%d-%s.db", m.Version, timestamp)
 	snapPath := filepath.Join(snapDir, snapName)
 
-	// VACUUM INTO is the SQLite-blessed atomic copy. It produces a complete,
-	// self-contained DB file in one statement, page-by-page from a consistent
-	// snapshot, while the source DB stays open and readable.
+	// VACUUM INTO is the SQLite-blessed atomic copy. DO NOT replace this with
+	// a file-level copy (os.Rename / io.Copy / `cp` / `tar` / etc.). Reasons:
+	//
+	//   1. WAL mode is on by default (see configurePragmas), which means the
+	//      main .db file is INCOMPLETE on its own. Recent commits live in
+	//      <path>-wal until a checkpoint moves them into the main file. A
+	//      naïve file copy of <path> alone would silently drop everything in
+	//      the WAL — the snapshot would look intact but be missing the most
+	//      recent writes (which is exactly the data the user most cares
+	//      about preserving across a risky migration).
+	//
+	//   2. Copying all three files (.db, .db-wal, .db-shm) together does NOT
+	//      fix the problem: another connection can be writing at any byte
+	//      offset, and a copy that interleaves with writes yields a torn
+	//      image. Acquiring an OS file lock doesn't help — SQLite uses
+	//      cooperative locking through its own engine, not OS-level file
+	//      locks.
+	//
+	//   3. VACUUM INTO routes through the SQLite engine. It acquires the
+	//      correct shared read lock on the source, walks page-by-page from a
+	//      consistent transaction view that INCLUDES the WAL, and emits a
+	//      single self-contained destination file with no separate WAL or
+	//      SHM. Source writers are not blocked (concurrent reads + writes
+	//      continue normally during VACUUM INTO). This is the contract;
+	//      rely on it.
+	//
+	// TestSnapshot_CapturesWALActiveData pins this behavior against
+	// regression — it writes a row that lives only in the WAL, takes a
+	// snapshot, and asserts the row landed in the snapshot. A naïve file
+	// copy would fail that test.
 	if _, err := db.Exec("VACUUM INTO ?", snapPath); err != nil {
 		return "", fmt.Errorf("vacuum into %s: %w", snapPath, err)
 	}

--- a/internal/store/snapshot.go
+++ b/internal/store/snapshot.go
@@ -35,6 +35,18 @@ type MigrationSnapshot struct {
 	BootsSince    int
 }
 
+// snapshotDirForDB returns the per-database directory that holds this DB's
+// migration snapshots: <dbdir>/snapshots/<db-filename>/. Namespacing by the
+// database's own filename is what keeps two databases that happen to share a
+// parent directory (two CONTINUITY_DB targets, or the default DB beside a
+// scratch copy) from ever seeing — let alone deleting — each other's
+// snapshots. Filenames are unique within a directory, so the basename is a
+// stable, collision-free per-DB key: pruning one DB can only ever reach into
+// its own subdirectory.
+func snapshotDirForDB(dbPath string) string {
+	return filepath.Join(filepath.Dir(dbPath), "snapshots", filepath.Base(dbPath))
+}
+
 // ensureSnapshotStateTable creates the sidecar tracking table. Called from
 // migrate() before the migration loop so the table is available whether or
 // not any prior migration has touched it. Deliberately NOT part of the
@@ -81,8 +93,7 @@ func (db *DB) snapshotBeforeRiskyMigration(m migration) (string, error) {
 		return "", nil
 	}
 
-	dbDir := filepath.Dir(db.Path)
-	snapDir := filepath.Join(dbDir, "snapshots")
+	snapDir := snapshotDirForDB(db.Path)
 	if err := os.MkdirAll(snapDir, 0o700); err != nil {
 		return "", fmt.Errorf("create snapshot dir %s: %w", snapDir, err)
 	}
@@ -248,15 +259,29 @@ func (db *DB) TickSnapshotRetention() error {
 // (not nil) when no snapshots are retained. Used by both the boot-time
 // surfacing log and the `continuity snapshot list` command.
 func (db *DB) ListMigrationSnapshots() ([]MigrationSnapshot, error) {
+	// The ONLY tolerable reason this read comes up empty is the sidecar table
+	// not existing yet (a fresh/never-migrated DB, e.g. opened via
+	// OpenNoMigrate). Tell that apart from a genuine query failure — a
+	// catch-all that swallowed real errors would report a corrupt or
+	// incompatible migration_snapshots table as "no snapshots", and prune
+	// would then treat still-tracked files as untracked.
+	var hasTable int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='migration_snapshots'`,
+	).Scan(&hasTable); err != nil {
+		return nil, fmt.Errorf("check migration_snapshots table: %w", err)
+	}
+	if hasTable == 0 {
+		return []MigrationSnapshot{}, nil
+	}
+
 	rows, err := db.Query(`
 		SELECT snapshot_path, pre_version, target_version, created_at, boots_since
 		FROM migration_snapshots
 		ORDER BY created_at DESC
 	`)
 	if err != nil {
-		// migration_snapshots may not exist yet on a fresh install that
-		// hasn't been through migrate() — treat that as empty.
-		return []MigrationSnapshot{}, nil
+		return nil, fmt.Errorf("query migration_snapshots: %w", err)
 	}
 	defer rows.Close()
 
@@ -299,14 +324,16 @@ func (db *DB) PruneMigrationSnapshots() (int, error) {
 		removed[s.Path] = true
 	}
 
-	// 2. Untracked snapshot files: scan the snapshots/ directory for full DB
-	//    copies that have no tracking row. These get stranded when recording a
-	//    snapshot fails after its migration commits, or when a superseded-file
-	//    delete fails — paths that leave the file on disk with no row. Pruning
-	//    only tracked rows would leave these large copies to leak forever,
-	//    contradicting this command's promise to reclaim the safety net fully.
+	// 2. Untracked snapshot files: scan THIS DB's own snapshot directory for
+	//    full DB copies that have no tracking row. These get stranded when
+	//    recording a snapshot fails after its migration commits, or when a
+	//    superseded-file delete fails — paths that leave the file on disk with
+	//    no row. Pruning only tracked rows would leak these copies forever.
+	//    The scan is confined to snapshotDirForDB(db.Path), so it can never
+	//    reach a sibling database's snapshots even when both share a parent
+	//    directory.
 	if db.Path != "" && db.Path != ":memory:" {
-		snapDir := filepath.Join(filepath.Dir(db.Path), "snapshots")
+		snapDir := snapshotDirForDB(db.Path)
 		entries, dirErr := os.ReadDir(snapDir)
 		if dirErr != nil && !os.IsNotExist(dirErr) {
 			return len(removed), fmt.Errorf("scan snapshot dir %s: %w", snapDir, dirErr)

--- a/internal/store/snapshot_test.go
+++ b/internal/store/snapshot_test.go
@@ -563,6 +563,61 @@ func TestSnapshot_RetentionLeavesSnapshotBeforeThreshold(t *testing.T) {
 	}
 }
 
+// TestSnapshot_RetentionKeepsRowWhenRemoveFails pins the failure-path contract:
+// when os.Remove can't delete an expired snapshot file (permission denied, a DB
+// held open on Windows, etc.), TickSnapshotRetention must KEEP the tracking row
+// so the file stays visible to `snapshot list/prune` and a later tick can retry.
+// Dropping the row on a failed remove would strand the file on disk, untracked
+// and unreclaimable — a silent leak of exactly the data we promised to manage.
+func TestSnapshot_RetentionKeepsRowWhenRemoveFails(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildSnapshotDBAtVersion(t, dbPath, 8) // v9 is risky → one snapshot recorded
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	snaps, _ := db.ListMigrationSnapshots()
+	if len(snaps) != 1 {
+		t.Fatalf("setup: expected 1 snapshot row, got %d", len(snaps))
+	}
+	snapPath := snaps[0].Path
+
+	// Make the snapshot path undeletable in a portable way: replace the file
+	// with a NON-EMPTY directory. os.Remove on a non-empty dir fails with a
+	// non-IsNotExist error (ENOTEMPTY) on every OS — no permission games.
+	if err := os.Remove(snapPath); err != nil {
+		t.Fatalf("setup: remove real snapshot file: %v", err)
+	}
+	if err := os.MkdirAll(snapPath, 0o700); err != nil {
+		t.Fatalf("setup: mkdir at snapshot path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(snapPath, "blocker"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("setup: write blocker file: %v", err)
+	}
+
+	// Tick past the threshold. Each tick will try (and fail) to remove the
+	// "file"; the row must survive every time.
+	for i := 0; i < SnapshotRetentionBoots+1; i++ {
+		if err := db.TickSnapshotRetention(); err != nil {
+			t.Fatalf("tick %d returned error; a failed os.Remove must not fail the tick: %v", i+1, err)
+		}
+	}
+
+	after, _ := db.ListMigrationSnapshots()
+	if len(after) != 1 {
+		t.Fatalf("row must survive while its file can't be deleted; got %d rows", len(after))
+	}
+	if after[0].Path != snapPath {
+		t.Errorf("surviving row path = %q, want %q", after[0].Path, snapPath)
+	}
+}
+
 // =========================================================================
 // Permissions
 // =========================================================================

--- a/internal/store/snapshot_test.go
+++ b/internal/store/snapshot_test.go
@@ -262,6 +262,114 @@ func TestSnapshot_FailureBlocksMigration(t *testing.T) {
 }
 
 // =========================================================================
+// VACUUM INTO contract — protects against a future maintainer replacing
+// the snapshot with a naïve file copy
+// =========================================================================
+
+// TestSnapshot_CapturesWALActiveData pins the WAL/source-locking contract
+// that the snapshot code depends on. In WAL mode (Continuity's default —
+// see configurePragmas), committed data may live in the <path>-wal sidecar
+// until a checkpoint moves it into the main .db file. A file-level copy
+// (os.Rename, io.Copy, `cp`, `tar`) of <path> alone would silently miss
+// that data — the snapshot would look intact but be missing the most
+// recent writes.
+//
+// VACUUM INTO routes through the SQLite engine and walks a consistent
+// transaction view that includes the WAL. This test demonstrates the
+// difference would matter: a WAL-resident row written via a held-open
+// connection MUST appear in the snapshot. If a future maintainer
+// replaces VACUUM INTO with a file copy, this test fails — and the
+// comment on snapshotBeforeRiskyMigration explains why before the
+// reviewer even reads the test.
+func TestSnapshot_CapturesWALActiveData(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildDBAtVersion(t, dbPath, 8) // pre-v9 so v9 (risky) triggers the snapshot
+
+	// Open a keeper connection in WAL mode and write a row. Keep the
+	// connection OPEN so its close-time checkpoint does not quietly
+	// migrate the row into the main DB file before the snapshot runs.
+	// The row must still be WAL-resident when the snapshot is taken.
+	keeper, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("keeper open: %v", err)
+	}
+	defer keeper.Close()
+
+	for _, pragma := range []string{
+		`PRAGMA journal_mode=WAL`,
+		`PRAGMA synchronous=NORMAL`,
+	} {
+		if _, err := keeper.Exec(pragma); err != nil {
+			t.Fatalf("%s: %v", pragma, err)
+		}
+	}
+
+	const walResidentURI = "mem://user/events/wal-resident-row"
+	const walResidentBody = "lives in WAL until checkpoint"
+	if _, err := keeper.Exec(`
+		INSERT INTO mem_nodes (uri, node_type, category, l0_abstract, created_at, updated_at)
+		VALUES (?, 'leaf', 'events', ?, 1000, 1000)
+	`, walResidentURI, walResidentBody); err != nil {
+		t.Fatalf("insert WAL-resident row: %v", err)
+	}
+
+	// Sanity precondition: the WAL sidecar should exist now. If it doesn't,
+	// the runtime SQLite checkpointed eagerly and the WAL path isn't
+	// being exercised — skip rather than pass for the wrong reason.
+	if info, err := os.Stat(dbPath + "-wal"); err != nil || info.Size() == 0 {
+		t.Skipf("WAL sidecar not populated (err=%v); environment did not exercise the WAL path", err)
+	}
+
+	// Trigger the production snapshot via store.Open → migrate() → v9 →
+	// VACUUM INTO. The keeper connection stays open during this, which
+	// is the realistic scenario (a user's hooks may be holding connections
+	// when serve restarts and migrates).
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open during keeper hold: %v", err)
+	}
+	defer db.Close()
+
+	snaps, err := db.ListMigrationSnapshots()
+	if err != nil {
+		t.Fatalf("ListMigrationSnapshots: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 snapshot from v9 migration, got %d", len(snaps))
+	}
+
+	// The load-bearing assertion: a row that was WAL-resident at snapshot
+	// time MUST land in the snapshot file. A naïve file copy of the .db
+	// would have produced a snapshot missing this row.
+	snap, err := sql.Open("sqlite", snaps[0].Path)
+	if err != nil {
+		t.Fatalf("open snapshot file: %v", err)
+	}
+	defer snap.Close()
+
+	var gotBody string
+	err = snap.QueryRow(
+		`SELECT l0_abstract FROM mem_nodes WHERE uri = ?`,
+		walResidentURI,
+	).Scan(&gotBody)
+	if err == sql.ErrNoRows {
+		t.Fatal("WAL-resident row missing from snapshot — VACUUM INTO did not " +
+			"capture WAL state. This is the failure mode a future replacement of " +
+			"VACUUM INTO with a file copy would produce. See the comment block on " +
+			"snapshotBeforeRiskyMigration for why VACUUM INTO is load-bearing here.")
+	}
+	if err != nil {
+		t.Fatalf("read WAL row from snapshot: %v", err)
+	}
+	if gotBody != walResidentBody {
+		t.Errorf("WAL row content mangled in snapshot: got %q, want %q", gotBody, walResidentBody)
+	}
+}
+
+// =========================================================================
 // Content fidelity
 // =========================================================================
 

--- a/internal/store/snapshot_test.go
+++ b/internal/store/snapshot_test.go
@@ -931,3 +931,71 @@ func TestSnapshot_ListSurfacesRealQueryErrors(t *testing.T) {
 		t.Error("PruneMigrationSnapshots must refuse to run when the snapshot table is unreadable")
 	}
 }
+
+// TestSnapshot_DeletesNeverEscapeNamespace pins the deletion-side cross-DB
+// guard. Tracking rows store absolute paths, so a database COPIED or RENAMED
+// from another (the repo's own smoke test does `cp continuity.db scratch.db`)
+// inherits rows pointing at the ORIGINAL's snapshot files. Neither prune nor
+// the retention tick may unlink a file outside this DB's own namespace, no
+// matter what a stale row claims.
+func TestSnapshot_DeletesNeverEscapeNamespace(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	origPath := filepath.Join(dir, "continuity.db")
+	buildSnapshotDBAtVersion(t, origPath, 8)
+	orig, err := Open(origPath) // v9 risky → snapshot under snapshots/continuity.db/
+	if err != nil {
+		t.Fatal(err)
+	}
+	origSnaps, _ := orig.ListMigrationSnapshots()
+	if len(origSnaps) != 1 {
+		t.Fatalf("setup: orig should have 1 snapshot, got %d", len(origSnaps))
+	}
+	origSnapPath := origSnaps[0].Path
+
+	// Two consistent copies (VACUUM INTO), each inheriting orig's tracking row.
+	pruneCopy := filepath.Join(dir, "prune-scratch.db")
+	tickCopy := filepath.Join(dir, "tick-scratch.db")
+	if _, err := orig.Exec("VACUUM INTO ?", pruneCopy); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := orig.Exec("VACUUM INTO ?", tickCopy); err != nil {
+		t.Fatal(err)
+	}
+	orig.Close()
+
+	// Prune the copy: clears its stale row but must NOT unlink orig's file.
+	pc, err := OpenNoMigrate(pruneCopy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ss, _ := pc.ListMigrationSnapshots(); len(ss) != 1 || ss[0].Path != origSnapPath {
+		t.Fatalf("setup: prune copy should carry orig's stale row pointing at %s", origSnapPath)
+	}
+	if _, err := pc.PruneMigrationSnapshots(); err != nil {
+		t.Fatal(err)
+	}
+	if after, _ := pc.ListMigrationSnapshots(); len(after) != 0 {
+		t.Errorf("copy's stale row should be cleared; got %d", len(after))
+	}
+	pc.Close()
+	if _, err := os.Stat(origSnapPath); err != nil {
+		t.Errorf("prune on a copied DB deleted the ORIGINAL's snapshot: %v", err)
+	}
+
+	// Retention tick on the other copy: drive past threshold; same guarantee.
+	tc, err := OpenNoMigrate(tickCopy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < SnapshotRetentionBoots+1; i++ {
+		if err := tc.TickSnapshotRetention(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tc.Close()
+	if _, err := os.Stat(origSnapPath); err != nil {
+		t.Errorf("retention tick on a copied DB deleted the ORIGINAL's snapshot: %v", err)
+	}
+}

--- a/internal/store/snapshot_test.go
+++ b/internal/store/snapshot_test.go
@@ -54,9 +54,9 @@ func applyMigrationsUpTo(t *testing.T, sqlDB *sql.DB, target int) {
 	}
 }
 
-// buildDBAtVersion creates a DB file at path with schema at the given
+// buildSnapshotDBAtVersion creates a DB file at path with schema at the given
 // version. Returns nothing because the path is the input.
-func buildDBAtVersion(t *testing.T, path string, target int) {
+func buildSnapshotDBAtVersion(t *testing.T, path string, target int) {
 	t.Helper()
 	sqlDB, err := sql.Open("sqlite", path)
 	if err != nil {
@@ -79,7 +79,7 @@ func TestSnapshot_CreatedBeforeRiskyMigration(t *testing.T) {
 
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
-	buildDBAtVersion(t, dbPath, 5) // pre-v6, so v6 (risky) will run
+	buildSnapshotDBAtVersion(t, dbPath, 5) // pre-v6, so v6 (risky) will run
 
 	db, err := Open(dbPath)
 	if err != nil {
@@ -118,7 +118,7 @@ func TestSnapshot_OptOutEnvVarSkips(t *testing.T) {
 
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
-	buildDBAtVersion(t, dbPath, 5)
+	buildSnapshotDBAtVersion(t, dbPath, 5)
 
 	db, err := Open(dbPath)
 	if err != nil {
@@ -152,7 +152,7 @@ func TestSnapshot_NotCreatedForAdditiveMigration(t *testing.T) {
 
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
-	buildDBAtVersion(t, dbPath, 9) // current head
+	buildSnapshotDBAtVersion(t, dbPath, 9) // current head
 
 	db, err := Open(dbPath)
 	if err != nil {
@@ -223,7 +223,7 @@ func TestSnapshot_FailureBlocksMigration(t *testing.T) {
 
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
-	buildDBAtVersion(t, dbPath, 5)
+	buildSnapshotDBAtVersion(t, dbPath, 5)
 
 	// Plant a regular FILE where the snapshots/ directory would land,
 	// so MkdirAll fails with "not a directory".
@@ -286,7 +286,7 @@ func TestSnapshot_CapturesWALActiveData(t *testing.T) {
 
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
-	buildDBAtVersion(t, dbPath, 8) // pre-v9 so v9 (risky) triggers the snapshot
+	buildSnapshotDBAtVersion(t, dbPath, 8) // pre-v9 so v9 (risky) triggers the snapshot
 
 	// Open a keeper connection in WAL mode and write a row. Keep the
 	// connection OPEN so its close-time checkpoint does not quietly
@@ -383,7 +383,7 @@ func TestSnapshot_ContentMatchesPreMigrationState(t *testing.T) {
 
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
-	buildDBAtVersion(t, dbPath, 5)
+	buildSnapshotDBAtVersion(t, dbPath, 5)
 
 	// Seed a v5-era row directly.
 	raw, err := sql.Open("sqlite", dbPath)
@@ -461,7 +461,7 @@ func TestSnapshot_OnlyMostRecentRetained(t *testing.T) {
 
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
-	buildDBAtVersion(t, dbPath, 5)
+	buildSnapshotDBAtVersion(t, dbPath, 5)
 
 	db, err := Open(dbPath)
 	if err != nil {
@@ -495,7 +495,7 @@ func TestSnapshot_RetentionDeletesAfterNBoots(t *testing.T) {
 
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
-	buildDBAtVersion(t, dbPath, 8) // v9 is risky, so this triggers exactly one snapshot
+	buildSnapshotDBAtVersion(t, dbPath, 8) // v9 is risky, so this triggers exactly one snapshot
 
 	db, err := Open(dbPath)
 	if err != nil {
@@ -539,7 +539,7 @@ func TestSnapshot_RetentionLeavesSnapshotBeforeThreshold(t *testing.T) {
 
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
-	buildDBAtVersion(t, dbPath, 8)
+	buildSnapshotDBAtVersion(t, dbPath, 8)
 
 	db, err := Open(dbPath)
 	if err != nil {
@@ -575,7 +575,7 @@ func TestSnapshot_FilePermissions(t *testing.T) {
 
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
-	buildDBAtVersion(t, dbPath, 8)
+	buildSnapshotDBAtVersion(t, dbPath, 8)
 
 	db, err := Open(dbPath)
 	if err != nil {
@@ -617,7 +617,7 @@ func TestSnapshot_ListReturnsRecordedFields(t *testing.T) {
 
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
-	buildDBAtVersion(t, dbPath, 8)
+	buildSnapshotDBAtVersion(t, dbPath, 8)
 
 	db, err := Open(dbPath)
 	if err != nil {
@@ -657,7 +657,7 @@ func TestSnapshot_PruneRemovesEverything(t *testing.T) {
 
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
-	buildDBAtVersion(t, dbPath, 8)
+	buildSnapshotDBAtVersion(t, dbPath, 8)
 
 	db, err := Open(dbPath)
 	if err != nil {

--- a/internal/store/snapshot_test.go
+++ b/internal/store/snapshot_test.go
@@ -1,0 +1,600 @@
+package store
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// =========================================================================
+// Test helpers
+// =========================================================================
+
+// applyMigrationsUpTo executes migrations[1..target] directly against the
+// connection, bypassing DB.migrate() entirely. Used to construct DB files
+// at historical schema versions so we can exercise the upgrade path that
+// store.Open() takes when those files are reopened by the current binary.
+func applyMigrationsUpTo(t *testing.T, sqlDB *sql.DB, target int) {
+	t.Helper()
+	if _, err := sqlDB.Exec(`
+		CREATE TABLE IF NOT EXISTS schema_versions (
+			version     INTEGER PRIMARY KEY,
+			description TEXT NOT NULL,
+			applied_at  INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+		)
+	`); err != nil {
+		t.Fatalf("schema_versions: %v", err)
+	}
+	for _, m := range migrations {
+		if m.Version > target {
+			break
+		}
+		tx, err := sqlDB.Begin()
+		if err != nil {
+			t.Fatalf("begin v%d: %v", m.Version, err)
+		}
+		if _, err := tx.Exec(m.SQL); err != nil {
+			tx.Rollback()
+			t.Fatalf("apply v%d: %v", m.Version, err)
+		}
+		if _, err := tx.Exec(
+			"INSERT INTO schema_versions (version, description) VALUES (?, ?)",
+			m.Version, m.Description,
+		); err != nil {
+			tx.Rollback()
+			t.Fatalf("record v%d: %v", m.Version, err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit v%d: %v", m.Version, err)
+		}
+	}
+}
+
+// buildDBAtVersion creates a DB file at path with schema at the given
+// version. Returns nothing because the path is the input.
+func buildDBAtVersion(t *testing.T, path string, target int) {
+	t.Helper()
+	sqlDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer sqlDB.Close()
+	applyMigrationsUpTo(t, sqlDB, target)
+}
+
+// =========================================================================
+// Creation behavior
+// =========================================================================
+
+// TestSnapshot_CreatedBeforeRiskyMigration pins the central invariant:
+// when a risky migration runs against an on-disk DB, a snapshot file
+// lands in the sibling snapshots/ directory before the migration touches
+// the DB.
+func TestSnapshot_CreatedBeforeRiskyMigration(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildDBAtVersion(t, dbPath, 5) // pre-v6, so v6 (risky) will run
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	snapDir := filepath.Join(dir, "snapshots")
+	entries, err := os.ReadDir(snapDir)
+	if err != nil {
+		t.Fatalf("snapshots dir not created: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("no snapshot file in snapshots/ after v5→v9 upgrade")
+	}
+	// After v5→v9 only ONE snapshot must remain (the pre-v9 one); recording
+	// pruned the pre-v6 file when v9's snapshot landed.
+	if len(entries) != 1 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected exactly 1 retained snapshot file, got %d: %v", len(entries), names)
+	}
+	if !strings.HasPrefix(entries[0].Name(), "continuity-pre-v9-") {
+		t.Errorf("retained snapshot should be pre-v9; got %q", entries[0].Name())
+	}
+}
+
+// TestSnapshot_OptOutEnvVarSkips pins the explicit opt-out: with
+// CONTINUITY_NO_MIGRATION_SNAPSHOT set, even a risky migration runs
+// without snapshotting. The operator who sets this is accepting the
+// recoverability tradeoff knowingly.
+func TestSnapshot_OptOutEnvVarSkips(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "1")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildDBAtVersion(t, dbPath, 5)
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open with opt-out: %v", err)
+	}
+	defer db.Close()
+
+	snapDir := filepath.Join(dir, "snapshots")
+	if _, err := os.Stat(snapDir); err == nil {
+		entries, _ := os.ReadDir(snapDir)
+		if len(entries) > 0 {
+			t.Errorf("opt-out set, but %d snapshot file(s) created", len(entries))
+		}
+	}
+
+	snaps, err := db.ListMigrationSnapshots()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snaps) != 0 {
+		t.Errorf("opt-out set, but %d snapshot row(s) recorded", len(snaps))
+	}
+}
+
+// TestSnapshot_NotCreatedForAdditiveMigration unit-tests the gate directly
+// against migrations marked Risky=false. Risky=false → no snapshot, no
+// error. This is the load-bearing test for the "additive migrations skip
+// snapshots" half of the policy.
+func TestSnapshot_NotCreatedForAdditiveMigration(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildDBAtVersion(t, dbPath, 9) // current head
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Walk every migration and confirm snapshotBeforeRiskyMigration ONLY
+	// returns a path for the ones we explicitly mark Risky.
+	for _, m := range migrations {
+		path, err := db.snapshotBeforeRiskyMigration(m)
+		if err != nil {
+			t.Fatalf("v%d: %v", m.Version, err)
+		}
+		switch {
+		case m.Risky && path == "":
+			t.Errorf("v%d is Risky but snapshot returned empty path", m.Version)
+		case !m.Risky && path != "":
+			t.Errorf("v%d is additive but snapshot returned path %q", m.Version, path)
+		}
+		// Clean up any file the test wrote so we don't leak across iterations.
+		if path != "" {
+			_ = os.Remove(path)
+		}
+	}
+}
+
+// TestSnapshot_MemoryDBSkipsSnapshot pins that :memory: DBs don't try to
+// snapshot themselves. In-memory tests (which is most of the suite) would
+// otherwise crash trying to VACUUM INTO an unwriteable path.
+func TestSnapshot_MemoryDBSkipsSnapshot(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	db, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// All migrations have already run via OpenMemory. Probe the gate
+	// directly with a risky migration descriptor and assert no path
+	// returned, no error.
+	for _, m := range migrations {
+		if !m.Risky {
+			continue
+		}
+		path, err := db.snapshotBeforeRiskyMigration(m)
+		if err != nil {
+			t.Errorf("memory DB: v%d snapshot returned error %v", m.Version, err)
+		}
+		if path != "" {
+			t.Errorf("memory DB: v%d returned snapshot path %q", m.Version, path)
+		}
+	}
+}
+
+// =========================================================================
+// Failure behavior
+// =========================================================================
+
+// TestSnapshot_FailureBlocksMigration pins the contract: if the snapshot
+// CANNOT be created (e.g., the snapshots/ directory cannot be made),
+// migrate() refuses to proceed. This is the load-bearing safety net
+// invariant — a "snapshots are optional" implementation would silently
+// run the risky migration without protection.
+func TestSnapshot_FailureBlocksMigration(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildDBAtVersion(t, dbPath, 5)
+
+	// Plant a regular FILE where the snapshots/ directory would land,
+	// so MkdirAll fails with "not a directory".
+	blockPath := filepath.Join(dir, "snapshots")
+	if err := os.WriteFile(blockPath, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("plant block file: %v", err)
+	}
+
+	_, err := Open(dbPath)
+	if err == nil {
+		t.Fatal("Open succeeded; migration must abort when snapshot fails")
+	}
+	// Message must surface the env-var escape hatch so the operator knows
+	// they have a path forward.
+	if !strings.Contains(err.Error(), EnvNoMigrationSnapshot) {
+		t.Errorf("error must name the opt-out env var; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "snapshot") {
+		t.Errorf("error must mention snapshot in some form; got: %v", err)
+	}
+
+	// Schema must still be at the pre-failure version (v5) — the
+	// migration was aborted before any change.
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	var pre int
+	if err := raw.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM schema_versions`).Scan(&pre); err != nil {
+		t.Fatal(err)
+	}
+	if pre != 5 {
+		t.Errorf("schema must be at v5 after aborted migration; got v%d", pre)
+	}
+}
+
+// =========================================================================
+// Content fidelity
+// =========================================================================
+
+// TestSnapshot_ContentMatchesPreMigrationState seeds a row at v5, runs the
+// upgrade, and opens the snapshot file directly — the snapshot must be a
+// valid SQLite DB AT THE PRE-MIGRATION SCHEMA, with the seeded row intact.
+// This is what makes restoration meaningful: the operator can cp the
+// snapshot over the live DB and get back to a working state.
+func TestSnapshot_ContentMatchesPreMigrationState(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildDBAtVersion(t, dbPath, 5)
+
+	// Seed a v5-era row directly.
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = raw.Exec(`
+		INSERT INTO mem_nodes (uri, node_type, category, l0_abstract, created_at, updated_at)
+		VALUES ('mem://user/events/pre-migration', 'leaf', 'events', 'lands in the snapshot', 1000, 1000)
+	`)
+	raw.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Now run the upgrade.
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	snaps, err := db.ListMigrationSnapshots()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 retained snapshot, got %d", len(snaps))
+	}
+
+	// Open the snapshot file as a regular SQLite DB and read back the
+	// row. If the snapshot is corrupted, this open or query fails.
+	snap, err := sql.Open("sqlite", snaps[0].Path)
+	if err != nil {
+		t.Fatalf("snapshot is not a readable SQLite DB: %v", err)
+	}
+	defer snap.Close()
+
+	var abstract string
+	if err := snap.QueryRow(`SELECT l0_abstract FROM mem_nodes WHERE uri = ?`,
+		"mem://user/events/pre-migration").Scan(&abstract); err != nil {
+		t.Fatalf("seeded row missing from snapshot: %v", err)
+	}
+	if abstract != "lands in the snapshot" {
+		t.Errorf("seeded row mangled: got %q", abstract)
+	}
+
+	// Snapshot's schema must be the PRE-v9 schema. Specifically: the
+	// feedback category was added in v9, so an attempt to insert a
+	// feedback row into the snapshot would fail under the v8-era CHECK
+	// constraint.
+	_, err = snap.Exec(`
+		INSERT INTO mem_nodes (uri, node_type, category, created_at, updated_at)
+		VALUES ('mem://user/feedback/post-snapshot', 'leaf', 'feedback', 1000, 1000)
+	`)
+	// We seeded at v5; the snapshot was taken right before v6, so feedback
+	// (added v9) would fail. If it succeeded, the snapshot got post-v9
+	// content somehow, meaning the snapshot was taken AFTER instead of
+	// before.
+	if err == nil {
+		t.Error("snapshot accepted post-v9 category; was taken AFTER migration instead of BEFORE")
+	}
+}
+
+// =========================================================================
+// Retention
+// =========================================================================
+
+// TestSnapshot_OnlyMostRecentRetained pins the "single snapshot" policy:
+// after v5→v9 (two risky migrations: v6 and v9), exactly one snapshot
+// remains. The pre-v6 snapshot is replaced by the pre-v9 one when v9
+// runs.
+func TestSnapshot_OnlyMostRecentRetained(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildDBAtVersion(t, dbPath, 5)
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	snaps, err := db.ListMigrationSnapshots()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snaps) != 1 {
+		t.Errorf("expected exactly 1 retained snapshot row, got %d: %+v", len(snaps), snaps)
+	}
+	if len(snaps) > 0 && snaps[0].TargetVersion != 9 {
+		t.Errorf("retained snapshot should be pre-v9; got target_version=%d", snaps[0].TargetVersion)
+	}
+
+	// File system should match: one file in snapshots/.
+	files, _ := os.ReadDir(filepath.Join(dir, "snapshots"))
+	if len(files) != 1 {
+		t.Errorf("expected 1 file in snapshots/, got %d", len(files))
+	}
+}
+
+// TestSnapshot_RetentionDeletesAfterNBoots pins the auto-delete contract:
+// after SnapshotRetentionBoots successful boot ticks, the snapshot file
+// AND its tracking row are gone.
+func TestSnapshot_RetentionDeletesAfterNBoots(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildDBAtVersion(t, dbPath, 8) // v9 is risky, so this triggers exactly one snapshot
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	snaps, _ := db.ListMigrationSnapshots()
+	if len(snaps) != 1 {
+		t.Fatalf("setup: expected 1 snapshot row, got %d", len(snaps))
+	}
+	snapPath := snaps[0].Path
+	if _, err := os.Stat(snapPath); err != nil {
+		t.Fatalf("setup: snapshot file missing: %v", err)
+	}
+
+	for i := 0; i < SnapshotRetentionBoots; i++ {
+		if err := db.TickSnapshotRetention(); err != nil {
+			t.Fatalf("tick %d: %v", i+1, err)
+		}
+	}
+
+	// After N ticks the snapshot should be gone — file and row.
+	if _, err := os.Stat(snapPath); !os.IsNotExist(err) {
+		t.Errorf("snapshot file should have been deleted after %d boots; stat: %v",
+			SnapshotRetentionBoots, err)
+	}
+	after, _ := db.ListMigrationSnapshots()
+	if len(after) != 0 {
+		t.Errorf("snapshot row should have been deleted after %d boots; got %+v",
+			SnapshotRetentionBoots, after)
+	}
+}
+
+// TestSnapshot_RetentionLeavesSnapshotBeforeThreshold is the boundary
+// guard: TickSnapshotRetention must NOT delete a snapshot until it has
+// actually crossed the threshold. Off-by-one here would mean snapshots
+// disappear after N-1 boots, shortening the safety window.
+func TestSnapshot_RetentionLeavesSnapshotBeforeThreshold(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildDBAtVersion(t, dbPath, 8)
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	for i := 0; i < SnapshotRetentionBoots-1; i++ {
+		if err := db.TickSnapshotRetention(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snaps, _ := db.ListMigrationSnapshots()
+	if len(snaps) != 1 {
+		t.Errorf("snapshot must persist for at least %d ticks; got %d remaining",
+			SnapshotRetentionBoots, len(snaps))
+	}
+	if len(snaps) > 0 && snaps[0].BootsSince != SnapshotRetentionBoots-1 {
+		t.Errorf("boots_since = %d, want %d after %d ticks",
+			snaps[0].BootsSince, SnapshotRetentionBoots-1, SnapshotRetentionBoots-1)
+	}
+}
+
+// =========================================================================
+// Permissions
+// =========================================================================
+
+// TestSnapshot_FilePermissions pins that the snapshot file and its parent
+// directory are tightened to user-only. The snapshot contains the same
+// data as the DB; its permissions must match.
+func TestSnapshot_FilePermissions(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildDBAtVersion(t, dbPath, 8)
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	snaps, _ := db.ListMigrationSnapshots()
+	if len(snaps) != 1 {
+		t.Fatalf("setup: expected 1 snapshot, got %d", len(snaps))
+	}
+
+	dirInfo, err := os.Stat(filepath.Join(dir, "snapshots"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dirInfo.Mode().Perm()&0o077 != 0 {
+		t.Errorf("snapshots/ permissions too loose: %v", dirInfo.Mode().Perm())
+	}
+
+	fileInfo, err := os.Stat(snaps[0].Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fileInfo.Mode().Perm()&0o077 != 0 {
+		t.Errorf("snapshot file permissions too loose: %v", fileInfo.Mode().Perm())
+	}
+}
+
+// =========================================================================
+// CLI-surface helpers (List / Prune)
+// =========================================================================
+
+// TestSnapshot_ListReturnsRecordedFields pins the fields ListMigrationSnapshots
+// exposes — these drive the `continuity snapshot list` output. Drift here
+// shows up as wrong info in the operator's terminal.
+func TestSnapshot_ListReturnsRecordedFields(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildDBAtVersion(t, dbPath, 8)
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	snaps, err := db.ListMigrationSnapshots()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("setup: expected 1 snapshot, got %d", len(snaps))
+	}
+	s := snaps[0]
+	if s.Path == "" || !strings.Contains(s.Path, "snapshots") {
+		t.Errorf("Path = %q", s.Path)
+	}
+	if s.PreVersion != 8 {
+		t.Errorf("PreVersion = %d, want 8", s.PreVersion)
+	}
+	if s.TargetVersion != 9 {
+		t.Errorf("TargetVersion = %d, want 9", s.TargetVersion)
+	}
+	if s.CreatedAt.IsZero() {
+		t.Errorf("CreatedAt is zero")
+	}
+	if s.BootsSince != 0 {
+		t.Errorf("BootsSince = %d on fresh snapshot, want 0", s.BootsSince)
+	}
+}
+
+// TestSnapshot_PruneRemovesEverything pins the destructive contract of
+// PruneMigrationSnapshots: file gone, row gone, return count correct.
+func TestSnapshot_PruneRemovesEverything(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildDBAtVersion(t, dbPath, 8)
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	snaps, _ := db.ListMigrationSnapshots()
+	if len(snaps) != 1 {
+		t.Fatalf("setup: expected 1 snapshot, got %d", len(snaps))
+	}
+	snapPath := snaps[0].Path
+
+	removed, err := db.PruneMigrationSnapshots()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 1 {
+		t.Errorf("prune count = %d, want 1", removed)
+	}
+
+	if _, err := os.Stat(snapPath); !os.IsNotExist(err) {
+		t.Errorf("snapshot file should be gone after prune; stat: %v", err)
+	}
+	after, _ := db.ListMigrationSnapshots()
+	if len(after) != 0 {
+		t.Errorf("snapshot rows should be cleared; got %+v", after)
+	}
+}
+
+// TestSnapshot_PruneNoOpOnEmpty pins that prune on an empty state is
+// safe and returns 0 — the `continuity snapshot prune` CLI surface
+// relies on this for its "no snapshots to prune" message.
+func TestSnapshot_PruneNoOpOnEmpty(t *testing.T) {
+	db, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	n, err := db.PruneMigrationSnapshots()
+	if err != nil {
+		t.Errorf("prune on empty: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("prune on empty returned %d", n)
+	}
+}

--- a/internal/store/snapshot_test.go
+++ b/internal/store/snapshot_test.go
@@ -87,7 +87,9 @@ func TestSnapshot_CreatedBeforeRiskyMigration(t *testing.T) {
 	}
 	defer db.Close()
 
-	snapDir := filepath.Join(dir, "snapshots")
+	// Snapshots are namespaced under snapshots/<db-filename>/ so sibling DBs
+	// never collide; this DB is test.db.
+	snapDir := filepath.Join(dir, "snapshots", "test.db")
 	entries, err := os.ReadDir(snapDir)
 	if err != nil {
 		t.Fatalf("snapshots dir not created: %v", err)
@@ -480,10 +482,10 @@ func TestSnapshot_OnlyMostRecentRetained(t *testing.T) {
 		t.Errorf("retained snapshot should be pre-v9; got target_version=%d", snaps[0].TargetVersion)
 	}
 
-	// File system should match: one file in snapshots/.
-	files, _ := os.ReadDir(filepath.Join(dir, "snapshots"))
+	// File system should match: one file in this DB's snapshots/<db>/ dir.
+	files, _ := os.ReadDir(filepath.Join(dir, "snapshots", "test.db"))
 	if len(files) != 1 {
-		t.Errorf("expected 1 file in snapshots/, got %d", len(files))
+		t.Errorf("expected 1 file in snapshots/test.db/, got %d", len(files))
 	}
 }
 
@@ -785,9 +787,9 @@ func TestSnapshot_PruneReclaimsUntrackedFiles(t *testing.T) {
 		t.Fatalf("setup: expected 1 tracked snapshot, got %d", len(snaps))
 	}
 
-	// Strand an untracked snapshot file in snapshots/ — a real DB copy with no
-	// row, plus a foreign file prune must NOT touch.
-	snapDir := filepath.Join(dir, "snapshots")
+	// Strand an untracked snapshot file in THIS DB's snapshots/<db>/ dir — a
+	// real DB copy with no row, plus a foreign file prune must NOT touch.
+	snapDir := filepath.Join(dir, "snapshots", "test.db")
 	orphan := filepath.Join(snapDir, "continuity-pre-v6-2020-01-01T00-00-00Z.db")
 	if err := os.WriteFile(orphan, []byte("orphaned snapshot copy"), 0o600); err != nil {
 		t.Fatalf("write orphan: %v", err)
@@ -855,5 +857,77 @@ func TestSnapshot_PruneViaNoMigrateOpenDoesNotMigrate(t *testing.T) {
 	}
 	if v, _ := db.SchemaVersion(); v != 8 {
 		t.Errorf("schema advanced to v%d during prune; must stay v8", v)
+	}
+}
+
+// TestSnapshot_PruneIsolatedAcrossSiblingDBs pins the cross-DB safety contract:
+// two databases sharing a parent directory each keep their snapshots under
+// snapshots/<db-filename>/, so pruning one must never reach the other's
+// rollback point. Without per-DB namespacing, the untracked-file scan would
+// see the sibling's snapshots as "untracked" and delete them.
+func TestSnapshot_PruneIsolatedAcrossSiblingDBs(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir() // shared parent for both DBs
+	dbAPath := filepath.Join(dir, "a.db")
+	dbBPath := filepath.Join(dir, "b.db")
+	buildSnapshotDBAtVersion(t, dbAPath, 8)
+	buildSnapshotDBAtVersion(t, dbBPath, 8)
+
+	dbA, err := Open(dbAPath) // v9 risky → snapshot under snapshots/a.db/
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbA.Close()
+	dbB, err := Open(dbBPath) // snapshot under snapshots/b.db/
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbB.Close()
+
+	bSnaps, _ := dbB.ListMigrationSnapshots()
+	if len(bSnaps) != 1 {
+		t.Fatalf("setup: DB B should have 1 snapshot, got %d", len(bSnaps))
+	}
+	bSnapPath := bSnaps[0].Path
+
+	// Prune A. B must be completely untouched — file AND row.
+	if _, err := dbA.PruneMigrationSnapshots(); err != nil {
+		t.Fatalf("prune A: %v", err)
+	}
+	if _, err := os.Stat(bSnapPath); err != nil {
+		t.Errorf("pruning DB A destroyed DB B's snapshot file: %v", err)
+	}
+	if after, _ := dbB.ListMigrationSnapshots(); len(after) != 1 {
+		t.Errorf("pruning DB A cleared DB B's tracking row; B now has %d", len(after))
+	}
+}
+
+// TestSnapshot_ListSurfacesRealQueryErrors pins that ListMigrationSnapshots
+// distinguishes "table absent" (tolerated → empty) from a genuine query
+// failure (surfaced). A catch-all that reported a corrupt/incompatible table
+// as empty would make prune treat still-tracked files as untracked.
+func TestSnapshot_ListSurfacesRealQueryErrors(t *testing.T) {
+	db, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Replace the sidecar with an incompatible shape: the table EXISTS but
+	// lacks the expected columns, so the real SELECT fails.
+	if _, err := db.Exec(`DROP TABLE migration_snapshots`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE migration_snapshots (unexpected INTEGER)`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.ListMigrationSnapshots(); err == nil {
+		t.Fatal("ListMigrationSnapshots must surface a real query error, not report empty")
+	}
+	// Prune must propagate the error and NOT proceed to delete anything.
+	if _, err := db.PruneMigrationSnapshots(); err == nil {
+		t.Error("PruneMigrationSnapshots must refuse to run when the snapshot table is unreadable")
 	}
 }

--- a/internal/store/snapshot_test.go
+++ b/internal/store/snapshot_test.go
@@ -761,3 +761,99 @@ func TestSnapshot_PruneNoOpOnEmpty(t *testing.T) {
 		t.Errorf("prune on empty returned %d", n)
 	}
 }
+
+// TestSnapshot_PruneReclaimsUntrackedFiles pins that prune scans the snapshots/
+// directory and removes our snapshot files that have no tracking row — the
+// stranded-file case that arises when recording fails after a migration commits
+// or a superseded-file delete fails. Tracked-only pruning would leak these full
+// DB copies forever, contradicting prune's promise to reclaim the safety net.
+func TestSnapshot_PruneReclaimsUntrackedFiles(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildSnapshotDBAtVersion(t, dbPath, 8) // v9 risky → one tracked snapshot
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	snaps, _ := db.ListMigrationSnapshots()
+	if len(snaps) != 1 {
+		t.Fatalf("setup: expected 1 tracked snapshot, got %d", len(snaps))
+	}
+
+	// Strand an untracked snapshot file in snapshots/ — a real DB copy with no
+	// row, plus a foreign file prune must NOT touch.
+	snapDir := filepath.Join(dir, "snapshots")
+	orphan := filepath.Join(snapDir, "continuity-pre-v6-2020-01-01T00-00-00Z.db")
+	if err := os.WriteFile(orphan, []byte("orphaned snapshot copy"), 0o600); err != nil {
+		t.Fatalf("write orphan: %v", err)
+	}
+	foreign := filepath.Join(snapDir, "operator-notes.txt")
+	if err := os.WriteFile(foreign, []byte("do not delete"), 0o600); err != nil {
+		t.Fatalf("write foreign: %v", err)
+	}
+
+	removed, err := db.PruneMigrationSnapshots()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Tracked snapshot + the orphan = 2.
+	if removed != 2 {
+		t.Errorf("prune count = %d, want 2 (1 tracked + 1 untracked)", removed)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Errorf("untracked snapshot file should be reclaimed; stat: %v", err)
+	}
+	if _, err := os.Stat(foreign); err != nil {
+		t.Errorf("prune must not touch non-snapshot files; foreign file gone: %v", err)
+	}
+	after, _ := db.ListMigrationSnapshots()
+	if len(after) != 0 {
+		t.Errorf("rows should be cleared; got %+v", after)
+	}
+}
+
+// TestSnapshot_PruneViaNoMigrateOpenDoesNotMigrate pins the New-1 contract:
+// inspecting/cleaning snapshots must not upgrade the schema. Opening a
+// pre-head DB with OpenNoMigrate and pruning must NOT run the pending risky
+// migration — which would manufacture a snapshot and then immediately delete
+// it, silently discarding the only rollback point.
+func TestSnapshot_PruneViaNoMigrateOpenDoesNotMigrate(t *testing.T) {
+	t.Setenv(EnvNoMigrationSnapshot, "")
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	buildSnapshotDBAtVersion(t, dbPath, 8) // pre-v9; v9 is risky
+
+	db, err := OpenNoMigrate(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// No migration ran on open, so schema is still v8.
+	if v, err := db.SchemaVersion(); err != nil || v != 8 {
+		t.Fatalf("schema version = %d (err %v); OpenNoMigrate must not migrate (want 8)", v, err)
+	}
+
+	n, err := db.PruneMigrationSnapshots()
+	if err != nil {
+		t.Fatalf("prune on never-migrated DB must tolerate missing sidecar table: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("prune removed %d; a pre-migration DB has no snapshots to remove", n)
+	}
+
+	// Crucially: no snapshots/ directory full of a just-created-then-deleted
+	// snapshot. The schema stayed put, so no risky migration fired.
+	if entries, err := os.ReadDir(filepath.Join(dir, "snapshots")); err == nil && len(entries) > 0 {
+		t.Errorf("prune manufactured snapshots via migration: %d file(s) in snapshots/", len(entries))
+	}
+	if v, _ := db.SchemaVersion(); v != 8 {
+		t.Errorf("schema advanced to v%d during prune; must stay v8", v)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the migration safety snapshot policy approved in the design review. Migrations are the one place Continuity knowingly performs potentially destructive operations against the user's substrate. SQLite's transaction guarantees handle failure modes; they cannot catch a buggy migration that successfully commits the wrong state. v6 and v9 are full-table rebuilds where column-order parity is by developer discipline, not enforcement. This PR adds an automatic safety snapshot taken immediately before each migration marked risky.

**Not a backup system. A one-shot safety net during the upgrade window.**

Independent of the test stack (#27/#28/#29) and the forward-compat guard (#30) — bases on main, merges in any order.

## Policy implemented (per the approved design)

| Rule | How it's enforced |
|---|---|
| Snapshots only for migrations explicitly marked Risky | `Risky bool` on the `migration` struct; v6/v9 set true with inline rationale |
| Additive migrations don't snapshot | Walked by `TestSnapshot_NotCreatedForAdditiveMigration` — asserts every migration descriptor against its flag |
| Snapshot failure blocks migration | Error message names the opt-out env var so the operator has a deliberate path forward |
| Opt-out escape hatch | `CONTINUITY_NO_MIGRATION_SNAPSHOT=1` — deliberate, non-default |
| Only most recent retained | `recordSnapshotAndPruneOlder` swaps the tracking row in one tx, deletes superseded files after DB commit |
| Auto-delete after N successful boots | `SnapshotRetentionBoots = 3`; `TickSnapshotRetention` called explicitly from `runServe`, NOT from `Open` (so CLI inspect/prune commands don't advance the counter) |
| No auto-restore | CLI provides `snapshot list` and `snapshot prune` only; restoration is documented as a manual `cp` |
| No multi-version backup management | Single-snapshot retention is the bound that keeps this from becoming a backup system |
| Clearly documented as safety net, not backup | README section leads with the framing and links to the manual-restore mechanic |

## Implementation

**Core (`internal/store/snapshot.go`, new)**
- `snapshotBeforeRiskyMigration` — VACUUM INTO + chmod 0600, gated on `Risky` / opt-out env / `:memory:`
- `recordSnapshotAndPruneOlder` — atomic swap of tracking rows + post-commit file cleanup
- `TickSnapshotRetention` — boot counter + threshold-triggered deletion
- `ListMigrationSnapshots` / `PruneMigrationSnapshots` — surface for CLI
- `MigrationSnapshot` struct + `SnapshotRetentionBoots` / `EnvNoMigrationSnapshot` constants

**Migration wiring (`internal/store/migrations.go`)**
- `migration.Risky bool` added; v6 and v9 set true
- `migrate()`: ensures sidecar `migration_snapshots` table, captures pre-version per migration, calls snapshot before, aborts on snapshot error, removes snapshot file on migration rollback, records + prunes after successful commit
- `migration_snapshots` is sidecar (`CREATE IF NOT EXISTS` in `migrate()`), deliberately NOT under the schema_versions system — needed before v6, the first risky migration

**Serve integration (`internal/cli/serve.go`)**
- `TickSnapshotRetention` after `Open`
- One stderr line per retained snapshot showing the auto-delete countdown

**CLI surface (`internal/cli/snapshot.go`, new)**
- `continuity snapshot list` — path, pre/target versions, created time, boots remaining, closes with manual-restore instruction
- `continuity snapshot prune` — destructive; reports count
- **No restore subcommand by design.** Restoration is `cp <snapshot> ~/.continuity/continuity.db`.

**Documentation (`README.md`)**
- New "Migration safety snapshots" subsection under "Memory accountability"
- States policy explicitly, leads with the "not a backup system" framing
- Two CLI entries added to the short reference

## Tests (13, in-process)

| Test | Pins |
|---|---|
| `CreatedBeforeRiskyMigration` | snapshot creation on v5→v9 |
| `OptOutEnvVarSkips` | the deliberate opt-out |
| `NotCreatedForAdditiveMigration` | walks every migration descriptor against its `Risky` flag |
| `MemoryDBSkipsSnapshot` | `:memory:` is safe |
| **`FailureBlocksMigration`** | **the load-bearing invariant** — plants a file where `snapshots/` should be so `MkdirAll` fails; asserts `Open` returns an error naming the env var and the schema stays at the pre-failure version |
| `ContentMatchesPreMigrationState` | seeds a v5 row, runs upgrade, opens snapshot directly via `sql.Open`, verifies the row is present AND that an attempted v9-only category insert into the snapshot fails (proving the snapshot was taken BEFORE migration, not after) |
| `OnlyMostRecentRetained` | v5→v9 leaves exactly one snapshot row + file |
| `RetentionDeletesAfterNBoots` | N ticks → file and row gone |
| `RetentionLeavesSnapshotBeforeThreshold` | N-1 ticks → still there (off-by-one guard) |
| `FilePermissions` | `snapshots/` 0700, file 0600 |
| `ListReturnsRecordedFields` | every field round-trips |
| `PruneRemovesEverything` | file gone, row gone, count correct |
| `PruneNoOpOnEmpty` | safe on empty state |

## Verification

- `go test -count=1 ./internal/...` — full suite green
- `go vet ./internal/...` — clean
- `gofmt -l internal/store/ internal/cli/` shows two pre-existing drift files (`observations_test.go`, `extract.go`) NOT touched by this PR — same family of drift PRs #26 and #29 flagged. Worth a one-shot cleanup separately.

## Out of scope (held the line)

The design called these out as the slippery slopes. None of them ship here:

- ✗ Rotation across many migrations
- ✗ Compression, encryption
- ✗ Off-machine sync, S3, remote storage
- ✗ Auto-restore
- ✗ Multi-version retention
- ✗ Any management UI beyond list + prune

Per the policy: if the boundary drifts in any of those directions in a future PR, kill the feature — at that point we're a backup system and we've lost the plot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)