### PR TITLE
Surface real validation errors on write endpoints (#35)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -291,7 +291,7 @@ func (e *Engine) Remember(ctx context.Context, input RememberInput) (string, boo
 	// silently overwriting the tombstone. The agent must choose a different slug
 	// or, if the retraction was wrong, restore via SQL (the friction-bearing path).
 	if existing != nil && existing.IsRetracted() {
-		return "", false, fmt.Errorf("uri %s is retracted; choose a different slug", requestedURI)
+		return "", false, validationErrorf("uri %s is retracted; choose a different slug", requestedURI)
 	}
 
 	// Dedup against retracted memories. Retracted memories must still participate

--- a/internal/engine/retract.go
+++ b/internal/engine/retract.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -29,14 +30,23 @@ type RetractInput struct {
 // as a marker — no silent erasure. See issue #12 / RFC for the contract.
 func (e *Engine) Retract(ctx context.Context, input RetractInput) (bool, error) {
 	if !strings.HasPrefix(input.URI, "mem://") {
-		return false, fmt.Errorf("invalid URI %q: must start with mem://", input.URI)
+		return false, validationErrorf("invalid URI %q: must start with mem://", input.URI)
 	}
 	if input.SupersededBy != "" && !strings.HasPrefix(input.SupersededBy, "mem://") {
-		return false, fmt.Errorf("invalid superseded_by URI %q: must start with mem://", input.SupersededBy)
+		return false, validationErrorf("invalid superseded_by URI %q: must start with mem://", input.SupersededBy)
 	}
 
 	newly, err := e.DB.RetractNode(input.URI, input.Reason, input.SupersededBy)
 	if err != nil {
+		// Store-level domain rejections (memory not found, directory node,
+		// system-owned URI, self-supersession, missing successor) are actionable
+		// user input — re-wrap as ValidationError so the HTTP boundary surfaces
+		// the real reason as 400. Internal failures (DB errors) stay plain and
+		// generic. store cannot import engine, hence the cross-layer re-wrap.
+		var rve *store.RetractValidationError
+		if errors.As(err, &rve) {
+			return false, validationErrorf("%s", rve.Message)
+		}
 		return false, err
 	}
 

--- a/internal/engine/validate.go
+++ b/internal/engine/validate.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"fmt"
 	"log"
 	"strings"
 	"unicode"
@@ -58,19 +57,19 @@ func sanitizeURIHint(hint string) string {
 func validateCandidate(c memoryCandidate) (memoryCandidate, error) {
 	// Category must be valid
 	if !validCategories[c.Category] {
-		return c, fmt.Errorf("invalid category %q", c.Category)
+		return c, validationErrorf("invalid category %q", c.Category)
 	}
 
 	// Sanitize and validate URI hint
 	c.URIHint = sanitizeURIHint(c.URIHint)
 	if c.URIHint == "" {
-		return c, fmt.Errorf("empty URI hint after sanitization")
+		return c, validationErrorf("empty URI hint after sanitization")
 	}
 
 	// L0 is required
 	c.L0 = strings.TrimSpace(c.L0)
 	if c.L0 == "" {
-		return c, fmt.Errorf("empty L0 abstract")
+		return c, validationErrorf("empty L0 abstract")
 	}
 
 	// Trim all content tiers
@@ -79,7 +78,7 @@ func validateCandidate(c memoryCandidate) (memoryCandidate, error) {
 
 	// L1 must be non-trivial (it's the primary context injection content)
 	if len(c.L1) < minL1Chars {
-		return c, fmt.Errorf("L1 too short (%d chars, min %d)", len(c.L1), minL1Chars)
+		return c, validationErrorf("L1 too short (%d chars, min %d)", len(c.L1), minL1Chars)
 	}
 
 	// Size ceilings — truncate rather than reject, but log it

--- a/internal/engine/validation_error.go
+++ b/internal/engine/validation_error.go
@@ -1,0 +1,41 @@
+package engine
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ValidationError signals that a write was rejected because of bad user/agent
+// input — an invalid category, a missing required field, a malformed URI, a
+// content tier outside its size bounds, and so on. These messages are safe to
+// surface verbatim to the client: they describe the caller's own input, not
+// internal state (SQL, filesystem paths, etc.).
+//
+// Internal failures (DB errors, embed failures, upsert collisions) are NOT
+// wrapped in ValidationError and stay generic at the HTTP boundary.
+//
+// Mirrors the RetractedMatchError pattern: a typed error the boundary layer
+// classifies via IsValidationError.
+type ValidationError struct {
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return e.Message
+}
+
+// validationErrorf constructs a *ValidationError with a formatted message.
+func validationErrorf(format string, args ...any) error {
+	return &ValidationError{Message: fmt.Sprintf(format, args...)}
+}
+
+// IsValidationError reports whether err (or anything it wraps) is a
+// *ValidationError, returning its client-safe message when so. The boundary
+// layer surfaces this message with HTTP 400; everything else stays generic.
+func IsValidationError(err error) (bool, string) {
+	var ve *ValidationError
+	if errors.As(err, &ve) {
+		return true, ve.Message
+	}
+	return false, ""
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -324,6 +324,13 @@ func (s *Server) handleRemember(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
+		// Genuine user-input validation errors (bad category, missing field,
+		// out-of-bounds tier, retracted slug collision) are safe to surface
+		// verbatim. Internal failures stay generic — logged, not leaked.
+		if isValidation, msg := engine.IsValidationError(err); isValidation {
+			jsonError(w, msg, http.StatusBadRequest)
+			return
+		}
 		log.Printf("remember: %v", err)
 		jsonError(w, "failed to store memory", http.StatusBadRequest)
 		return
@@ -376,6 +383,10 @@ func (s *Server) handleRetract(w http.ResponseWriter, r *http.Request) {
 		SupersededBy: req.SupersededBy,
 	})
 	if err != nil {
+		if isValidation, msg := engine.IsValidationError(err); isValidation {
+			jsonError(w, msg, http.StatusBadRequest)
+			return
+		}
 		log.Printf("retract: %v", err)
 		jsonError(w, "failed to retract memory", http.StatusBadRequest)
 		return

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -185,6 +186,204 @@ func testServerWithEngine(t *testing.T) *Server {
 	t.Cleanup(func() { db.Close() })
 	eng := engine.New(db, nil)
 	return New(db, eng, "test-version")
+}
+
+// TestRememberRouteInvalidCategorySurfacesReason is the regression for issue
+// #35: the remember handler used to collapse genuine validation errors into
+// the generic "failed to store memory" string, hiding the actionable reason
+// (e.g. an unknown category) server-side only. The reason must now reach the
+// client verbatim with a 400.
+func TestRememberRouteInvalidCategorySurfacesReason(t *testing.T) {
+	srv := testServerWithEngine(t)
+
+	body := `{"category":"feeback","name":"x","summary":"typo'd category","body":"body content long enough to clear the minimum length validation bar."}`
+	req := newTestRequest("POST", "/api/memories", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	got := resp["error"]
+	if got == "failed to store memory" {
+		t.Fatalf("client got the generic message, want the real validation reason; body: %s", w.Body.String())
+	}
+	if !strings.Contains(got, "invalid category") || !strings.Contains(got, "feeback") {
+		t.Errorf("error = %q, want it to name the bad category", got)
+	}
+}
+
+// TestRememberRouteRetractedMatchStillSequestered verifies the issue #35 change
+// did not disturb the retracted-match 409 path: a write that semantically
+// collides with a retracted memory must still get a 409 with matched URIs and
+// NO retraction reasons, not a 400 validation message.
+func TestRememberRouteRetractedMatchStillSequestered(t *testing.T) {
+	srv := testServerWithEngine(t)
+
+	// Mirror the engine-level regression ordering (retract_test.go): seed, then
+	// build the TFIDF embedder over the corpus, embed the node so the vector
+	// space has signal, and only then retract. This makes the
+	// dedup-against-retracted gate fire deterministically.
+	ctx := context.Background()
+	const l0 = "operator's mother's maiden name discussed in context"
+	uri, _, err := srv.engine.Remember(ctx, engine.RememberInput{
+		Category: "events", Name: "old-pii-event",
+		Summary: l0,
+		Body:    "Memory body content with more than enough length to pass validation thresholds.",
+		AcknowledgeRetracted: true,
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	embedder, err := engine.NewTFIDFEmbedder(srv.db, 512)
+	if err != nil {
+		t.Fatalf("embedder: %v", err)
+	}
+	srv.engine.SetEmbedder(embedder)
+	n, _ := srv.db.GetNodeByURI(uri)
+	if err := srv.engine.EmbedNode(ctx, n); err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if _, err := srv.db.RetractNode(uri, "PII captured accidentally", ""); err != nil {
+		t.Fatalf("retract: %v", err)
+	}
+
+	body := `{"category":"events","name":"new-event","summary":"operator's mother's maiden name from earlier discussion","body":"Different body content with more than enough length to pass validation thresholds."}`
+	req := newTestRequest("POST", "/api/memories", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d (409 retracted-match); body: %s", w.Code, http.StatusConflict, w.Body.String())
+	}
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != "matches_retracted" {
+		t.Errorf("status = %v, want matches_retracted", resp["status"])
+	}
+	if _, ok := resp["matched_uris"]; !ok {
+		t.Errorf("response missing matched_uris: %s", w.Body.String())
+	}
+	// The retraction reason must stay sequestered — it must not appear anywhere.
+	if strings.Contains(w.Body.String(), "PII") {
+		t.Errorf("retraction reason leaked into 409 response: %s", w.Body.String())
+	}
+}
+
+// TestRetractRouteInvalidURISurfacesReason confirms the same classification was
+// applied to the other write handler: a malformed URI is user input and its
+// reason must reach the client, not be collapsed to "failed to retract memory".
+func TestRetractRouteInvalidURISurfacesReason(t *testing.T) {
+	srv := testServerWithEngine(t)
+
+	body := `{"uri":"not-a-mem-uri","reason":"cleanup"}`
+	req := newTestRequest("POST", "/api/memories/retract", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	got := resp["error"]
+	if got == "failed to retract memory" {
+		t.Fatalf("client got the generic message, want the real validation reason; body: %s", w.Body.String())
+	}
+	if !strings.Contains(got, "must start with mem://") {
+		t.Errorf("error = %q, want it to explain the mem:// requirement", got)
+	}
+}
+
+// TestRememberRouteInternalErrorStaysGeneric documents that a non-validation
+// failure (here: a direct URI collision with a retracted tombstone is a
+// validation error, but a true internal error path) is NOT surfaced verbatim.
+// We exercise the closest practical internal-ish path: a retracted-slug
+// collision is classified as validation (safe to surface), while everything
+// the engine does not tag as ValidationError keeps the generic message. This
+// asserts the negative: the generic message is reachable and unchanged.
+func TestRememberRouteValidationVsGenericClassification(t *testing.T) {
+	// Sanity-check the classifier contract the handler relies on: a plain
+	// (non-ValidationError) error must NOT be reported as a validation error,
+	// so the handler falls through to the generic message + server log.
+	if isVal, _ := engine.IsValidationError(context.DeadlineExceeded); isVal {
+		t.Errorf("IsValidationError mis-classified a generic error as validation")
+	}
+	verr := &engine.ValidationError{Message: "invalid category \"feeback\""}
+	if isVal, msg := engine.IsValidationError(verr); !isVal || msg != verr.Message {
+		t.Errorf("IsValidationError(%v) = (%v, %q), want (true, %q)", verr, isVal, msg, verr.Message)
+	}
+}
+
+// TestRememberRouteInternalErrorStaysGenericOverHTTP drives the actual handler
+// with a genuine internal (non-validation) failure: closing the DB before an
+// otherwise-valid POST forces a "check existing" lookup error deep in
+// Engine.Remember, which is NOT a ValidationError. The client must see exactly
+// the generic "failed to store memory" and none of the underlying error text —
+// no DB/SQL/path leak. This is the positive complement to the classifier unit
+// test, exercising the real HTTP path the generic branch guards.
+func TestRememberRouteInternalErrorStaysGenericOverHTTP(t *testing.T) {
+	srv := testServerWithEngine(t)
+
+	// Force every subsequent store call to fail with an internal error.
+	srv.db.Close()
+
+	body := `{"category":"preferences","name":"devbox","summary":"Always use devbox","body":"The project uses devbox shell to provide Go and SQLite tools."}`
+	req := newTestRequest("POST", "/api/memories", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["error"] != "failed to store memory" {
+		t.Fatalf("error = %q, want exactly %q (generic, no internal detail)", resp["error"], "failed to store memory")
+	}
+	// Belt-and-suspenders: no internal error vocabulary may leak into the body.
+	for _, leak := range []string{"check existing", "sql", "SQL", "database is closed", "upsert"} {
+		if strings.Contains(w.Body.String(), leak) {
+			t.Errorf("internal detail %q leaked into client response: %s", leak, w.Body.String())
+		}
+	}
+}
+
+// TestRetractRouteStoreDomainRejectionSurfacesReason is the issue #35 follow-up:
+// store-level domain rejections (here, retracting a URI that does not exist) used
+// to fall through Engine.Retract unclassified and collapse into the generic
+// "failed to retract memory". They must now be surfaced as 400 with their real,
+// client-safe reason.
+func TestRetractRouteStoreDomainRejectionSurfacesReason(t *testing.T) {
+	srv := testServerWithEngine(t)
+
+	// Well-formed mem:// URI (passes the engine-level prefix check) that points at
+	// a memory that does not exist — a store-level domain rejection.
+	body := `{"uri":"mem://user/events/does-not-exist","reason":"cleanup"}`
+	req := newTestRequest("POST", "/api/memories/retract", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	got := resp["error"]
+	if got == "failed to retract memory" {
+		t.Fatalf("client got the generic message, want the real store-level reason; body: %s", w.Body.String())
+	}
+	if !strings.Contains(got, "not found") {
+		t.Errorf("error = %q, want it to explain the memory was not found", got)
+	}
 }
 
 func TestRememberRoute(t *testing.T) {

--- a/internal/store/retract.go
+++ b/internal/store/retract.go
@@ -19,6 +19,30 @@ var systemOwnedURIs = map[string]bool{
 	"mem://user/profile/communication": true, // synthesized relational profile; bootstraps session context
 }
 
+// RetractValidationError signals that a retraction was rejected for a
+// user/domain reason (memory not found, target is a directory, system-owned URI,
+// self-supersession, missing successor) rather than an internal failure. Its
+// Message describes the caller's own input — no SQL, no filesystem paths — so
+// the boundary layer may surface it verbatim. Genuinely-internal failures (DB
+// errors) stay plain errors and stay generic at the boundary.
+//
+// store cannot import engine (engine imports store, not vice versa), so engine
+// detects this type via errors.As and re-wraps it as an engine.ValidationError
+// to reuse the existing HTTP-400 classification path. See issue #35.
+type RetractValidationError struct {
+	Message string
+}
+
+func (e *RetractValidationError) Error() string {
+	return e.Message
+}
+
+// retractValidationErrorf constructs a *RetractValidationError with a formatted,
+// client-safe message.
+func retractValidationErrorf(format string, args ...any) error {
+	return &RetractValidationError{Message: fmt.Sprintf(format, args...)}
+}
+
 // RetractNode marks a memory as retracted. The node remains in the database
 // (tombstone, not delete) but is excluded from default reads.
 //
@@ -34,13 +58,13 @@ var systemOwnedURIs = map[string]bool{
 // silently corrupt.
 func (db *DB) RetractNode(uri, reason, supersededBy string) (newly bool, err error) {
 	if uri == "" {
-		return false, fmt.Errorf("uri required")
+		return false, retractValidationErrorf("uri required")
 	}
 	if reason == "" {
-		return false, fmt.Errorf("reason required")
+		return false, retractValidationErrorf("reason required")
 	}
 	if systemOwnedURIs[uri] {
-		return false, fmt.Errorf("system-owned: %s cannot be retracted via the public verb", uri)
+		return false, retractValidationErrorf("system-owned: %s cannot be retracted via the public verb", uri)
 	}
 
 	target, err := db.GetNodeByURI(uri)
@@ -48,10 +72,10 @@ func (db *DB) RetractNode(uri, reason, supersededBy string) (newly bool, err err
 		return false, fmt.Errorf("look up target: %w", err)
 	}
 	if target == nil {
-		return false, fmt.Errorf("memory not found: %s", uri)
+		return false, retractValidationErrorf("memory not found: %s", uri)
 	}
 	if target.NodeType != "leaf" {
-		return false, fmt.Errorf("cannot retract %s node: %s (only leaf memories are retractable)", target.NodeType, uri)
+		return false, retractValidationErrorf("cannot retract %s node: %s (only leaf memories are retractable)", target.NodeType, uri)
 	}
 
 	if target.IsRetracted() {
@@ -60,14 +84,14 @@ func (db *DB) RetractNode(uri, reason, supersededBy string) (newly bool, err err
 
 	if supersededBy != "" {
 		if supersededBy == uri {
-			return false, fmt.Errorf("self-supersession: %s cannot supersede itself", uri)
+			return false, retractValidationErrorf("self-supersession: %s cannot supersede itself", uri)
 		}
 		successor, err := db.GetNodeByURI(supersededBy)
 		if err != nil {
 			return false, fmt.Errorf("look up successor: %w", err)
 		}
 		if successor == nil {
-			return false, fmt.Errorf("successor not found: %s", supersededBy)
+			return false, retractValidationErrorf("successor not found: %s", supersededBy)
 		}
 	}
 


### PR DESCRIPTION
Draft for final review. Closes #35.

## Problem
Write handlers collapsed every engine error into a generic string — `failed to store memory` / `failed to retract memory` — so actionable input errors (e.g. `invalid category "feedback"`) only reached the server log, not the caller. That's the friction that kicked this whole thread off.

## Fix
Surface genuine **validation/user-input** errors verbatim; keep **internal** errors generic (logged, not leaked).

- `engine.ValidationError` + `engine.IsValidationError(err)` — `errors.As`-based (survives `%w` wrapping), mirrors the existing `RetractedMatchError` pattern.
- Engine input validation (bad category, empty URI hint, empty L0, short L1) and the retracted-slug collision now return `ValidationError`.
- `store.RetractValidationError` for retract domain rejections (not found, system-owned, directory node, self-supersession, missing successor). Store can't import engine, so `Engine.Retract` maps it up to `engine.ValidationError`. Internal DB errors stay plain → generic.
- `handleRemember` / `handleRetract` surface validation messages as 400; the retracted-match **409 sequestering branch is unchanged and still checked first**.

## Tests
- invalid category / domain-rejected retract → 400 with the real reason
- internal failure (closed DB) → exactly the generic message, no leaked detail
- 409 retracted-match path still sequestered

## Validation
Adversarial review by codex (2 rounds). Round 1 flagged retract's store-level rejections + a weak boundary test → both fixed in round 2. Round 2: code path validated sound (no false-surface of internal errors, messages client-safe, layering clean, tests exercise the right paths). One deliberately **declined** finding: the `uri … is retracted` collision message stays — sequestering is about *reasons*, not *existence*, and the 409 path already surfaces matched URIs. `go test -tags noembed ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)