### PR TITLE
Subprocess e2e tests: hook handlers + migration upgrade-path (roadmap ① + ②)

### DIFF
--- a/internal/cli/retract_e2e_test.go
+++ b/internal/cli/retract_e2e_test.go
@@ -3,25 +3,13 @@
 package cli
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"net"
-	"net/http"
-	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
-	"strconv"
 	"strings"
-	"syscall"
 	"testing"
-	"time"
 
 	"github.com/lazypower/continuity/internal/store"
+	"github.com/lazypower/continuity/internal/testharness"
 )
 
 // TestRetract_SubprocessE2E_TFIDF exercises the retract / dedup-against-retracted
@@ -52,14 +40,10 @@ func TestRetract_SubprocessE2E_TFIDF(t *testing.T) {
 		t.Skip("subprocess e2e: skipped under -short (builds a binary, spawns a server)")
 	}
 
-	bin := buildContinuityBinary(t)
+	bin := testharness.BuildContinuityBinary(t)
 
 	workDir := t.TempDir()
 	dbPath := filepath.Join(workDir, "test.db")
-	homeDir := filepath.Join(workDir, "home")
-	if err := os.MkdirAll(homeDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
 
 	// Seed the DB with enough varied text that TFIDF builds a real vocabulary
 	// covering the tokens our test queries use (operator, home, address,
@@ -69,59 +53,46 @@ func TestRetract_SubprocessE2E_TFIDF(t *testing.T) {
 	// fail to exercise its target invariant.
 	seedTFIDFCorpus(t, dbPath)
 
-	port := freeTCPPort(t)
-	serverURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	serverURL, procEnv := testharness.HermeticEnv(t, workDir, dbPath, 0)
 
-	procEnv := append(os.Environ(),
-		"HOME="+homeDir,
-		"CONTINUITY_DB="+dbPath,
-		"CONTINUITY_PORT="+strconv.Itoa(port),
-		"CONTINUITY_BIND=127.0.0.1",
-		"CONTINUITY_EMBEDDER=tfidf",
-		"CONTINUITY_URL="+serverURL,
-	)
-
-	srv := startServeProcess(t, bin, procEnv)
-	t.Cleanup(srv.stop)
-	waitForReady(t, serverURL+"/api/health")
+	srv := testharness.StartServeProcess(t, bin, procEnv)
+	t.Cleanup(srv.Stop)
+	testharness.WaitForReady(t, serverURL+"/api/health")
 
 	// Step 1 — remember original.
-	step1 := runCLI(t, bin, procEnv, "remember",
+	step1 := testharness.RunCLI(t, bin, procEnv, "remember",
 		"-c", "events",
 		"-n", "operator-home-address-discussion",
 		"-s", "operator's full home address discussion",
 		"-b", "Body content captured during conversation that has enough length to pass validation thresholds easily.",
 	)
-	step1.expectExit(t, 0).
-		expectStdoutContains(t, "created:").
-		expectStdoutContains(t, "mem://user/events/operator-home-address-discussion")
+	step1.ExpectExit(t, 0).
+		ExpectStdoutContains(t, "created:", "mem://user/events/operator-home-address-discussion")
 
 	// Step 2 — retract the original. Reason carries the PII-shaped marker; we
 	// will assert this string never leaks via the gate's stderr or via the
 	// default show output.
 	const piiReason = "captured operator home address by accident; remove on sight"
-	step2 := runCLI(t, bin, procEnv, "retract",
+	step2 := testharness.RunCLI(t, bin, procEnv, "retract",
 		"mem://user/events/operator-home-address-discussion",
 		"--reason", piiReason,
 	)
-	step2.expectExit(t, 0).
-		expectStdoutContains(t, "retracted:").
-		expectStdoutContains(t, "mem://user/events/operator-home-address-discussion")
+	step2.ExpectExit(t, 0).
+		ExpectStdoutContains(t, "retracted:", "mem://user/events/operator-home-address-discussion")
 
 	// Step 3 — write a semantically similar memory under the same category.
 	// The dedup-against-retracted gate must fire: exit 2, stderr names the
 	// matched URI, stderr DOES NOT leak the reason. This is the agent-facing
 	// contract from PR #20's design.
-	step3 := runCLI(t, bin, procEnv, "remember",
+	step3 := testharness.RunCLI(t, bin, procEnv, "remember",
 		"-c", "events",
 		"-n", "second-attempt-similar",
 		"-s", "operator home address mentioned again in same discussion thread",
 		"-b", "Different body content carrying enough length to pass validation easily as well.",
 	)
-	step3.expectExit(t, 2).
-		expectStderrContains(t, "matches_retracted").
-		expectStderrContains(t, "mem://user/events/operator-home-address-discussion").
-		expectStdoutAbsent(t, "created:", "updated:") // stdout MUST stay clean on the gate path
+	step3.ExpectExit(t, 2).
+		ExpectStderrContains(t, "matches_retracted", "mem://user/events/operator-home-address-discussion").
+		ExpectStdoutAbsent(t, "created:", "updated:") // stdout MUST stay clean on the gate path
 
 	// Absence-of-leakage: the reason field is sequestered by contract. Verify
 	// no fragment of the reason text appears in stderr.
@@ -131,47 +102,47 @@ func TestRetract_SubprocessE2E_TFIDF(t *testing.T) {
 		"remove on sight",
 		piiReason,
 	} {
-		if strings.Contains(step3.stderr, leak) {
-			t.Errorf("step 3 stderr leaks tombstone reason via %q:\n%s", leak, step3.stderr)
+		if strings.Contains(step3.Stderr, leak) {
+			t.Errorf("step 3 stderr leaks tombstone reason via %q:\n%s", leak, step3.Stderr)
 		}
 	}
 
 	// Step 4 — show with --include-retracted reveals the reason deliberately.
-	step4 := runCLI(t, bin, procEnv, "show",
+	step4 := testharness.RunCLI(t, bin, procEnv, "show",
 		"mem://user/events/operator-home-address-discussion",
 		"--include-retracted",
 	)
-	step4.expectExit(t, 0).
-		expectStdoutContains(t, piiReason)
+	step4.ExpectExit(t, 0).
+		ExpectStdoutContains(t, piiReason)
 
 	// Step 5 — show WITHOUT the flag suppresses the reason and the body.
-	step5 := runCLI(t, bin, procEnv, "show",
+	step5 := testharness.RunCLI(t, bin, procEnv, "show",
 		"mem://user/events/operator-home-address-discussion",
 	)
-	step5.expectExit(t, 0)
+	step5.ExpectExit(t, 0)
 	for _, leak := range []string{
 		"captured operator",
 		"home address by accident",
 		"remove on sight",
 		piiReason,
 	} {
-		if strings.Contains(step5.stdout, leak) {
-			t.Errorf("step 5 (show without flag) leaks reason via %q:\n%s", leak, step5.stdout)
+		if strings.Contains(step5.Stdout, leak) {
+			t.Errorf("step 5 (show without flag) leaks reason via %q:\n%s", leak, step5.Stdout)
 		}
 	}
-	if !strings.Contains(step5.stdout, "[retracted]") {
-		t.Errorf("step 5 must mark the node as retracted in output:\n%s", step5.stdout)
+	if !strings.Contains(step5.Stdout, "[retracted]") {
+		t.Errorf("step 5 must mark the node as retracted in output:\n%s", step5.Stdout)
 	}
 
 	// Step 6 — show --json without the flag omits reason/summary/body fields.
-	step6 := runCLI(t, bin, procEnv, "show",
+	step6 := testharness.RunCLI(t, bin, procEnv, "show",
 		"mem://user/events/operator-home-address-discussion",
 		"--json",
 	)
-	step6.expectExit(t, 0)
+	step6.ExpectExit(t, 0)
 	var jsonOut map[string]any
-	if err := json.Unmarshal([]byte(step6.stdout), &jsonOut); err != nil {
-		t.Fatalf("step 6 stdout is not valid JSON: %v\n%s", err, step6.stdout)
+	if err := json.Unmarshal([]byte(step6.Stdout), &jsonOut); err != nil {
+		t.Fatalf("step 6 stdout is not valid JSON: %v\n%s", err, step6.Stdout)
 	}
 	for _, key := range []string{"tombstone_reason", "summary", "body"} {
 		if _, ok := jsonOut[key]; ok {
@@ -184,84 +155,29 @@ func TestRetract_SubprocessE2E_TFIDF(t *testing.T) {
 
 	// Step 7 — retry the same similar write with --acknowledge-retracted.
 	// Gate bypassed, write succeeds, exit 0, stdout reports created.
-	step7 := runCLI(t, bin, procEnv, "remember",
+	step7 := testharness.RunCLI(t, bin, procEnv, "remember",
 		"-c", "events",
 		"-n", "second-attempt-similar",
 		"-s", "operator home address mentioned again in same discussion thread",
 		"-b", "Different body content carrying enough length to pass validation easily as well.",
 		"--acknowledge-retracted",
 	)
-	step7.expectExit(t, 0).
-		expectStdoutContains(t, "created:").
-		expectStdoutContains(t, "mem://user/events/second-attempt-similar").
-		expectStderrAbsent(t, "matches_retracted")
+	step7.ExpectExit(t, 0).
+		ExpectStdoutContains(t, "created:", "mem://user/events/second-attempt-similar").
+		ExpectStderrAbsent(t, "matches_retracted")
 
 	// Step 8 — show the override write proves the override landed at the
 	// expected URI (i.e. the gate-bypass path doesn't sneak the write onto a
 	// timestamp-suffixed slug).
-	step8 := runCLI(t, bin, procEnv, "show", "mem://user/events/second-attempt-similar")
-	step8.expectExit(t, 0).
-		expectStdoutContains(t, "mem://user/events/second-attempt-similar")
-
-	// Step 9 — server shutdown is clean (cleanup will SIGTERM; assert in the
-	// stop() helper that exit is 0 and stderr shows the expected drain line).
-	// (Handled in srv.stop via t.Cleanup; nothing to do here.)
-}
-
-// ----- helpers below -----
-
-// buildContinuityBinary compiles cmd/continuity with the noembed build tag so
-// the binary builds without the UI assets the production Makefile bakes in.
-// Returns the absolute path to the binary.
-func buildContinuityBinary(t *testing.T) string {
-	t.Helper()
-	binDir := t.TempDir()
-	binName := "continuity"
-	if runtime.GOOS == "windows" {
-		binName += ".exe"
-	}
-	binPath := filepath.Join(binDir, binName)
-
-	repoRoot, err := findRepoRoot()
-	if err != nil {
-		t.Fatalf("findRepoRoot: %v", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "go", "build", "-tags", "noembed", "-o", binPath, "./cmd/continuity")
-	cmd.Dir = repoRoot
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("go build: %v\n%s", err, stderr.String())
-	}
-	return binPath
-}
-
-// findRepoRoot walks up from the test file's directory until it finds a go.mod
-// file, returning the directory containing it.
-func findRepoRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", errors.New("go.mod not found in any parent of test cwd")
-		}
-		dir = parent
-	}
+	step8 := testharness.RunCLI(t, bin, procEnv, "show", "mem://user/events/second-attempt-similar")
+	step8.ExpectExit(t, 0).
+		ExpectStdoutContains(t, "mem://user/events/second-attempt-similar")
 }
 
 // seedTFIDFCorpus opens the SQLite DB directly and writes enough varied L0
 // abstracts that NewTFIDFEmbedder has a real vocabulary covering the tokens
-// the test queries use. Seeding here (not via the CLI) is intentional: it
-// represents the production state where the user already has a populated DB
+// the retract test queries use. Seeding here (not via the CLI) is intentional:
+// it represents the production state where the user already has a populated DB
 // when they invoke retract.
 func seedTFIDFCorpus(t *testing.T, dbPath string) {
 	t.Helper()
@@ -291,181 +207,4 @@ func seedTFIDFCorpus(t *testing.T, dbPath string) {
 			t.Fatalf("seed %s: %v", s.name, err)
 		}
 	}
-}
-
-// freeTCPPort asks the kernel for a free TCP port, releases the listener, and
-// returns the port number. There is a small race window between Close() and
-// the subprocess Listen, acceptable for tests.
-func freeTCPPort(t *testing.T) int {
-	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("freeTCPPort: %v", err)
-	}
-	port := l.Addr().(*net.TCPAddr).Port
-	if err := l.Close(); err != nil {
-		t.Fatalf("freeTCPPort close: %v", err)
-	}
-	return port
-}
-
-// serverProcess wraps a running `continuity serve` child process with safe
-// shutdown helpers.
-type serverProcess struct {
-	cmd       *exec.Cmd
-	stderrBuf *bytes.Buffer
-	stopped   bool
-}
-
-// startServeProcess spawns `continuity serve` with the given env and pipes its
-// stderr to a buffer for post-mortem inspection. Returns once the process is
-// running; callers must wait for /api/health before issuing CLI commands.
-func startServeProcess(t *testing.T, bin string, env []string) *serverProcess {
-	t.Helper()
-	cmd := exec.Command(bin, "serve")
-	cmd.Env = env
-
-	stderr := &bytes.Buffer{}
-	cmd.Stderr = stderr
-	cmd.Stdout = io.Discard
-
-	// Put the server in its own process group so we can deliver SIGTERM
-	// without racing the test harness's signal handling.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start serve: %v", err)
-	}
-	return &serverProcess{cmd: cmd, stderrBuf: stderr}
-}
-
-// stop sends SIGTERM to the server's process group and waits up to 5 seconds
-// for it to exit. Errors are reported via t.Errorf so cleanup never panics in
-// flight.
-func (s *serverProcess) stop() {
-	if s.stopped {
-		return
-	}
-	s.stopped = true
-
-	// SIGTERM the process group. The leading minus targets the pgid.
-	if s.cmd.Process != nil {
-		_ = syscall.Kill(-s.cmd.Process.Pid, syscall.SIGTERM)
-	}
-
-	done := make(chan error, 1)
-	go func() { done <- s.cmd.Wait() }()
-	select {
-	case <-done:
-		// graceful exit (or non-zero — we tolerate either; the test asserts
-		// the meaningful surfaces elsewhere)
-	case <-time.After(5 * time.Second):
-		if s.cmd.Process != nil {
-			_ = syscall.Kill(-s.cmd.Process.Pid, syscall.SIGKILL)
-		}
-		<-done
-	}
-}
-
-// waitForReady polls /api/health up to 10 seconds, failing the test if the
-// server never responds 200. The poll interval is short so the test isn't
-// dominated by startup latency.
-func waitForReady(t *testing.T, healthURL string) {
-	t.Helper()
-	client := &http.Client{Timeout: 500 * time.Millisecond}
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		resp, err := client.Get(healthURL)
-		if err == nil {
-			resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				return
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	t.Fatalf("server did not become ready at %s within 10s", healthURL)
-}
-
-// cliResult is the outcome of one CLI invocation: captured channels and exit
-// code. Methods chain so call sites read top-down.
-type cliResult struct {
-	args     []string
-	stdout   string
-	stderr   string
-	exitCode int
-}
-
-// runCLI executes the binary with the given args + env, capturing both
-// channels and the exit code. It does NOT fail the test on non-zero exit —
-// the caller does, via expectExit.
-func runCLI(t *testing.T, bin string, env []string, args ...string) *cliResult {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, bin, args...)
-	cmd.Env = env
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	res := &cliResult{
-		args:   args,
-		stdout: stdout.String(),
-		stderr: stderr.String(),
-	}
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		res.exitCode = exitErr.ExitCode()
-	} else if err != nil {
-		t.Fatalf("runCLI: launch failed for args %v: %v\nstderr:\n%s", args, err, stderr.String())
-	}
-	return res
-}
-
-func (r *cliResult) expectExit(t *testing.T, want int) *cliResult {
-	t.Helper()
-	if r.exitCode != want {
-		t.Errorf("args %v: exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s",
-			r.args, r.exitCode, want, r.stdout, r.stderr)
-	}
-	return r
-}
-
-func (r *cliResult) expectStdoutContains(t *testing.T, frag string) *cliResult {
-	t.Helper()
-	if !strings.Contains(r.stdout, frag) {
-		t.Errorf("args %v: stdout missing %q\nstdout:\n%s", r.args, frag, r.stdout)
-	}
-	return r
-}
-
-func (r *cliResult) expectStderrContains(t *testing.T, frag string) *cliResult {
-	t.Helper()
-	if !strings.Contains(r.stderr, frag) {
-		t.Errorf("args %v: stderr missing %q\nstderr:\n%s", r.args, frag, r.stderr)
-	}
-	return r
-}
-
-func (r *cliResult) expectStdoutAbsent(t *testing.T, frags ...string) *cliResult {
-	t.Helper()
-	for _, f := range frags {
-		if strings.Contains(r.stdout, f) {
-			t.Errorf("args %v: stdout must NOT contain %q\nstdout:\n%s", r.args, f, r.stdout)
-		}
-	}
-	return r
-}
-
-func (r *cliResult) expectStderrAbsent(t *testing.T, frags ...string) *cliResult {
-	t.Helper()
-	for _, f := range frags {
-		if strings.Contains(r.stderr, f) {
-			t.Errorf("args %v: stderr must NOT contain %q\nstderr:\n%s", r.args, f, r.stderr)
-		}
-	}
-	return r
 }

--- a/internal/hooks/hooks_e2e_test.go
+++ b/internal/hooks/hooks_e2e_test.go
@@ -1,0 +1,572 @@
+//go:build !windows
+
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lazypower/continuity/internal/store"
+	"github.com/lazypower/continuity/internal/testharness"
+)
+
+// hookE2E is the shared per-test scaffold: a built binary, a running serve
+// process with TFIDF forced, env vars wired, a DB handle for state
+// assertions, and the server URL. Sub-tests build their own stdin payloads
+// and call the binary via the testharness CLI helpers.
+type hookE2E struct {
+	bin       string
+	env       []string
+	workDir   string
+	dbPath    string
+	serverURL string
+	srv       *testharness.ServerProcess
+	db        *store.DB
+}
+
+// setupHookE2E builds the binary, starts the server with a hermetic env, and
+// opens a second DB handle for the test to inspect server-mutated state.
+// SQLite WAL mode lets the test's connection coexist with the server's.
+func setupHookE2E(t *testing.T) *hookE2E {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("hooks subprocess e2e: skipped under -short")
+	}
+
+	bin := testharness.BuildContinuityBinary(t)
+	workDir := t.TempDir()
+	dbPath := filepath.Join(workDir, "test.db")
+
+	serverURL, env := testharness.HermeticEnv(t, workDir, dbPath, 0)
+	srv := testharness.StartServeProcess(t, bin, env)
+	t.Cleanup(srv.Stop)
+	testharness.WaitForReady(t, serverURL+"/api/health")
+
+	// Open the DB AFTER serve has started so migrations have run.
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db for assertions: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	return &hookE2E{
+		bin:       bin,
+		env:       env,
+		workDir:   workDir,
+		dbPath:    dbPath,
+		serverURL: serverURL,
+		srv:       srv,
+		db:        db,
+	}
+}
+
+// runHook is the hook-subprocess analogue of testharness.RunCLI: it pipes a
+// JSON-encoded HookInput to `bin hook <event>` and captures the result.
+func (h *hookE2E) runHook(t *testing.T, event string, input HookInput) *testharness.CLIResult {
+	t.Helper()
+	stdin, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("marshal hook input: %v", err)
+	}
+	return testharness.RunCLIWithStdin(t, h.bin, h.env, string(stdin), "hook", event)
+}
+
+// writeTranscript writes a synthetic Claude Code JSONL transcript with the
+// given number of user / assistant message pairs and returns the file path.
+// userText is repeated per message so the condensed length can be tuned by
+// the caller (low-message tests vs past-threshold tests).
+func writeTranscript(t *testing.T, dir string, name string, userMessages int, userText, assistantText string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	var b strings.Builder
+	for i := 0; i < userMessages; i++ {
+		userMsg := map[string]any{
+			"type": "user",
+			"message": map[string]any{
+				"role":    "user",
+				"content": fmt.Sprintf("%s (turn %d)", userText, i+1),
+			},
+		}
+		line, _ := json.Marshal(userMsg)
+		b.Write(line)
+		b.WriteString("\n")
+
+		asstMsg := map[string]any{
+			"type": "assistant",
+			"message": map[string]any{
+				"role":    "assistant",
+				"content": fmt.Sprintf("%s (turn %d)", assistantText, i+1),
+			},
+		}
+		line, _ = json.Marshal(asstMsg)
+		b.Write(line)
+		b.WriteString("\n")
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+// =========================================================================
+// SessionStart contract
+// =========================================================================
+
+// TestHookStart_SubprocessE2E_WritesContextJSON pins the agent contract for
+// SessionStart: stdout MUST be a valid SessionStartOutput JSON document with
+// the hookSpecificOutput.hookEventName field set to "SessionStart", because
+// Claude Code parses this to discover the context-injection payload. Exit
+// code MUST be 0 (hooks must never crash Claude — see ExitError in output.go).
+func TestHookStart_SubprocessE2E_WritesContextJSON(t *testing.T) {
+	h := setupHookE2E(t)
+
+	res := h.runHook(t, "start", HookInput{
+		SessionID:     "test-session-start-1",
+		HookEventName: "SessionStart",
+		Source:        "startup",
+	})
+	res.ExpectExit(t, 0)
+
+	var out SessionStartOutput
+	if err := json.Unmarshal([]byte(res.Stdout), &out); err != nil {
+		t.Fatalf("stdout is not valid SessionStartOutput JSON: %v\nstdout:\n%s", err, res.Stdout)
+	}
+	if out.HookSpecificOutput.HookEventName != "SessionStart" {
+		t.Errorf("hookEventName = %q, want SessionStart", out.HookSpecificOutput.HookEventName)
+	}
+}
+
+// TestHookStart_SubprocessE2E_ServerDownDegradesGracefully pins the
+// graceful-degradation contract from handler.go:25-30. With the server
+// stopped, SessionStart must still produce a valid empty-context JSON
+// document and exit 0. Crashing or returning malformed JSON here would
+// break every Claude Code session that fires while the server is restarting.
+func TestHookStart_SubprocessE2E_ServerDownDegradesGracefully(t *testing.T) {
+	h := setupHookE2E(t)
+	h.srv.Stop() // intentional: simulate server-down before the hook fires
+
+	// Disable autostart by pointing HOME away from any persisted plist/unit.
+	// HermeticEnv already does this — the tempdir HOME has no
+	// LaunchAgents / systemd-unit files, so TryAutostart returns false.
+
+	res := h.runHook(t, "start", HookInput{
+		SessionID:     "test-server-down",
+		HookEventName: "SessionStart",
+	})
+	res.ExpectExit(t, 0)
+
+	var out SessionStartOutput
+	if err := json.Unmarshal([]byte(res.Stdout), &out); err != nil {
+		t.Fatalf("server-down stdout is not valid JSON: %v\nstdout:\n%s", err, res.Stdout)
+	}
+	if out.HookSpecificOutput.AdditionalContext != "" {
+		t.Errorf("server-down context should be empty; got %q", out.HookSpecificOutput.AdditionalContext)
+	}
+	if out.HookSpecificOutput.HookEventName != "SessionStart" {
+		t.Errorf("server-down hookEventName drift: %q", out.HookSpecificOutput.HookEventName)
+	}
+}
+
+// =========================================================================
+// UserPromptSubmit contract
+// =========================================================================
+
+// TestHookSubmit_SubprocessE2E_CreatesSession pins that a fresh
+// UserPromptSubmit POSTs /api/sessions/init and the server creates the
+// sessions row. Exit 0, no stdout (hooks except SessionStart must stay
+// silent — anything they print would be injected into Claude's context).
+func TestHookSubmit_SubprocessE2E_CreatesSession(t *testing.T) {
+	h := setupHookE2E(t)
+
+	sessionID := "test-submit-init-" + time.Now().Format("150405.000000")
+	res := h.runHook(t, "submit", HookInput{
+		SessionID: sessionID,
+		CWD:       "/tmp/test-project",
+		Prompt:    "ordinary user message",
+	})
+	res.ExpectExit(t, 0)
+	if strings.TrimSpace(res.Stdout) != "" {
+		t.Errorf("non-start hook leaked to stdout (would contaminate Claude context):\n%s", res.Stdout)
+	}
+
+	testharness.WaitForCondition(t, 2*time.Second,
+		fmt.Sprintf("session %q should be created after submit", sessionID),
+		func() bool {
+			sess, _ := h.db.GetSession(sessionID)
+			return sess != nil
+		})
+}
+
+// TestHookSubmit_SubprocessE2E_InternalSentinelSkipsInit pins the
+// anti-recursion guard from submit.go:31. When the server calls `claude -p`
+// for extraction, that spawns a new Claude Code session whose hooks fire
+// back into us; the sentinel prefix tells us to bail before init. Without
+// this guard, extraction would recursively trigger more extractions.
+func TestHookSubmit_SubprocessE2E_InternalSentinelSkipsInit(t *testing.T) {
+	h := setupHookE2E(t)
+
+	sessionID := "test-internal-sentinel-" + time.Now().Format("150405.000000")
+	res := h.runHook(t, "submit", HookInput{
+		SessionID: sessionID,
+		CWD:       "/tmp/test-project",
+		Prompt:    internalSentinel + " extraction call",
+	})
+	res.ExpectExit(t, 0)
+	if strings.TrimSpace(res.Stdout) != "" {
+		t.Errorf("internal-sentinel submit leaked to stdout:\n%s", res.Stdout)
+	}
+
+	// Wait long enough that an init would have landed if it were going to,
+	// then assert it didn't.
+	time.Sleep(200 * time.Millisecond)
+	sess, err := h.db.GetSession(sessionID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess != nil {
+		t.Errorf("internal-sentinel prompt must NOT create session %q (recursion guard); got %+v", sessionID, sess)
+	}
+}
+
+// TestHookSubmit_SubprocessE2E_SignalTriggerReachesServer pins the signal
+// keyword path: prompts containing "remember this" (etc.) trigger a
+// fire-and-forget POST to /api/sessions/<id>/signal. In CI there is no LLM
+// configured, so the server-side ExtractSignal call fails — the failure log
+// line is our proof the route was reached. (Successful extraction depends on
+// the LLM and is covered by engine-layer tests.)
+func TestHookSubmit_SubprocessE2E_SignalTriggerReachesServer(t *testing.T) {
+	h := setupHookE2E(t)
+
+	sessionID := "test-signal-trigger-" + time.Now().Format("150405.000000")
+	res := h.runHook(t, "submit", HookInput{
+		SessionID: sessionID,
+		CWD:       "/tmp/test-project",
+		Prompt:    "remember this: the cache eviction policy is LRU not LFU",
+	})
+	res.ExpectExit(t, 0)
+
+	testharness.WaitForCondition(t, 3*time.Second,
+		"server should attempt signal extraction (and fail without LLM)",
+		func() bool {
+			return strings.Contains(h.srv.Stderr(),
+				fmt.Sprintf("signal extraction failed for %s", sessionID))
+		})
+}
+
+// =========================================================================
+// PostToolUse contract
+// =========================================================================
+
+// TestHookTool_SubprocessE2E_RecordsObservation pins the happy path: a tool
+// invocation produces exactly one observations row attributed to the session.
+func TestHookTool_SubprocessE2E_RecordsObservation(t *testing.T) {
+	h := setupHookE2E(t)
+
+	sessionID := "test-tool-record-" + time.Now().Format("150405.000000")
+	// Pre-init the session so foreign-key-ish coupling is realistic.
+	_ = h.runHook(t, "submit", HookInput{
+		SessionID: sessionID, CWD: "/tmp", Prompt: "init",
+	}).ExpectExit(t, 0)
+	testharness.WaitForCondition(t, 2*time.Second,
+		"session created via submit",
+		func() bool { s, _ := h.db.GetSession(sessionID); return s != nil })
+
+	res := h.runHook(t, "tool", HookInput{
+		SessionID:    sessionID,
+		ToolName:     "Write",
+		ToolInput:    json.RawMessage(`{"file_path":"/tmp/x.txt","content":"hi"}`),
+		ToolResponse: json.RawMessage(`{"success":true}`),
+	})
+	res.ExpectExit(t, 0)
+	if strings.TrimSpace(res.Stdout) != "" {
+		t.Errorf("tool hook leaked to stdout:\n%s", res.Stdout)
+	}
+
+	testharness.WaitForCondition(t, 2*time.Second,
+		"observation should be persisted",
+		func() bool {
+			c, _ := h.db.GetSessionObservationCount(sessionID)
+			return c >= 1
+		})
+}
+
+// TestHookTool_SubprocessE2E_SkipsMetaTools pins the skipTools allowlist
+// from input.go: TodoRead, Thinking, TaskList, etc. must NOT produce
+// observations rows, because they are meta-noise that would crowd out real
+// tool signals during extraction.
+func TestHookTool_SubprocessE2E_SkipsMetaTools(t *testing.T) {
+	h := setupHookE2E(t)
+
+	sessionID := "test-tool-skip-" + time.Now().Format("150405.000000")
+	_ = h.runHook(t, "submit", HookInput{
+		SessionID: sessionID, CWD: "/tmp", Prompt: "init",
+	}).ExpectExit(t, 0)
+	testharness.WaitForCondition(t, 2*time.Second,
+		"session created",
+		func() bool { s, _ := h.db.GetSession(sessionID); return s != nil })
+
+	for _, skip := range []string{"TodoRead", "TodoWrite", "Thinking", "TaskList", "TaskCreate", "TaskGet", "TaskUpdate"} {
+		res := h.runHook(t, "tool", HookInput{
+			SessionID:    sessionID,
+			ToolName:     skip,
+			ToolInput:    json.RawMessage(`{}`),
+			ToolResponse: json.RawMessage(`{}`),
+		})
+		res.ExpectExit(t, 0)
+	}
+
+	// Wait long enough that a write would have landed; then assert count is 0.
+	time.Sleep(300 * time.Millisecond)
+	c, err := h.db.GetSessionObservationCount(sessionID)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if c != 0 {
+		t.Errorf("meta-tools should not produce observations; got count=%d", c)
+	}
+}
+
+// =========================================================================
+// Stop contract — client-side gate
+// =========================================================================
+
+// TestHookStop_SubprocessE2E_LowMessageSkipsExtractCall pins the client-side
+// gate from stop.go: if the transcript has fewer than 3 user messages, Stop
+// MUST NOT call /api/sessions/<id>/extract at all (the server gate would
+// also skip, but the cheap parse here avoids per-turn HTTP). Asserted by
+// checking the server's stderr does NOT show any extraction-attempt log
+// line attributable to this session.
+func TestHookStop_SubprocessE2E_LowMessageSkipsExtractCall(t *testing.T) {
+	h := setupHookE2E(t)
+
+	sessionID := "test-stop-lowmsg-" + time.Now().Format("150405.000000")
+	_ = h.runHook(t, "submit", HookInput{
+		SessionID: sessionID, CWD: "/tmp", Prompt: "init",
+	}).ExpectExit(t, 0)
+	testharness.WaitForCondition(t, 2*time.Second, "session ready",
+		func() bool { s, _ := h.db.GetSession(sessionID); return s != nil })
+
+	transcriptPath := writeTranscript(t, h.workDir, "low-msg.jsonl", 1,
+		"hi", "hello back")
+
+	res := h.runHook(t, "stop", HookInput{
+		SessionID:      sessionID,
+		TranscriptPath: transcriptPath,
+	})
+	res.ExpectExit(t, 0)
+
+	// Give async paths time to land — but assert what should be ABSENT.
+	time.Sleep(400 * time.Millisecond)
+	for _, banned := range []string{
+		fmt.Sprintf("extraction: skipping %s", sessionID),
+		fmt.Sprintf("extraction failed for %s", sessionID),
+		fmt.Sprintf("extraction: failed to mark %s", sessionID),
+	} {
+		if strings.Contains(h.srv.Stderr(), banned) {
+			t.Errorf("Stop client-side gate failed: server log shows %q for low-message transcript", banned)
+		}
+	}
+	sess, _ := h.db.GetSession(sessionID)
+	if sess == nil {
+		t.Fatal("session disappeared")
+	}
+	if sess.ExtractedAt != nil {
+		t.Errorf("extracted_at must remain NULL on low-message Stop; got %v", *sess.ExtractedAt)
+	}
+}
+
+// =========================================================================
+// SessionEnd contract — PR #4 regression invariant
+// =========================================================================
+
+// TestHookEnd_SubprocessE2E_PR4Invariant_LowContentDoesNotMark is the direct
+// regression test for the PR #4 bug class. SessionEnd always POSTs /extract
+// (belt-and-suspenders, end.go:13-22). With a low-content transcript, the
+// server-side gate in engine.extractSession MUST short-circuit BEFORE
+// MarkExtracted. If the gate accidentally ran AFTER the mark (the original
+// bug), extracted_at would get set despite no extraction happening, and a
+// later End with real content would idempotency-skip silently.
+//
+// Pinned signals:
+//   - Server stderr contains "extraction: skipping <id> ... (not marking)".
+//   - DB sessions.extracted_at remains NULL.
+//   - No "extraction failed for" log (we never reached the LLM path).
+func TestHookEnd_SubprocessE2E_PR4Invariant_LowContentDoesNotMark(t *testing.T) {
+	h := setupHookE2E(t)
+
+	sessionID := "test-end-pr4-" + time.Now().Format("150405.000000")
+	_ = h.runHook(t, "submit", HookInput{
+		SessionID: sessionID, CWD: "/tmp", Prompt: "init",
+	}).ExpectExit(t, 0)
+	testharness.WaitForCondition(t, 2*time.Second, "session ready",
+		func() bool { s, _ := h.db.GetSession(sessionID); return s != nil })
+
+	// 1 user message → fewer than 3 → gate skips, must not mark.
+	transcriptPath := writeTranscript(t, h.workDir, "low-content.jsonl", 1,
+		"hi", "hello back")
+
+	res := h.runHook(t, "end", HookInput{
+		SessionID:      sessionID,
+		TranscriptPath: transcriptPath,
+		Reason:         "test",
+	})
+	res.ExpectExit(t, 0)
+
+	// Wait for the async server goroutine to finish its skip-and-log path.
+	testharness.WaitForCondition(t, 3*time.Second,
+		"server should log gate-skip without marking",
+		func() bool {
+			return strings.Contains(h.srv.Stderr(),
+				fmt.Sprintf("extraction: skipping %s", sessionID))
+		})
+
+	if !strings.Contains(h.srv.Stderr(), "(not marking)") {
+		t.Errorf("server stderr missing '(not marking)' suffix:\n%s", h.srv.Stderr())
+	}
+	if strings.Contains(h.srv.Stderr(), fmt.Sprintf("extraction failed for %s", sessionID)) {
+		t.Errorf("gate did not skip — LLM extraction was attempted")
+	}
+
+	// The load-bearing assertion: extracted_at MUST be NULL.
+	sess, err := h.db.GetSession(sessionID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("session disappeared")
+	}
+	if sess.ExtractedAt != nil {
+		t.Errorf("PR #4 regression: gate-skipped extraction must NOT mark extracted_at; got %v", *sess.ExtractedAt)
+	}
+}
+
+// TestHookEnd_SubprocessE2E_PastThresholdReachesExtractor pins the positive
+// side of the gate: a transcript with >=3 user messages AND >=100 chars
+// condensed MUST let extraction proceed to the LLM call. In CI there is no
+// LLM, so we see "extraction failed for <id>" — which is the proof we want.
+// Without this assertion, a regression that flipped the gate to always-skip
+// would pass the PR-4 invariant test silently.
+func TestHookEnd_SubprocessE2E_PastThresholdReachesExtractor(t *testing.T) {
+	h := setupHookE2E(t)
+
+	sessionID := "test-end-past-" + time.Now().Format("150405.000000")
+	_ = h.runHook(t, "submit", HookInput{
+		SessionID: sessionID, CWD: "/tmp", Prompt: "init",
+	}).ExpectExit(t, 0)
+	testharness.WaitForCondition(t, 2*time.Second, "session ready",
+		func() bool { s, _ := h.db.GetSession(sessionID); return s != nil })
+
+	// 5 user messages × long content → well past both gate thresholds.
+	longUser := strings.Repeat("question about the architecture and design choices ", 3)
+	longAsst := strings.Repeat("here is the substantive answer with reasoning and context ", 3)
+	transcriptPath := writeTranscript(t, h.workDir, "past.jsonl", 5,
+		longUser, longAsst)
+
+	res := h.runHook(t, "end", HookInput{
+		SessionID:      sessionID,
+		TranscriptPath: transcriptPath,
+		Reason:         "test",
+	})
+	res.ExpectExit(t, 0)
+
+	testharness.WaitForCondition(t, 10*time.Second,
+		"past-threshold extraction should reach the LLM call and fail without one",
+		func() bool {
+			return strings.Contains(h.srv.Stderr(),
+				fmt.Sprintf("extraction failed for %s", sessionID))
+		})
+	// Negative check: must NOT have hit the gate-skip path.
+	if strings.Contains(h.srv.Stderr(),
+		fmt.Sprintf("extraction: skipping %s", sessionID)) {
+		t.Errorf("past-threshold transcript hit the gate-skip path:\n%s", h.srv.Stderr())
+	}
+}
+
+// =========================================================================
+// Full lifecycle — end-to-end pin
+// =========================================================================
+
+// TestHookLifecycle_SubprocessE2E_FullSession walks the realistic hook order
+// against a single hermetic DB and asserts the cumulative state: session
+// row exists, observations are recorded, extraction was attempted (and
+// failed gracefully without an LLM). This is the integration check the
+// per-handler tests cannot give on their own — it pins that the handlers
+// compose correctly across a session boundary.
+func TestHookLifecycle_SubprocessE2E_FullSession(t *testing.T) {
+	h := setupHookE2E(t)
+	sessionID := "test-lifecycle-" + time.Now().Format("150405.000000")
+
+	// SessionStart — agent receives context JSON.
+	startRes := h.runHook(t, "start", HookInput{
+		SessionID:     sessionID,
+		HookEventName: "SessionStart",
+	})
+	startRes.ExpectExit(t, 0)
+	var startOut SessionStartOutput
+	if err := json.Unmarshal([]byte(startRes.Stdout), &startOut); err != nil {
+		t.Fatalf("SessionStart JSON: %v\n%s", err, startRes.Stdout)
+	}
+
+	// 3 user prompts (init + 2 follow-ups).
+	for i := 0; i < 3; i++ {
+		h.runHook(t, "submit", HookInput{
+			SessionID: sessionID,
+			CWD:       "/tmp/test-project",
+			Prompt:    fmt.Sprintf("question %d about the architecture", i),
+		}).ExpectExit(t, 0)
+	}
+
+	// 2 tool invocations.
+	h.runHook(t, "tool", HookInput{
+		SessionID:    sessionID,
+		ToolName:     "Write",
+		ToolInput:    json.RawMessage(`{"file":"x"}`),
+		ToolResponse: json.RawMessage(`{"ok":true}`),
+	}).ExpectExit(t, 0)
+	h.runHook(t, "tool", HookInput{
+		SessionID:    sessionID,
+		ToolName:     "Read",
+		ToolInput:    json.RawMessage(`{"file":"y"}`),
+		ToolResponse: json.RawMessage(`{"ok":true}`),
+	}).ExpectExit(t, 0)
+
+	// Past-threshold transcript so Stop's gate passes.
+	longUser := strings.Repeat("substantive user content about the system design ", 3)
+	longAsst := strings.Repeat("thorough assistant response with code references ", 3)
+	transcriptPath := writeTranscript(t, h.workDir, "lifecycle.jsonl", 5,
+		longUser, longAsst)
+
+	h.runHook(t, "stop", HookInput{
+		SessionID:      sessionID,
+		TranscriptPath: transcriptPath,
+	}).ExpectExit(t, 0)
+	h.runHook(t, "end", HookInput{
+		SessionID:      sessionID,
+		TranscriptPath: transcriptPath,
+		Reason:         "test_complete",
+	}).ExpectExit(t, 0)
+
+	// State assertions.
+	testharness.WaitForCondition(t, 2*time.Second, "session row present",
+		func() bool { s, _ := h.db.GetSession(sessionID); return s != nil })
+
+	testharness.WaitForCondition(t, 2*time.Second, "observations recorded",
+		func() bool {
+			c, _ := h.db.GetSessionObservationCount(sessionID)
+			return c >= 2 // Write + Read; meta-tools would have been skipped if any were here
+		})
+
+	// Extraction was attempted at least once (Stop or End both POSTed /extract
+	// past the gate; either log line is fine).
+	testharness.WaitForCondition(t, 10*time.Second,
+		"extraction was attempted",
+		func() bool {
+			return strings.Contains(h.srv.Stderr(),
+				fmt.Sprintf("extraction failed for %s", sessionID))
+		})
+}

--- a/internal/store/migration_e2e_test.go
+++ b/internal/store/migration_e2e_test.go
@@ -1,0 +1,577 @@
+//go:build !windows
+
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/lazypower/continuity/internal/testharness"
+)
+
+// TestMigrationE2E_* tests pin the upgrade-path contract: a continuity DB
+// built at an OLD schema version must round-trip cleanly when the current
+// binary opens it — schema migrates to head, every seeded row survives with
+// new columns nullable-defaulted, and the HTTP read surface returns the same
+// data we put in.
+//
+// What this covers that the in-process tests in db_test.go do NOT:
+//
+//   - In-process tests build a fresh DB straight to v9 (via OpenMemory).
+//     They cannot exercise the incremental upgrade path a real user takes.
+//   - In-process tests cannot prove the BINARY boots against an old DB —
+//     migrations may succeed in isolation but the engine/server/embedder
+//     init that runs after Open could trip on an unexpected state.
+//   - The HTTP read surface is never exercised against a migrated DB in
+//     the in-process suite; a regression that broke /api/memories on
+//     freshly-migrated rows would slip through.
+//
+// Why this matters: the v6 and v9 migrations are full-table rebuilds
+// (CREATE _new + INSERT SELECT * + DROP + RENAME). SQLite's SELECT * uses
+// source column order — any drift between source and destination column
+// lists silently misaligns columns. Pre-existing column-count parity is
+// the only thing keeping current migrations safe; this suite locks it in.
+//
+// Tests run with `-tags noembed` to inherit the hermetic CI story from
+// the PR #27 / #28 e2e jobs.
+
+// buildDBAtVersion programmatically applies migrations [1..target] to a
+// fresh SQLite DB and returns its path. This is the time machine: we use it
+// to manufacture DB images that look like a user upgrading from an earlier
+// continuity release.
+//
+// Reuses the same migration code the production Open path uses. Avoiding
+// hand-rolled per-version schemas keeps drift impossible — if a future PR
+// changes how a migration runs, this helper reflects that change for free.
+func buildDBAtVersion(t *testing.T, dir string, target int) string {
+	t.Helper()
+	if target < 0 || target > len(migrations) {
+		t.Fatalf("buildDBAtVersion: invalid target %d (have %d migrations)", target, len(migrations))
+	}
+	path := filepath.Join(dir, "test.db")
+
+	sqlDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer sqlDB.Close()
+
+	if _, err := sqlDB.Exec(`PRAGMA foreign_keys=ON`); err != nil {
+		t.Fatalf("pragma: %v", err)
+	}
+	if _, err := sqlDB.Exec(`
+		CREATE TABLE IF NOT EXISTS schema_versions (
+			version     INTEGER PRIMARY KEY,
+			description TEXT NOT NULL,
+			applied_at  INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+		)
+	`); err != nil {
+		t.Fatalf("schema_versions: %v", err)
+	}
+
+	for _, m := range migrations {
+		if m.Version > target {
+			break
+		}
+		tx, err := sqlDB.Begin()
+		if err != nil {
+			t.Fatalf("begin v%d: %v", m.Version, err)
+		}
+		if _, err := tx.Exec(m.SQL); err != nil {
+			tx.Rollback()
+			t.Fatalf("apply v%d: %v", m.Version, err)
+		}
+		if _, err := tx.Exec(
+			"INSERT INTO schema_versions (version, description) VALUES (?, ?)",
+			m.Version, m.Description,
+		); err != nil {
+			tx.Rollback()
+			t.Fatalf("record v%d: %v", m.Version, err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit v%d: %v", m.Version, err)
+		}
+	}
+
+	return path
+}
+
+// seedV5Data inserts a representative mix of rows at v5-era schema (pre-
+// moments, pre-tone, pre-retraction). Every column visible at v5 gets a
+// distinguishable value so a column-misalignment bug post-migration shows
+// up as garbled data, not just a missing column.
+func seedV5Data(t *testing.T, dbPath string) {
+	t.Helper()
+	sqlDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("seedV5: %v", err)
+	}
+	defer sqlDB.Close()
+
+	now := time.Now().UnixMilli()
+	// One node per v5-valid category to exercise the CHECK constraint range.
+	cats := []string{"profile", "preferences", "entities", "events", "patterns", "cases"}
+	for i, cat := range cats {
+		uri := fmt.Sprintf("mem://user/%s/v5-seed-%d", cat, i)
+		_, err := sqlDB.Exec(`
+			INSERT INTO mem_nodes (
+				uri, node_type, category,
+				l0_abstract, l1_overview, l2_content,
+				mergeable, relevance, last_access, access_count,
+				source_session, created_at, updated_at
+			) VALUES (?, 'leaf', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, uri, cat,
+			fmt.Sprintf("L0 for %s", cat),
+			fmt.Sprintf("L1 overview for %s with enough length", cat),
+			fmt.Sprintf("L2 detail for %s", cat),
+			i%2, 0.75, now, i*3,
+			"v5-test-session", now, now)
+		if err != nil {
+			t.Fatalf("seed mem_node %s: %v", cat, err)
+		}
+	}
+
+	if _, err := sqlDB.Exec(`
+		INSERT INTO sessions (
+			session_id, project, started_at, ended_at, status,
+			message_count, tool_count, extracted_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, "v5-test-session", "/tmp/v5-project", now-3600000, now, "completed",
+		7, 3, now); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	if _, err := sqlDB.Exec(`
+		INSERT INTO observations (session_id, tool_name, tool_input, tool_response, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, "v5-test-session", "Write", `{"file":"v5.txt"}`, `{"ok":true}`, now); err != nil {
+		t.Fatalf("seed observation: %v", err)
+	}
+}
+
+// seedV7Tone adds a non-NULL tone value to the v5 session, exercising the
+// v7 ALTER TABLE ADD COLUMN tone path.
+func seedV7Tone(t *testing.T, dbPath string) {
+	t.Helper()
+	sqlDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("seedV7Tone: %v", err)
+	}
+	defer sqlDB.Close()
+	if _, err := sqlDB.Exec(`UPDATE sessions SET tone = ? WHERE session_id = ?`,
+		"focused", "v5-test-session"); err != nil {
+		t.Fatalf("set tone: %v", err)
+	}
+}
+
+// seedV6Moment adds a 'moments' row, exercising the v6-introduced category
+// and the CHECK constraint's downstream survival through v9's table rebuild.
+func seedV6Moment(t *testing.T, dbPath string) {
+	t.Helper()
+	sqlDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("seedV6Moment: %v", err)
+	}
+	defer sqlDB.Close()
+	now := time.Now().UnixMilli()
+	if _, err := sqlDB.Exec(`
+		INSERT INTO mem_nodes (
+			uri, node_type, category,
+			l0_abstract, l1_overview,
+			created_at, updated_at
+		) VALUES (?, 'leaf', 'moments', ?, ?, ?, ?)
+	`, "mem://user/moments/v6-first-gift",
+		"received a thoughtful gift from a mentor",
+		"Detailed body content about the moment with enough length.",
+		now, now); err != nil {
+		t.Fatalf("seed moment: %v", err)
+	}
+}
+
+// seedV8Tombstone adds a retracted (tombstoned) mem_node row, exercising
+// the v8 retraction columns and — critically — the v9 INSERT SELECT *
+// rebuild that must carry tombstone_at / tombstone_reason / superseded_by
+// across without misalignment.
+func seedV8Tombstone(t *testing.T, dbPath string) {
+	t.Helper()
+	sqlDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("seedV8Tombstone: %v", err)
+	}
+	defer sqlDB.Close()
+	now := time.Now().UnixMilli()
+	if _, err := sqlDB.Exec(`
+		INSERT INTO mem_nodes (
+			uri, node_type, category,
+			l0_abstract, l1_overview,
+			tombstoned_at, tombstone_reason, superseded_by,
+			created_at, updated_at
+		) VALUES (?, 'leaf', 'events', ?, ?, ?, ?, ?, ?, ?)
+	`, "mem://user/events/v8-retracted-row",
+		"PII captured by mistake",
+		"Original L1 with enough length to look real.",
+		now-1000, "captured operator's home address by accident",
+		"mem://user/events/v8-replacement",
+		now-3600000, now-1000); err != nil {
+		t.Fatalf("seed tombstone: %v", err)
+	}
+}
+
+// startSubprocessAgainstDB boots `continuity serve` against the given DB.
+// Returns the server's resolved URL, the env vector (for follow-up CLI
+// calls), and the live ServerProcess (caller registers Stop via t.Cleanup).
+func startSubprocessAgainstDB(t *testing.T, bin, workDir, dbPath string) (string, []string, *testharness.ServerProcess) {
+	t.Helper()
+	serverURL, env := testharness.HermeticEnv(t, workDir, dbPath, 0)
+	srv := testharness.StartServeProcess(t, bin, env)
+	testharness.WaitForReady(t, serverURL+"/api/health")
+	return serverURL, env, srv
+}
+
+// fetchMemoryByURI queries /api/memories?uri=<uri> and decodes the JSON
+// payload. Returns nil on 404 so callers can assert presence/absence.
+func fetchMemoryByURI(t *testing.T, serverURL, uri string) map[string]any {
+	t.Helper()
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(serverURL + "/api/memories?uri=" + uri)
+	if err != nil {
+		t.Fatalf("GET memories: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET memories %s = %s", uri, resp.Status)
+	}
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out
+}
+
+// assertSchemaV9 reopens the DB and asserts SchemaVersion() returns the
+// current head version (9). Inline so call sites read top-down.
+func assertSchemaV9(t *testing.T, dbPath string) {
+	t.Helper()
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen after migration: %v", err)
+	}
+	defer db.Close()
+	v, err := db.SchemaVersion()
+	if err != nil {
+		t.Fatalf("SchemaVersion: %v", err)
+	}
+	if v != 9 {
+		t.Errorf("schema_version = %d, want 9 (have %d migrations)", v, len(migrations))
+	}
+}
+
+// =========================================================================
+// Upgrade-path tests — one per historical starting point
+// =========================================================================
+
+// TestMigrationE2E_UpgradeFromV5_PreservesData covers the longest upgrade
+// chain we exercise: v5 (pre-moments) all the way to v9. Touches both
+// table rebuilds (v6 and v9). Seeds one row per v5-valid category so a
+// CHECK-constraint drift would surface.
+func TestMigrationE2E_UpgradeFromV5_PreservesData(t *testing.T) {
+	if testing.Short() {
+		t.Skip("migration e2e: skipped under -short")
+	}
+
+	bin := testharness.BuildContinuityBinary(t)
+	workDir := t.TempDir()
+
+	dbPath := buildDBAtVersion(t, workDir, 5)
+	seedV5Data(t, dbPath)
+
+	serverURL, _, srv := startSubprocessAgainstDB(t, bin, workDir, dbPath)
+	t.Cleanup(srv.Stop)
+
+	assertSchemaV9(t, dbPath)
+
+	// Every seeded category should still be reachable via the HTTP API
+	// (server boot + migrate + read path all functional end-to-end).
+	cats := []string{"profile", "preferences", "entities", "events", "patterns", "cases"}
+	for i, cat := range cats {
+		uri := fmt.Sprintf("mem://user/%s/v5-seed-%d", cat, i)
+		got := fetchMemoryByURI(t, serverURL, uri)
+		if got == nil {
+			t.Errorf("v5 seed %s lost after migration to v9", uri)
+			continue
+		}
+		if got["category"] != cat {
+			t.Errorf("seed %s category drift: got %v, want %s", uri, got["category"], cat)
+		}
+		if got["uri"] != uri {
+			t.Errorf("seed %s uri drift: got %v", uri, got["uri"])
+		}
+	}
+
+	// Re-open the DB and check the v8-added columns exist and default to
+	// NULL on rows that pre-existed them. SQLite ALTER TABLE ADD COLUMN
+	// defaults are NULL, and v9's INSERT SELECT * must preserve that.
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer db.Close()
+	var nullCount int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM mem_nodes
+		WHERE tombstoned_at IS NULL
+		  AND tombstone_reason IS NULL
+		  AND superseded_by IS NULL
+	`).Scan(&nullCount); err != nil {
+		t.Fatalf("count nulls: %v", err)
+	}
+	if nullCount != len(cats) {
+		t.Errorf("rows with NULL retraction columns = %d, want %d (one per seeded category)",
+			nullCount, len(cats))
+	}
+
+	// And the session/observations tables came through intact.
+	var msgCount int
+	if err := db.QueryRow(`SELECT message_count FROM sessions WHERE session_id = ?`,
+		"v5-test-session").Scan(&msgCount); err != nil {
+		t.Fatalf("session lost: %v", err)
+	}
+	if msgCount != 7 {
+		t.Errorf("session.message_count = %d, want 7", msgCount)
+	}
+	var obsCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM observations WHERE session_id = ?`,
+		"v5-test-session").Scan(&obsCount); err != nil {
+		t.Fatalf("obs count: %v", err)
+	}
+	if obsCount != 1 {
+		t.Errorf("observation count = %d, want 1", obsCount)
+	}
+}
+
+// TestMigrationE2E_UpgradeFromV7_PreservesToneAndMoments covers the user
+// path most likely to be live in the wild today: a DB built before
+// retraction landed (PR #20 / #19). Pins that the v7 tone column and a
+// v6 moments row survive the v8 ALTER and v9 rebuild.
+func TestMigrationE2E_UpgradeFromV7_PreservesToneAndMoments(t *testing.T) {
+	if testing.Short() {
+		t.Skip("migration e2e: skipped under -short")
+	}
+
+	bin := testharness.BuildContinuityBinary(t)
+	workDir := t.TempDir()
+
+	dbPath := buildDBAtVersion(t, workDir, 7)
+	seedV5Data(t, dbPath)
+	seedV6Moment(t, dbPath)
+	seedV7Tone(t, dbPath)
+
+	_, _, srv := startSubprocessAgainstDB(t, bin, workDir, dbPath)
+	t.Cleanup(srv.Stop)
+
+	assertSchemaV9(t, dbPath)
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer db.Close()
+
+	// Tone column survives v8 ALTER and v9 rebuild.
+	var tone sql.NullString
+	if err := db.QueryRow(`SELECT tone FROM sessions WHERE session_id = ?`,
+		"v5-test-session").Scan(&tone); err != nil {
+		t.Fatalf("read tone: %v", err)
+	}
+	if !tone.Valid || tone.String != "focused" {
+		t.Errorf("tone lost or mangled: got valid=%v string=%q", tone.Valid, tone.String)
+	}
+
+	// moments row still present with original category + content.
+	var (
+		category   string
+		l0Abstract sql.NullString
+	)
+	if err := db.QueryRow(`
+		SELECT category, l0_abstract FROM mem_nodes WHERE uri = ?
+	`, "mem://user/moments/v6-first-gift").Scan(&category, &l0Abstract); err != nil {
+		t.Fatalf("read moment: %v", err)
+	}
+	if category != "moments" {
+		t.Errorf("moments category lost: got %q", category)
+	}
+	if !l0Abstract.Valid || l0Abstract.String == "" {
+		t.Errorf("moment l0_abstract lost: %+v", l0Abstract)
+	}
+}
+
+// TestMigrationE2E_UpgradeFromV8_PreservesTombstones is the load-bearing
+// test for the v9 INSERT SELECT * rebuild. v8 ALTER TABLE added three
+// retraction columns AT THE END of the mem_nodes column list. v9's
+// CREATE TABLE mem_nodes_new declares those same three columns AT THE END
+// too. The rebuild relies on this column-order parity; a regression that
+// moved retraction columns in v9 (or added new columns in the wrong
+// position) would silently misalign data.
+//
+// We seed a tombstoned row with distinguishable values for every retraction
+// column, then verify each one survives the v9 rebuild byte-identical.
+func TestMigrationE2E_UpgradeFromV8_PreservesTombstones(t *testing.T) {
+	if testing.Short() {
+		t.Skip("migration e2e: skipped under -short")
+	}
+
+	bin := testharness.BuildContinuityBinary(t)
+	workDir := t.TempDir()
+
+	dbPath := buildDBAtVersion(t, workDir, 8)
+	seedV8Tombstone(t, dbPath)
+
+	_, _, srv := startSubprocessAgainstDB(t, bin, workDir, dbPath)
+	t.Cleanup(srv.Stop)
+
+	assertSchemaV9(t, dbPath)
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer db.Close()
+
+	var (
+		tombstonedAt    sql.NullInt64
+		tombstoneReason sql.NullString
+		supersededBy    sql.NullString
+	)
+	err = db.QueryRow(`
+		SELECT tombstoned_at, tombstone_reason, superseded_by
+		FROM mem_nodes WHERE uri = ?
+	`, "mem://user/events/v8-retracted-row").Scan(&tombstonedAt, &tombstoneReason, &supersededBy)
+	if err != nil {
+		t.Fatalf("read tombstone after v9: %v", err)
+	}
+	if !tombstonedAt.Valid || tombstonedAt.Int64 == 0 {
+		t.Error("tombstoned_at lost through v9 rebuild")
+	}
+	if !tombstoneReason.Valid || tombstoneReason.String != "captured operator's home address by accident" {
+		t.Errorf("tombstone_reason mangled: %+v", tombstoneReason)
+	}
+	if !supersededBy.Valid || supersededBy.String != "mem://user/events/v8-replacement" {
+		t.Errorf("superseded_by mangled: %+v", supersededBy)
+	}
+
+	// The v9 CHECK constraint additions (feedback, reference) must be live.
+	// If v9 didn't run, this insert would be rejected.
+	_, err = db.Exec(`
+		INSERT INTO mem_nodes (uri, node_type, category, created_at, updated_at)
+		VALUES ('mem://user/feedback/post-v9', 'leaf', 'feedback', 1000, 1000)
+	`)
+	if err != nil {
+		t.Errorf("v9 did not run on this DB: feedback category still rejected: %v", err)
+	}
+}
+
+// TestMigrationE2E_FreshInstallReachesV9 pins the cold-start path: no
+// pre-existing DB, the binary creates one and migrates straight to v9.
+// Covers the new-user install case.
+func TestMigrationE2E_FreshInstallReachesV9(t *testing.T) {
+	if testing.Short() {
+		t.Skip("migration e2e: skipped under -short")
+	}
+
+	bin := testharness.BuildContinuityBinary(t)
+	workDir := t.TempDir()
+	dbPath := filepath.Join(workDir, "fresh.db")
+
+	_, _, srv := startSubprocessAgainstDB(t, bin, workDir, dbPath)
+	t.Cleanup(srv.Stop)
+
+	assertSchemaV9(t, dbPath)
+}
+
+// TestMigrationE2E_IdempotentSecondBoot pins that booting against an
+// already-migrated DB is a no-op (no errors, schema stays at head).
+// The in-process TestMigrationsIdempotent covers the migrate() call path
+// in isolation; this covers the same invariant through the binary's full
+// boot path, where a regression that re-ran migrations could destroy data.
+func TestMigrationE2E_IdempotentSecondBoot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("migration e2e: skipped under -short")
+	}
+
+	bin := testharness.BuildContinuityBinary(t)
+	workDir := t.TempDir()
+
+	// First boot — fresh DB → v9.
+	dbPath := filepath.Join(workDir, "twice.db")
+	_, _, srv1 := startSubprocessAgainstDB(t, bin, workDir, dbPath)
+	assertSchemaV9(t, dbPath)
+
+	// Seed a marker row so a destructive re-migration would be visible.
+	{
+		db, err := Open(dbPath)
+		if err != nil {
+			srv1.Stop()
+			t.Fatal(err)
+		}
+		_, err = db.Exec(`
+			INSERT INTO mem_nodes (uri, node_type, category, l0_abstract, created_at, updated_at)
+			VALUES ('mem://user/events/idempotency-marker', 'leaf', 'events', 'survives second boot', 1000, 1000)
+		`)
+		db.Close()
+		if err != nil {
+			srv1.Stop()
+			t.Fatal(err)
+		}
+	}
+	srv1.Stop()
+
+	// Second boot — same DB, fresh subprocess.
+	workDir2 := t.TempDir() // for HOME
+	_, env := testharness.HermeticEnv(t, workDir2, dbPath, 0)
+	srv2 := testharness.StartServeProcess(t, bin, env)
+	t.Cleanup(srv2.Stop)
+	testharness.WaitForReady(t, fmt.Sprintf("http://127.0.0.1:%s/api/health",
+		envGet(env, "CONTINUITY_PORT")))
+
+	assertSchemaV9(t, dbPath)
+
+	// Marker row must still be present — a re-run of v6 or v9 (full table
+	// rebuilds) would either fail (table already exists in their CREATE
+	// statements) or, worse, wipe rows.
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var marker string
+	if err := db.QueryRow(`SELECT l0_abstract FROM mem_nodes WHERE uri = ?`,
+		"mem://user/events/idempotency-marker").Scan(&marker); err != nil {
+		t.Fatalf("marker row lost on second boot: %v", err)
+	}
+	if marker != "survives second boot" {
+		t.Errorf("marker mangled: %q", marker)
+	}
+}
+
+// envGet pulls a single KEY=VAL out of an env vector (the env slice returned
+// by testharness.HermeticEnv). Used so the idempotency test can recover the
+// kernel-allocated port for its second-boot wait.
+func envGet(env []string, key string) string {
+	prefix := key + "="
+	for _, kv := range env {
+		if len(kv) > len(prefix) && kv[:len(prefix)] == prefix {
+			return kv[len(prefix):]
+		}
+	}
+	return ""
+}

--- a/internal/testharness/harness.go
+++ b/internal/testharness/harness.go
@@ -1,0 +1,313 @@
+// Package testharness provides shared scaffolding for subprocess end-to-end
+// tests. It is NOT a _test.go-only package — exposing it as a regular package
+// lets every test package import it (Go's test-package rules forbid importing
+// _test files across package boundaries).
+//
+// Build a binary, start `continuity serve`, wait for /api/health, invoke the
+// CLI as a real child process, capture stdout/stderr/exit. The same harness
+// powers internal/cli/retract_e2e_test.go and internal/hooks/hooks_e2e_test.go;
+// extending it for migration / install / concurrency tests should be cheap.
+package testharness
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// BuildContinuityBinary compiles cmd/continuity with the noembed build tag so
+// the binary builds without the UI assets `make ui` bakes in. Returns the
+// absolute path to the built binary.
+func BuildContinuityBinary(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	binName := "continuity"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	binPath := filepath.Join(binDir, binName)
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("findRepoRoot: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "build", "-tags", "noembed", "-o", binPath, "./cmd/continuity")
+	cmd.Dir = repoRoot
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("go build: %v\n%s", err, stderr.String())
+	}
+	return binPath
+}
+
+// findRepoRoot walks up from the test cwd until it finds a go.mod file.
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("go.mod not found in any parent of test cwd")
+		}
+		dir = parent
+	}
+}
+
+// FreeTCPPort asks the kernel for a free TCP port, releases the listener, and
+// returns the port. There is a small race window between Close() and the
+// subprocess Listen — acceptable for tests.
+func FreeTCPPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("FreeTCPPort: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	if err := l.Close(); err != nil {
+		t.Fatalf("FreeTCPPort close: %v", err)
+	}
+	return port
+}
+
+// ServerProcess wraps a running `continuity serve` child process. Stderr is
+// captured to a buffer so tests can inspect server-side log lines (the server
+// uses Go's log package which writes to stderr).
+type ServerProcess struct {
+	cmd       *exec.Cmd
+	stderrBuf *bytes.Buffer
+	stopped   bool
+}
+
+// StartServeProcess spawns `continuity serve` with the given env. Callers
+// MUST call WaitForReady before issuing CLI commands and SHOULD register
+// Stop with t.Cleanup.
+func StartServeProcess(t *testing.T, bin string, env []string) *ServerProcess {
+	t.Helper()
+	cmd := exec.Command(bin, "serve")
+	cmd.Env = env
+
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
+	cmd.Stdout = io.Discard
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start serve: %v", err)
+	}
+	return &ServerProcess{cmd: cmd, stderrBuf: stderr}
+}
+
+// Stderr returns the server's accumulated stderr. Safe to call repeatedly;
+// reflects whatever the server has logged up to the moment of the call.
+func (s *ServerProcess) Stderr() string { return s.stderrBuf.String() }
+
+// Stop sends SIGTERM to the server's process group and waits up to 5 seconds
+// for a graceful exit. SIGKILL if it overshoots.
+func (s *ServerProcess) Stop() {
+	if s.stopped {
+		return
+	}
+	s.stopped = true
+
+	if s.cmd.Process != nil {
+		_ = syscall.Kill(-s.cmd.Process.Pid, syscall.SIGTERM)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.cmd.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		if s.cmd.Process != nil {
+			_ = syscall.Kill(-s.cmd.Process.Pid, syscall.SIGKILL)
+		}
+		<-done
+	}
+}
+
+// WaitForReady polls /api/health up to 10 seconds; t.Fatal if the server
+// never responds 200.
+func WaitForReady(t *testing.T, healthURL string) {
+	t.Helper()
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(healthURL)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("server did not become ready at %s within 10s", healthURL)
+}
+
+// WaitForCondition polls check() until it returns true or the deadline
+// elapses. msg is printed via t.Fatalf on timeout. Used to wait for async
+// server-side side effects (extraction goroutines, DB writes).
+func WaitForCondition(t *testing.T, timeout time.Duration, msg string, check func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if check() {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("waitForCondition timeout: %s", msg)
+}
+
+// CLIResult is the outcome of one CLI invocation: captured channels and exit
+// code. Methods chain so call sites read top-down.
+type CLIResult struct {
+	Args     []string
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// RunCLI executes the binary with the given args + env, capturing both
+// channels and the exit code. Caller asserts via ExpectExit; non-zero exits
+// do not Fatal here.
+func RunCLI(t *testing.T, bin string, env []string, args ...string) *CLIResult {
+	t.Helper()
+	return RunCLIWithStdin(t, bin, env, "", args...)
+}
+
+// RunCLIWithStdin is RunCLI with a stdin payload. The hook subprocess tests
+// use this to feed the JSON Claude Code would normally pipe to a hook.
+func RunCLIWithStdin(t *testing.T, bin string, env []string, stdin string, args ...string) *CLIResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = env
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	res := &CLIResult{
+		Args:   args,
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		res.ExitCode = exitErr.ExitCode()
+	} else if err != nil {
+		t.Fatalf("RunCLI: launch failed for args %v: %v\nstderr:\n%s", args, err, stderr.String())
+	}
+	return res
+}
+
+// ExpectExit asserts the captured exit code matches want.
+func (r *CLIResult) ExpectExit(t *testing.T, want int) *CLIResult {
+	t.Helper()
+	if r.ExitCode != want {
+		t.Errorf("args %v: exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s",
+			r.Args, r.ExitCode, want, r.Stdout, r.Stderr)
+	}
+	return r
+}
+
+// ExpectStdoutContains asserts stdout contains every fragment passed.
+func (r *CLIResult) ExpectStdoutContains(t *testing.T, frags ...string) *CLIResult {
+	t.Helper()
+	for _, f := range frags {
+		if !strings.Contains(r.Stdout, f) {
+			t.Errorf("args %v: stdout missing %q\nstdout:\n%s", r.Args, f, r.Stdout)
+		}
+	}
+	return r
+}
+
+// ExpectStderrContains asserts stderr contains every fragment passed.
+func (r *CLIResult) ExpectStderrContains(t *testing.T, frags ...string) *CLIResult {
+	t.Helper()
+	for _, f := range frags {
+		if !strings.Contains(r.Stderr, f) {
+			t.Errorf("args %v: stderr missing %q\nstderr:\n%s", r.Args, f, r.Stderr)
+		}
+	}
+	return r
+}
+
+// ExpectStdoutAbsent asserts stdout contains NONE of the given fragments.
+func (r *CLIResult) ExpectStdoutAbsent(t *testing.T, frags ...string) *CLIResult {
+	t.Helper()
+	for _, f := range frags {
+		if strings.Contains(r.Stdout, f) {
+			t.Errorf("args %v: stdout must NOT contain %q\nstdout:\n%s", r.Args, f, r.Stdout)
+		}
+	}
+	return r
+}
+
+// ExpectStderrAbsent asserts stderr contains NONE of the given fragments.
+func (r *CLIResult) ExpectStderrAbsent(t *testing.T, frags ...string) *CLIResult {
+	t.Helper()
+	for _, f := range frags {
+		if strings.Contains(r.Stderr, f) {
+			t.Errorf("args %v: stderr must NOT contain %q\nstderr:\n%s", r.Args, f, r.Stderr)
+		}
+	}
+	return r
+}
+
+// HermeticEnv is the canonical env-var set used by every subprocess test:
+// hermetic DB, hermetic HOME, kernel-allocated port, TFIDF forced (no Ollama
+// probe), bound to loopback, CONTINUITY_URL pointed at the chosen port.
+//
+// Returns the resolved server URL and the env slice ready to pass to
+// StartServeProcess / RunCLI. The DB path is filled in via dbPath; the rest
+// of workDir is left to the caller for any per-test fixtures.
+func HermeticEnv(t *testing.T, workDir string, dbPath string, port int) (string, []string) {
+	t.Helper()
+	if port == 0 {
+		port = FreeTCPPort(t)
+	}
+	homeDir := filepath.Join(workDir, "home")
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		t.Fatalf("mkdir HOME: %v", err)
+	}
+	serverURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	env := append(os.Environ(),
+		"HOME="+homeDir,
+		"CONTINUITY_DB="+dbPath,
+		"CONTINUITY_PORT="+strconv.Itoa(port),
+		"CONTINUITY_BIND=127.0.0.1",
+		"CONTINUITY_EMBEDDER=tfidf",
+		"CONTINUITY_URL="+serverURL,
+	)
+	return serverURL, env
+}


### PR DESCRIPTION
> **Note:** Replaces #28, which GitHub auto-closed when its base branch (`feat/issue-21-subprocess-e2e`, #27's head) was deleted on merge. Same two commits, cleanly rebased onto `main` — #26 and #27 have both landed, so this no longer stacks on anything. Items previously "blocked until #26 merges" are now unblocked.

> **Update:** Now also folds in #29 (migration upgrade-path subprocess tests, roadmap ②), which was stacked on this branch — its single commit sits directly on top of the hook-handler commits, so item ① and item ② land together rather than as two sequential merges. #29 is recorded as merged.

## Summary

Follow-up to #21. Closes the highest-leverage gap from #27's planning doc: subprocess tests for the five Claude Code hook handlers (`continuity hook start | submit | tool | stop | end`), plus a PR #4 regression invariant that would have caught the silent-extraction-lock-out bug at the test layer instead of via manual review.

This is item ① in the testing-hardening roadmap. Picked by the rubric:
- **Silent-failure class:** PR #4 (extracted_at set despite gate-skip → subsequent extractions silently no-op) was exactly this surface.
- **Agent-facing contract:** hooks ARE the Claude Code integration. Exit codes, stdout JSON shape (SessionStart), stderr channel are all read by Claude itself.
- **Harness reuse:** ~80% from #27.

## Ships

### Commit 1 — `internal/testharness` (harness extraction)

PR #27 inlined the subprocess plumbing in `retract_e2e_test.go`. With this PR's second consumer, that inlining becomes structural debt. Extracted to a non-test package so any test can import:

| Helper | Purpose |
|---|---|
| `BuildContinuityBinary(t)` | `go build -tags noembed` into a tempdir |
| `FreeTCPPort(t)` | kernel-allocated, race-acceptable |
| `StartServeProcess(t, bin, env)` + `ServerProcess.Stop()` / `.Stderr()` | child process with captured stderr for log-line assertions |
| `WaitForReady(t, url)` | poll `/api/health` |
| `WaitForCondition(t, timeout, msg, check)` | generic poll-until-true, needed for async server-side state |
| `CLIResult` + `RunCLI` / `RunCLIWithStdin` | hook tests need stdin; retract tests don't |
| `ExpectExit` / `ExpectStdoutContains` / `ExpectStderrContains` / `ExpectStdoutAbsent` / `ExpectStderrAbsent` | chainable assertions |
| `HermeticEnv(t, workDir, dbPath, port)` | canonical env: `CONTINUITY_DB` / `PORT` / `BIND` / `EMBEDDER=tfidf`, `HOME` to tempdir, `CONTINUITY_URL` wired |

`testharness` is intentionally a non-test package — Go forbids importing `_test.go` files across boundaries. The `"testing"` import in a non-test package is paid intentionally; it's only ever consumed by test code.

PR #27's retract test refactors to use the new package: 471 lines → 217 lines, logic unchanged. The retract-specific `seedTFIDFCorpus` stays inline since it's about the retract scenario's TFIDF vocabulary needs, not a general harness concern.

### Commit 2 — 11 hook subprocess tests

| Test | Pins |
|---|---|
| `TestHookStart_…_WritesContextJSON` | stdout is valid `SessionStartOutput` JSON, exit 0 |
| `TestHookStart_…_ServerDownDegradesGracefully` | server killed before fire; stdout still valid JSON (empty context), exit 0 |
| `TestHookSubmit_…_CreatesSession` | `/api/sessions/init` POST landed; DB row present |
| `TestHookSubmit_…_InternalSentinelSkipsInit` | `[continuity-internal]` prompts MUST NOT create a session (anti-recursion) |
| `TestHookSubmit_…_SignalTriggerReachesServer` | `remember this` etc. trigger fire-and-forget `/signal`; server log proves the call landed |
| `TestHookTool_…_RecordsObservation` | observation count ≥ 1 |
| `TestHookTool_…_SkipsMetaTools` | TodoRead, TodoWrite, Thinking, TaskList, TaskCreate, TaskGet, TaskUpdate must produce zero observations |
| `TestHookStop_…_LowMessageSkipsExtractCall` | Stop's **client-side** gate skips `/extract` entirely on <3-msg transcripts (avoid per-turn round-trip) |
| `TestHookEnd_…_PR4Invariant_LowContentDoesNotMark` | **the PR #4 regression test** — End ALWAYS POSTs `/extract`; server-side gate MUST short-circuit before `MarkExtracted` |
| `TestHookEnd_…_PastThresholdReachesExtractor` | counterpart positive: past-threshold transcript MUST reach LLM (LLM fails in CI; log line proves the gate let it through) — prevents a regression flipping gate-to-always-skip from passing the PR-4 invariant silently |
| `TestHookLifecycle_…_FullSession` | Start → 3× Submit → 2× Tool → Stop → End against one hermetic DB; cumulative state pinned |

### Why TFIDF / clean-room CI / hermetic env

Same story as #27: every test uses `CONTINUITY_EMBEDDER=tfidf` so the Ollama probe is bypassed entirely. Per-test `HOME` and DB land in a tempdir; per-test port is kernel-allocated. Build tag `!windows` because the SIGTERM-process-group shutdown pattern is Unix-specific.

### Sanity check

During development I inverted the load-bearing assertion in `TestHookEnd_…_PR4Invariant_LowContentDoesNotMark` (changed `if sess.ExtractedAt != nil` to `if sess.ExtractedAt == nil`), confirmed the test fails with the right error message ("must NOT mark extracted_at; got NULL"), then restored. The PR-4 contract assertion is real.

## CI

This PR inherits the `e2e` job that PR #27 added to `.github/workflows/ci.yml`. The job runs:

```
go test -tags noembed -v -count=1 -timeout 5m -run 'E2E|Subprocess' ./internal/...
```

Both `TestRetract_SubprocessE2E_TFIDF` (#27) and all 11 `TestHook*_SubprocessE2E_*` tests in this PR match the filter; no CI changes needed in this PR's diff.

## Test plan

- [x] `go test -tags noembed -count=1 ./internal/...` clean — all 11 hook tests + retract test + existing in-process tests green
- [x] `go vet -tags noembed ./...` clean
- [x] `go test -tags noembed -run 'E2E|Subprocess' ./internal/...` — CI filter dry-run; both packages report tests; the rest "no tests to run"
- [x] PR #4 assertion sanity check (inverted-then-restored)
- [x] Rebased onto `main` post-#26/#27 merge; full `go build ./...` + `go test ./...` green locally
- [ ] CI: e2e job green on a fresh clone (no Ollama, no UI build)

## Out of scope / next opportunities

- **②  migration upgrade-path test** — strongest next pick (silent-failure class, but lower agent-facing rank); see PR #29
- **③  concurrency under subprocess** — multiple hooks racing on the SQLite WAL; deserves its own PR because timing-flake debugging shouldn't block contract tests
- **④  service install/uninstall** — when PR #13-class brittle-path bugs bite, this is the test; platform-specific
- **⑤  TFIDF corpus-shift regression** — landed in #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

