### PR TITLE
chore: bump GitHub Actions to current majors (off deprecated Node 20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
 
       - name: Build UI (required for embed)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -36,9 +36,9 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
 
@@ -48,13 +48,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/migration-fixtures.yml
+++ b/.github/workflows/migration-fixtures.yml
@@ -25,9 +25,9 @@ jobs:
       # gh release download authenticates with the workflow token.
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,13 @@ jobs:
           - goos: windows
             goarch: amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -59,7 +59,7 @@ jobs:
           go build -ldflags "${LDFLAGS}" -o "continuity-${{ matrix.goos }}-${{ matrix.goarch }}${EXT}" ./cmd/continuity
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: continuity-${{ matrix.goos }}-${{ matrix.goarch }}
           # Anchor to the per-matrix binary name (with optional .exe for windows).
@@ -73,13 +73,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: artifacts
           merge-multiple: true
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: artifacts/continuity-*


### PR DESCRIPTION
Quick maintenance — no ticket. The pinned action versions target Node 20, which the runners now force onto Node 24 with deprecation warnings (visible in the v0.6.0 release run). Bumps each off the deprecated runtime.

| action | was | now |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-go | v5 | v6 |
| actions/setup-node | v4 | v6 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | **v7** (not v8 — see below) |
| softprops/action-gh-release | v2 | v3 |

**download-artifact held at v7 on purpose.** v8 makes artifact digest mismatches **fail by default** (was a warning), moved to ESM, and changed decompress behavior. `release.yml`'s artifact path only runs on a tag, so it's untestable in this PR — v7 is already Node-24-by-default (`runs.using: node24`) and avoids v8's new fail-by-default behavior. Best of both.

**Verified, not assumed:** pulled each action's `action.yml` at the target tag and confirmed every input we use still exists (`name`/`path`/`merge-multiple`/`files`/`generate_release_notes`/`go-version`/`node-version`), and read the major-bump release notes for behavioral breaks (which is how the v8 digest-default surfaced). upload/download-artifact both on the v7 line so the artifact backend stays consistent.

**Validation:** `ci.yml` is exercised by this PR's run. `release.yml`'s artifact path runs only on a tag — inputs unchanged, runtime now Node 24; worth a glance on the next release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)