### PR TITLE
0.7.1: restart verify, migration vector-cache, service PATH

### DIFF
--- a/internal/cli/restart.go
+++ b/internal/cli/restart.go
@@ -231,7 +231,19 @@ func decideRestartAction(hs *hooks.HealthStatus, statusErr error, svc serviceSta
 	return actionRefuse, "a non-continuity process is responding on the configured port; refusing to kill it"
 }
 
-var restartYes bool
+var (
+	restartYes     bool
+	restartTimeout time.Duration
+)
+
+// defaultRestartTimeout is the deadline verifyBounce waits for the bounced server
+// to come back healthy. It is deliberately generous: the FIRST restart after an
+// upgrade runs the schema migration inside store.Open BEFORE the listener binds —
+// including a VACUUM INTO snapshot of the whole DB (observed at 169 MB) — plus
+// launchd/systemd relaunch latency. A flat 10s legitimately under-counts that and
+// reports a false failure on a successful-but-slow restart. 60s comfortably covers
+// the common case; --timeout extends it for very large DBs.
+const defaultRestartTimeout = 60 * time.Second
 
 var restartCmd = &cobra.Command{
 	Use:   "restart",
@@ -245,13 +257,20 @@ process it is about to stop is genuinely continuity. If an unrelated process is
 holding the port, restart refuses.
 
 The new server applies any pending schema migration on boot (a safety snapshot
-is taken automatically before migrating).`,
-	RunE: runRestart,
+is taken automatically before migrating). On the first restart after an upgrade
+this migration + snapshot can take a while on a large database, so restart waits
+patiently (default 60s; raise with --timeout) before reporting a problem.`,
+	// SilenceUsage: a verify timeout or other RUNTIME failure is not a usage
+	// error — cobra must print only the message, never dump the flags/usage block.
+	SilenceUsage: true,
+	RunE:         runRestart,
 }
 
 func init() {
 	restartCmd.Flags().BoolVarP(&restartYes, "yes", "y", false,
 		"skip the confirmation prompt (non-interactive)")
+	restartCmd.Flags().DurationVar(&restartTimeout, "timeout", defaultRestartTimeout,
+		"how long to wait for the server to come back healthy (raise for very large DBs)")
 	rootCmd.AddCommand(restartCmd)
 }
 
@@ -303,7 +322,8 @@ func runRestart(cmd *cobra.Command, args []string) error {
 		if err := platformServiceStart(); err != nil {
 			return fmt.Errorf("start service: %w", err)
 		}
-		return verifyBounce(client, 0)
+		// Manager-owned relaunch: no bare child pid to liveness-check.
+		return verifyBounce(client, 0, 0)
 
 	case actionRestartLaunchd, actionRestartSystemd:
 		if !confirmRestart() {
@@ -319,7 +339,9 @@ func runRestart(cmd *cobra.Command, args []string) error {
 		if err := platformServiceRestart(); err != nil {
 			return fmt.Errorf("restart service: %w", err)
 		}
-		return verifyBounce(client, oldPID)
+		// Manager-owned relaunch: the manager owns the new pid, so we can't
+		// liveness-check a bare child — just poll to the deadline.
+		return verifyBounce(client, oldPID, 0)
 
 	case actionBounceBare:
 		if !confirmRestart() {
@@ -333,14 +355,18 @@ func runRestart(cmd *cobra.Command, args []string) error {
 		// without signalling — if the live endpoint no longer strongly identifies
 		// as this same continuity pid.
 		oldPID := hs.PID
-		if err := hooks.ConfirmAndBounce(client, oldPID); err != nil {
+		newPID, err := hooks.ConfirmAndBounce(client, oldPID)
+		if err != nil {
 			if hooks.IsRestartLockHeld(err) {
 				// A concurrent restart/bounce already holds the lock; do NOT kill.
 				return fmt.Errorf("%v.\n  Wait for it to finish, then re-run `continuity restart` if needed", err)
 			}
 			return fmt.Errorf("bounce server: %w", err)
 		}
-		return verifyBounce(client, oldPID)
+		// BARE path: we spawned newPID ourselves, so if THAT exact child has
+		// already exited we can positively call it a dead-process failure rather
+		// than a slow startup.
+		return verifyBounce(client, oldPID, newPID)
 	}
 
 	return fmt.Errorf("internal: unhandled restart action %q", action)
@@ -361,24 +387,100 @@ func surfaceMigrationNote() {
 	fmt.Println("  note: the restarted server picks up the new binary and applies any pending schema migration (a safety snapshot is taken automatically).")
 }
 
-// verifyBounce polls /api/health until the server comes back healthy, then
-// prints the new version. oldPID, when > 0, lets us detect that the OLD process
-// is truly gone vs. a stale healthy response from a process that never bounced.
-func verifyBounce(client *hooks.Client, oldPID int) error {
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
+// verifyState is the outcome of one poll iteration in the restart verify loop,
+// produced by the pure decideVerify so the timing/process logic can be table-
+// tested without real processes or sleeps.
+type verifyState int
+
+const (
+	// verifyKeepWaiting: not yet healthy, deadline not passed, and (for the bare
+	// path) the child we spawned is still alive — keep polling.
+	verifyKeepWaiting verifyState = iota
+
+	// verifyConfirmed: the server came back healthy as a DIFFERENT pid (or any
+	// healthy pid when we had no old pid) — the bounce succeeded.
+	verifyConfirmed
+
+	// verifyFailedDead: BARE path only — the child process we spawned has exited
+	// before becoming healthy. This is a positive, hard failure (crash on boot).
+	verifyFailedDead
+
+	// verifyTimedOutSoft: the deadline passed without a healthy server and we
+	// could NOT positively prove the process died (managed relaunch, or no child
+	// pid to probe). Report softly: it may still be coming up.
+	verifyTimedOutSoft
+)
+
+// decideVerify is the pure core of the restart verify loop. Given the current
+// time, the deadline, whether the endpoint is healthy-and-bounced this poll, and
+// (for the bare path) whether the spawned child is still alive, it returns the
+// next verifyState. It does NO I/O so it is exhaustively unit-testable.
+//
+//   - healthyBounced true                       -> confirmed (highest priority)
+//   - bare child known-dead (childPID>0,!alive) -> failed-dead (positive failure)
+//   - deadline passed                           -> timed-out-soft
+//   - otherwise                                 -> keep-waiting
+//
+// childPID == 0 means "no bare child to probe" (managed relaunch): childAlive is
+// then ignored and a missed deadline always lands on the soft timeout, never a
+// hard failure — we cannot prove a manager-owned process is dead.
+func decideVerify(now, deadline time.Time, healthyBounced bool, childPID int, childAlive bool) verifyState {
+	if healthyBounced {
+		return verifyConfirmed
+	}
+	if childPID > 0 && !childAlive {
+		return verifyFailedDead
+	}
+	if !now.Before(deadline) {
+		return verifyTimedOutSoft
+	}
+	return verifyKeepWaiting
+}
+
+// verifyBounce polls /api/health until the server comes back healthy, then prints
+// the new version. oldPID, when > 0, lets us detect that the OLD process is truly
+// gone vs. a stale healthy response from a process that never bounced. childPID,
+// when > 0, is the exact bare child we spawned — if it exits before becoming
+// healthy we can positively report a dead-process failure instead of a slow one.
+func verifyBounce(client *hooks.Client, oldPID, childPID int) error {
+	deadline := time.Now().Add(restartTimeout)
+	for {
 		hs, err := client.Status()
-		if err == nil && hooks.IsContinuityServer(hs) && (oldPID == 0 || hs.PID != oldPID) {
+		healthyBounced := err == nil && hooks.IsContinuityServer(hs) && (oldPID == 0 || hs.PID != oldPID)
+		childAlive := childPID > 0 && hooks.ProcessAlive(childPID)
+
+		switch decideVerify(time.Now(), deadline, healthyBounced, childPID, childAlive) {
+		case verifyConfirmed:
 			fmt.Printf("Restarted. Server is healthy: %s (pid %d).\n", hs.Version, hs.PID)
 			return nil
-		}
-		time.Sleep(250 * time.Millisecond)
-	}
 
-	home, _ := os.UserHomeDir()
-	return fmt.Errorf(
-		"server did not come back healthy within 10s — it may have failed to start or a migration may have errored.\n  Check the log: %s/.continuity/serve.log",
-		home)
+		case verifyFailedDead:
+			// The bare child we spawned is gone before it ever served — a real
+			// crash-on-boot (e.g. a migration error). This is the only case we
+			// hard-fail with certainty.
+			home, _ := os.UserHomeDir()
+			return fmt.Errorf(
+				"the restarted server process (pid %d) exited before coming up — it likely failed to start or a migration errored.\n  Check the log: %s/.continuity/serve.log",
+				childPID, home)
+
+		case verifyTimedOutSoft:
+			// Deadline passed but we can't prove the process is dead. Do NOT cry a
+			// false failure: a first-upgrade restart migrates + snapshots the DB and
+			// can legitimately exceed the timeout on a large DB. Inform, don't fail.
+			home, _ := os.UserHomeDir()
+			fmt.Printf(
+				"Server has not reported healthy within %s.\n"+
+					"  A first-upgrade restart migrates and snapshots the database before it starts serving,\n"+
+					"  which can take longer than this on a large database — it may still be coming up.\n"+
+					"  Check status with `continuity` or watch the log: %s/.continuity/serve.log\n"+
+					"  (raise the wait with `continuity restart --timeout`).\n",
+				restartTimeout, home)
+			return nil
+
+		case verifyKeepWaiting:
+			time.Sleep(250 * time.Millisecond)
+		}
+	}
 }
 
 // configuredAddr returns the human-facing address the client is targeting, for

--- a/internal/cli/restart_test.go
+++ b/internal/cli/restart_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/lazypower/continuity/internal/hooks"
 )
@@ -212,6 +213,97 @@ func TestIsDecodeError(t *testing.T) {
 				t.Errorf("isDecodeError() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDecideVerify(t *testing.T) {
+	now := time.Unix(1000, 0)
+	before := now.Add(5 * time.Second)  // deadline in the future
+	passed := now.Add(-1 * time.Second) // deadline already passed
+
+	tests := []struct {
+		name           string
+		deadline       time.Time
+		healthyBounced bool
+		childPID       int
+		childAlive     bool
+		want           verifyState
+	}{
+		{
+			name:           "healthy and bounced confirms (highest priority even past deadline)",
+			deadline:       passed,
+			healthyBounced: true,
+			childPID:       4242,
+			childAlive:     false,
+			want:           verifyConfirmed,
+		},
+		{
+			name:           "bare child dead before healthy is a hard failure",
+			deadline:       before,
+			healthyBounced: false,
+			childPID:       4242,
+			childAlive:     false,
+			want:           verifyFailedDead,
+		},
+		{
+			name:           "bare child still alive within deadline keeps waiting",
+			deadline:       before,
+			healthyBounced: false,
+			childPID:       4242,
+			childAlive:     true,
+			want:           verifyKeepWaiting,
+		},
+		{
+			name:           "bare child alive but deadline passed times out soft",
+			deadline:       passed,
+			healthyBounced: false,
+			childPID:       4242,
+			childAlive:     true,
+			want:           verifyTimedOutSoft,
+		},
+		{
+			name:           "managed (no child) within deadline keeps waiting",
+			deadline:       before,
+			healthyBounced: false,
+			childPID:       0,
+			childAlive:     false,
+			want:           verifyKeepWaiting,
+		},
+		{
+			name:           "managed (no child) past deadline times out soft, never hard-fails",
+			deadline:       passed,
+			healthyBounced: false,
+			childPID:       0,
+			childAlive:     false,
+			want:           verifyTimedOutSoft,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decideVerify(now, tt.deadline, tt.healthyBounced, tt.childPID, tt.childAlive)
+			if got != tt.want {
+				t.Errorf("decideVerify() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRestartCmdSilencesUsage(t *testing.T) {
+	// A verify timeout / runtime failure must not make cobra dump the usage block,
+	// so restartCmd must declare SilenceUsage.
+	if !restartCmd.SilenceUsage {
+		t.Error("restartCmd.SilenceUsage must be true so runtime errors don't print the flags/usage block")
+	}
+}
+
+func TestRestartCmdHasTimeoutFlag(t *testing.T) {
+	f := restartCmd.Flags().Lookup("timeout")
+	if f == nil {
+		t.Fatal("restart command must expose a --timeout flag")
+	}
+	if f.DefValue != defaultRestartTimeout.String() {
+		t.Errorf("--timeout default = %q, want %q", f.DefValue, defaultRestartTimeout.String())
 	}
 }
 

--- a/internal/cli/restart_test.go
+++ b/internal/cli/restart_test.go
@@ -2,6 +2,9 @@ package cli
 
 import (
 	"errors"
+	"os/exec"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -286,6 +289,63 @@ func TestDecideVerify(t *testing.T) {
 				t.Errorf("decideVerify() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestVerifyBounceBareChildCrashOnBootHardFails is the integration-ish guard for
+// Fix 1: a bare restart whose respawned child EXITS before becoming healthy must
+// surface as the hard verifyFailedDead failure, NOT the soft (nil-returning)
+// timeout. It spawns a real short-lived process (exits immediately), reaps it the
+// same way SpawnDetachedServe now does, then drives the real verifyBounce against
+// an unreachable server with a deliberately generous timeout — so the only way it
+// can return the hard failure is dead-child detection via hooks.ProcessAlive, not
+// the deadline. Without the SpawnDetachedServe reap, the child would linger as a
+// zombie that signal-0 reports ALIVE, verifyBounce would fall through to the soft
+// timeout (nil error), and this test fails.
+func TestVerifyBounceBareChildCrashOnBootHardFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bare bounce / detached spawn is unsupported on Windows")
+	}
+
+	// Point the client at a dead port so the server never reports healthy — the
+	// verify outcome is then decided purely by the child's liveness.
+	t.Setenv("CONTINUITY_URL", "http://127.0.0.1:1")
+
+	// Spawn a process that exits immediately (crash-on-boot stand-in) and reap it
+	// exactly like the fixed SpawnDetachedServe, so ProcessAlive(pid) can report
+	// false once it's gone instead of seeing a zombie we still parent.
+	cmd := exec.Command("sh", "-c", "exit 1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn short-lived child: %v", err)
+	}
+	childPID := cmd.Process.Pid
+	reaped := make(chan struct{})
+	go func() { _ = cmd.Wait(); close(reaped) }()
+
+	// Wait for the child to actually be gone (exited AND reaped) before verifying,
+	// so we exercise dead-child detection rather than racing a slow startup.
+	<-reaped
+	deadline := time.Now().Add(2 * time.Second)
+	for hooks.ProcessAlive(childPID) {
+		if time.Now().After(deadline) {
+			t.Fatalf("child pid %d still reported alive after reap; cannot exercise crash-on-boot path", childPID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Generous timeout so a soft deadline-timeout cannot fire first: a hard
+	// failure here can ONLY come from the dead-child branch (verifyFailedDead).
+	orig := restartTimeout
+	t.Cleanup(func() { restartTimeout = orig })
+	restartTimeout = 30 * time.Second
+
+	client := hooks.NewClient()
+	err := verifyBounce(client, 4242 /*oldPID*/, childPID)
+	if err == nil {
+		t.Fatal("verifyBounce returned nil (soft timeout) for a dead bare child; expected the hard crash-on-boot failure")
+	}
+	if !strings.Contains(err.Error(), "exited before coming up") {
+		t.Errorf("expected hard crash-on-boot error, got: %v", err)
 	}
 }
 

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -83,6 +83,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 		eng.StartDecayTimer()
 		defer eng.Stop()
 		fmt.Fprintf(os.Stderr, "  llm: %s (%s)\n", cfg.LLM.Provider, cfg.LLM.Model)
+		if bin := llm.ProviderBinaryUnresolved(cfg.LLM); bin != "" {
+			fmt.Fprintf(os.Stderr,
+				"warning: LLM provider binary %q is not on this process's PATH — extraction will fail.\n"+
+					"  If running as a service, re-run `continuity install-service` to bake in a usable PATH.\n",
+				bin)
+		}
 	}
 
 	// Detect and configure embedder

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -28,6 +28,65 @@ func resolveBinaryPath() (string, error) {
 	return resolveBinaryPathFrom(self, pathLoc)
 }
 
+// servicePATH returns the PATH string to bake into a generated launchd plist /
+// systemd unit. A service started by launchd/systemd does NOT inherit the
+// interactive login shell's PATH, so the LLM provider binaries (`claude`,
+// `ollama`) that live in Homebrew / user-local dirs are invisible to the
+// service and extraction silently fails (issue #41).
+//
+// We capture the install-time PATH (the shell that ran `install-service` DOES
+// have the login PATH) and union it with a set of well-known locations so the
+// result is robust even when install happens from a minimal environment. The
+// captured entries come first (user intent wins), then any common dirs not
+// already present are appended. Duplicates and empties are dropped while order
+// is preserved.
+func servicePATH() string {
+	return buildServicePATH(os.Getenv("PATH"), os.Getenv("HOME"))
+}
+
+// buildServicePATH is the pure core of servicePATH, taking the install-time PATH
+// and HOME explicitly so it is unit-testable. When installPATH is empty it still
+// returns a usable PATH built solely from the common defaults.
+func buildServicePATH(installPATH, home string) string {
+	var ordered []string
+	seen := map[string]bool{}
+	add := func(dir string) {
+		if dir == "" || seen[dir] {
+			return
+		}
+		seen[dir] = true
+		ordered = append(ordered, dir)
+	}
+
+	// Captured install-time PATH first — preserves the user's own ordering.
+	for _, dir := range filepath.SplitList(installPATH) {
+		add(strings.TrimSpace(dir))
+	}
+
+	// Then well-known locations the provider binaries commonly live in, so the
+	// service can resolve `claude`/`ollama` even from a minimal install env.
+	defaults := []string{
+		"/opt/homebrew/bin",
+		"/usr/local/bin",
+		"/usr/bin",
+		"/bin",
+		"/usr/sbin",
+		"/sbin",
+	}
+	if home != "" {
+		// Claude Code's local install + the conventional user bin dir.
+		defaults = append(defaults,
+			filepath.Join(home, ".claude", "local"),
+			filepath.Join(home, ".local", "bin"),
+		)
+	}
+	for _, dir := range defaults {
+		add(dir)
+	}
+
+	return strings.Join(ordered, string(os.PathListSeparator))
+}
+
 func resolveBinaryPathFrom(self, pathLoc string) (string, error) {
 	selfReal, err := filepath.EvalSymlinks(self)
 	if err != nil {

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -51,7 +51,14 @@ func buildServicePATH(installPATH, home string) string {
 	var ordered []string
 	seen := map[string]bool{}
 	add := func(dir string) {
-		if dir == "" || seen[dir] {
+		dir = strings.TrimSpace(dir)
+		// Drop any entry carrying a control char (newline, CR, tab, NUL, …). A
+		// newline in particular would let a PATH entry inject extra lines into the
+		// generated systemd unit (Environment=PATH=...) or break the plist; rather
+		// than try to escape it into a single line, refuse the malformed entry. We
+		// keep the remaining (well-formed) entries so the service still has a
+		// usable PATH.
+		if dir == "" || seen[dir] || containsControlChar(dir) {
 			return
 		}
 		seen[dir] = true
@@ -60,7 +67,7 @@ func buildServicePATH(installPATH, home string) string {
 
 	// Captured install-time PATH first — preserves the user's own ordering.
 	for _, dir := range filepath.SplitList(installPATH) {
-		add(strings.TrimSpace(dir))
+		add(dir)
 	}
 
 	// Then well-known locations the provider binaries commonly live in, so the
@@ -85,6 +92,19 @@ func buildServicePATH(installPATH, home string) string {
 	}
 
 	return strings.Join(ordered, string(os.PathListSeparator))
+}
+
+// containsControlChar reports whether s contains an ASCII control character
+// (including newline, CR, tab, and NUL). Such characters in a PATH entry would
+// corrupt the generated systemd unit (line injection) or plist, so they are
+// rejected in buildServicePATH.
+func containsControlChar(s string) bool {
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
 }
 
 func resolveBinaryPathFrom(self, pathLoc string) (string, error) {

--- a/internal/cli/service_darwin.go
+++ b/internal/cli/service_darwin.go
@@ -3,12 +3,25 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/xml"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 )
+
+// xmlEscape escapes a value for safe interpolation into a plist <string> element.
+// launchd plists are XML, so a PATH (or binary path) containing &, <, >, or quote
+// characters would otherwise corrupt the file. Uses encoding/xml's escaper.
+func xmlEscape(s string) string {
+	var buf bytes.Buffer
+	if err := xml.EscapeText(&buf, []byte(s)); err != nil {
+		return s
+	}
+	return buf.String()
+}
 
 const (
 	launchAgentLabel = "com.continuity.server"
@@ -63,7 +76,7 @@ func generatePlist() (string, error) {
     <string>%s</string>
 </dict>
 </plist>
-`, launchAgentLabel, self, servicePATH(), logPath, logPath), nil
+`, xmlEscape(launchAgentLabel), xmlEscape(self), xmlEscape(servicePATH()), xmlEscape(logPath), xmlEscape(logPath)), nil
 }
 
 func platformServiceStatus() (installed bool, status string) {

--- a/internal/cli/service_darwin.go
+++ b/internal/cli/service_darwin.go
@@ -35,6 +35,8 @@ func generatePlist() (string, error) {
 	}
 	logPath := filepath.Join(home, ".continuity", "serve.log")
 
+	// Bake a usable PATH into the plist so the service can find the LLM provider
+	// binaries (`claude`, `ollama`); launchd does not inherit the login PATH.
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -46,6 +48,11 @@ func generatePlist() (string, error) {
         <string>%s</string>
         <string>serve</string>
     </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>%s</string>
+    </dict>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
@@ -56,7 +63,7 @@ func generatePlist() (string, error) {
     <string>%s</string>
 </dict>
 </plist>
-`, launchAgentLabel, self, logPath, logPath), nil
+`, launchAgentLabel, self, servicePATH(), logPath, logPath), nil
 }
 
 func platformServiceStatus() (installed bool, status string) {
@@ -132,7 +139,12 @@ func platformServiceInstall() (string, error) {
 	return fmt.Sprintf(`Installed. Continuity is now running as a system service.
   Status:  launchctl list | grep continuity
   Stop:    launchctl unload %s
-  Remove:  continuity uninstall-service`, path), nil
+  Remove:  continuity uninstall-service
+
+  note: the service PATH (so it can find the 'claude'/'ollama' provider) is
+        baked in at install time. If you ever move those binaries — or upgraded
+        from a build that lacked this — re-run 'continuity install-service' to
+        refresh it.`, path), nil
 }
 
 func platformUninstallPlan() (string, error) {

--- a/internal/cli/service_darwin_test.go
+++ b/internal/cli/service_darwin_test.go
@@ -1,0 +1,33 @@
+//go:build darwin
+
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGeneratePlistContainsPATHStanza asserts the generated LaunchAgent plist
+// bakes in an EnvironmentVariables/PATH stanza so the service can resolve the
+// LLM provider binary (issue #41) — launchd does not inherit the login PATH.
+func TestGeneratePlistContainsPATHStanza(t *testing.T) {
+	t.Setenv("PATH", "/custom/tools:/opt/homebrew/bin")
+
+	plist, err := generatePlist()
+	if err != nil {
+		t.Fatalf("generatePlist: %v", err)
+	}
+
+	if !strings.Contains(plist, "<key>EnvironmentVariables</key>") {
+		t.Errorf("plist missing EnvironmentVariables dict:\n%s", plist)
+	}
+	if !strings.Contains(plist, "<key>PATH</key>") {
+		t.Errorf("plist missing PATH key:\n%s", plist)
+	}
+	if !strings.Contains(plist, "/custom/tools") {
+		t.Errorf("plist PATH stanza missing captured install-time dir:\n%s", plist)
+	}
+	if !strings.Contains(plist, "/usr/bin") {
+		t.Errorf("plist PATH stanza missing common default dir:\n%s", plist)
+	}
+}

--- a/internal/cli/service_darwin_test.go
+++ b/internal/cli/service_darwin_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"encoding/xml"
 	"strings"
 	"testing"
 )
@@ -29,5 +30,42 @@ func TestGeneratePlistContainsPATHStanza(t *testing.T) {
 	}
 	if !strings.Contains(plist, "/usr/bin") {
 		t.Errorf("plist PATH stanza missing common default dir:\n%s", plist)
+	}
+}
+
+// TestGeneratePlistEscapesXMLSpecialChars asserts Fix 2: a PATH containing XML
+// special chars (&, <, >) and spaces is escaped so the generated plist stays
+// well-formed XML and the raw chars do not appear unescaped inside the value.
+func TestGeneratePlistEscapesXMLSpecialChars(t *testing.T) {
+	// Newline/CR entries are dropped by buildServicePATH; here we focus on the
+	// XML-special chars that survive into the value and must be escaped.
+	t.Setenv("PATH", "/opt/A&B/bin:/tools/<weird>:/My Tools/bin")
+
+	plist, err := generatePlist()
+	if err != nil {
+		t.Fatalf("generatePlist: %v", err)
+	}
+
+	// Must parse as well-formed XML.
+	if err := xml.Unmarshal([]byte(plist), new(struct {
+		XMLName xml.Name `xml:"plist"`
+	})); err != nil {
+		t.Fatalf("generated plist is not well-formed XML: %v\n%s", err, plist)
+	}
+
+	// The escaped entities must be present, the raw special chars must NOT appear
+	// inside the PATH value.
+	if !strings.Contains(plist, "/opt/A&amp;B/bin") {
+		t.Errorf("'&' in PATH was not XML-escaped to &amp;:\n%s", plist)
+	}
+	if strings.Contains(plist, "/opt/A&B/bin") {
+		t.Errorf("raw unescaped '&' leaked into plist:\n%s", plist)
+	}
+	if strings.Contains(plist, "/tools/<weird>") {
+		t.Errorf("raw unescaped '<weird>' leaked into plist:\n%s", plist)
+	}
+	// Spaces are legal in XML text and need no escaping, but must be preserved.
+	if !strings.Contains(plist, "/My Tools/bin") {
+		t.Errorf("space-containing dir not preserved in plist:\n%s", plist)
 	}
 }

--- a/internal/cli/service_linux.go
+++ b/internal/cli/service_linux.go
@@ -34,12 +34,15 @@ func generateUnit() (string, error) {
 	}
 	logPath := filepath.Join(home, ".continuity", "serve.log")
 
+	// Bake a usable PATH into the unit so the service can find the LLM provider
+	// binaries (`claude`, `ollama`); systemd does not inherit the login PATH.
 	return fmt.Sprintf(`[Unit]
 Description=Continuity - Persistent memory for AI coding agents
 After=network.target
 
 [Service]
 Type=simple
+Environment=PATH=%s
 ExecStart=%s serve
 Restart=on-failure
 RestartSec=5
@@ -48,7 +51,7 @@ StandardError=append:%s
 
 [Install]
 WantedBy=default.target
-`, self, logPath, logPath), nil
+`, servicePATH(), self, logPath, logPath), nil
 }
 
 func platformServiceStatus() (installed bool, status string) {
@@ -129,10 +132,15 @@ func platformServiceInstall() (string, error) {
 		return "", fmt.Errorf("enable service: %w\n%s", err, out)
 	}
 
-	return fmt.Sprintf(`Installed. Continuity is now running as a system service.
+	return `Installed. Continuity is now running as a system service.
   Status:  systemctl --user status continuity
   Stop:    systemctl --user stop continuity
-  Remove:  continuity uninstall-service`), nil
+  Remove:  continuity uninstall-service
+
+  note: the service PATH (so it can find the 'claude'/'ollama' provider) is
+        baked in at install time. If you ever move those binaries — or upgraded
+        from a build that lacked this — re-run 'continuity install-service' to
+        refresh it.`, nil
 }
 
 func platformUninstallPlan() (string, error) {

--- a/internal/cli/service_linux.go
+++ b/internal/cli/service_linux.go
@@ -36,13 +36,19 @@ func generateUnit() (string, error) {
 
 	// Bake a usable PATH into the unit so the service can find the LLM provider
 	// binaries (`claude`, `ollama`); systemd does not inherit the login PATH.
+	//
+	// The Environment= assignment is QUOTED. systemd's Environment= parser splits
+	// on whitespace into KEY=VALUE pairs, so an unquoted value containing a space
+	// (legitimately: /opt/My Tools/bin) would be truncated, and a crafted entry
+	// could smuggle a second assignment. Quoting per systemd syntax keeps the value
+	// intact and inert. (The control-char drop in buildServicePATH still applies.)
 	return fmt.Sprintf(`[Unit]
 Description=Continuity - Persistent memory for AI coding agents
 After=network.target
 
 [Service]
 Type=simple
-Environment=PATH=%s
+Environment="PATH=%s"
 ExecStart=%s serve
 Restart=on-failure
 RestartSec=5
@@ -51,7 +57,23 @@ StandardError=append:%s
 
 [Install]
 WantedBy=default.target
-`, servicePATH(), self, logPath, logPath), nil
+`, escapeSystemdEnvValue(servicePATH()), self, logPath, logPath), nil
+}
+
+// escapeSystemdEnvValue escapes a value for inclusion inside a double-quoted
+// systemd Environment= assignment (Environment="KEY=VALUE"). Within double
+// quotes systemd requires backslash and double-quote to be escaped; we also
+// escape '%' as '%%' to defeat systemd specifier expansion (e.g. %h, %i). A
+// space is intentionally NOT escaped — it is the whole point of quoting that a
+// value with spaces survives intact. Control chars are already dropped upstream
+// in buildServicePATH.
+func escapeSystemdEnvValue(v string) string {
+	r := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		`%`, `%%`,
+	)
+	return r.Replace(v)
 }
 
 func platformServiceStatus() (installed bool, status string) {

--- a/internal/cli/service_linux_test.go
+++ b/internal/cli/service_linux_test.go
@@ -1,0 +1,30 @@
+//go:build linux
+
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGenerateUnitContainsPATHStanza asserts the generated systemd user unit
+// bakes in an Environment=PATH= line so the service can resolve the LLM provider
+// binary (issue #41) — systemd does not inherit the login PATH.
+func TestGenerateUnitContainsPATHStanza(t *testing.T) {
+	t.Setenv("PATH", "/custom/tools:/opt/homebrew/bin")
+
+	unit, err := generateUnit()
+	if err != nil {
+		t.Fatalf("generateUnit: %v", err)
+	}
+
+	if !strings.Contains(unit, "Environment=PATH=") {
+		t.Errorf("unit missing Environment=PATH= line:\n%s", unit)
+	}
+	if !strings.Contains(unit, "/custom/tools") {
+		t.Errorf("unit PATH stanza missing captured install-time dir:\n%s", unit)
+	}
+	if !strings.Contains(unit, "/usr/bin") {
+		t.Errorf("unit PATH stanza missing common default dir:\n%s", unit)
+	}
+}

--- a/internal/cli/service_linux_test.go
+++ b/internal/cli/service_linux_test.go
@@ -28,3 +28,54 @@ func TestGenerateUnitContainsPATHStanza(t *testing.T) {
 		t.Errorf("unit PATH stanza missing common default dir:\n%s", unit)
 	}
 }
+
+// TestGenerateUnitPATHIsSingleLine asserts Fix 2: a PATH entry carrying a newline
+// (line-injection attempt) must not produce an extra/forged line in the systemd
+// unit. The Environment=PATH= value must stay a single line and the injected
+// content must be absent.
+func TestGenerateUnitPATHIsSingleLine(t *testing.T) {
+	// The middle entry tries to inject a unit directive via an embedded newline.
+	t.Setenv("PATH", "/good/bin:/evil\nExecStartPre=/bin/rm -rf ~:/also/good")
+
+	unit, err := generateUnit()
+	if err != nil {
+		t.Fatalf("generateUnit: %v", err)
+	}
+
+	// The injected directive must not appear anywhere in the unit.
+	if strings.Contains(unit, "ExecStartPre=/bin/rm") {
+		t.Errorf("line-injection via PATH newline was not neutralized:\n%s", unit)
+	}
+
+	// Find the Environment=PATH= line and ensure it is a single, self-contained
+	// line that still carries the well-formed entries.
+	var pathLine string
+	for _, line := range strings.Split(unit, "\n") {
+		if strings.HasPrefix(line, "Environment=PATH=") {
+			pathLine = line
+			break
+		}
+	}
+	if pathLine == "" {
+		t.Fatalf("no Environment=PATH= line found:\n%s", unit)
+	}
+	if !strings.Contains(pathLine, "/good/bin") || !strings.Contains(pathLine, "/also/good") {
+		t.Errorf("well-formed PATH entries missing from the line: %q", pathLine)
+	}
+	if strings.ContainsAny(pathLine, "\r\t") {
+		t.Errorf("Environment=PATH= line carries control chars: %q", pathLine)
+	}
+}
+
+// TestGenerateUnitContainsSpaceDir confirms a space-containing PATH dir survives
+// into the systemd unit (spaces are valid in an Environment= value).
+func TestGenerateUnitContainsSpaceDir(t *testing.T) {
+	t.Setenv("PATH", "/opt/My Tools/bin")
+	unit, err := generateUnit()
+	if err != nil {
+		t.Fatalf("generateUnit: %v", err)
+	}
+	if !strings.Contains(unit, "/opt/My Tools/bin") {
+		t.Errorf("space-containing dir not preserved in unit:\n%s", unit)
+	}
+}

--- a/internal/cli/service_linux_test.go
+++ b/internal/cli/service_linux_test.go
@@ -18,8 +18,8 @@ func TestGenerateUnitContainsPATHStanza(t *testing.T) {
 		t.Fatalf("generateUnit: %v", err)
 	}
 
-	if !strings.Contains(unit, "Environment=PATH=") {
-		t.Errorf("unit missing Environment=PATH= line:\n%s", unit)
+	if !strings.Contains(unit, `Environment="PATH=`) {
+		t.Errorf("unit missing quoted Environment=\"PATH= line:\n%s", unit)
 	}
 	if !strings.Contains(unit, "/custom/tools") {
 		t.Errorf("unit PATH stanza missing captured install-time dir:\n%s", unit)
@@ -29,9 +29,20 @@ func TestGenerateUnitContainsPATHStanza(t *testing.T) {
 	}
 }
 
-// TestGenerateUnitPATHIsSingleLine asserts Fix 2: a PATH entry carrying a newline
+// envPATHLine returns the single `Environment="PATH=...` line from a generated
+// systemd unit, or "" if none is present.
+func envPATHLine(unit string) string {
+	for _, line := range strings.Split(unit, "\n") {
+		if strings.HasPrefix(line, `Environment="PATH=`) {
+			return line
+		}
+	}
+	return ""
+}
+
+// TestGenerateUnitPATHIsSingleLine asserts that a PATH entry carrying a newline
 // (line-injection attempt) must not produce an extra/forged line in the systemd
-// unit. The Environment=PATH= value must stay a single line and the injected
+// unit. The Environment="PATH= value must stay a single line and the injected
 // content must be absent.
 func TestGenerateUnitPATHIsSingleLine(t *testing.T) {
 	// The middle entry tries to inject a unit directive via an embedded newline.
@@ -47,35 +58,139 @@ func TestGenerateUnitPATHIsSingleLine(t *testing.T) {
 		t.Errorf("line-injection via PATH newline was not neutralized:\n%s", unit)
 	}
 
-	// Find the Environment=PATH= line and ensure it is a single, self-contained
-	// line that still carries the well-formed entries.
-	var pathLine string
-	for _, line := range strings.Split(unit, "\n") {
-		if strings.HasPrefix(line, "Environment=PATH=") {
-			pathLine = line
-			break
-		}
-	}
+	pathLine := envPATHLine(unit)
 	if pathLine == "" {
-		t.Fatalf("no Environment=PATH= line found:\n%s", unit)
+		t.Fatalf("no Environment=\"PATH= line found:\n%s", unit)
 	}
 	if !strings.Contains(pathLine, "/good/bin") || !strings.Contains(pathLine, "/also/good") {
 		t.Errorf("well-formed PATH entries missing from the line: %q", pathLine)
 	}
 	if strings.ContainsAny(pathLine, "\r\t") {
-		t.Errorf("Environment=PATH= line carries control chars: %q", pathLine)
+		t.Errorf("Environment=\"PATH= line carries control chars: %q", pathLine)
 	}
 }
 
-// TestGenerateUnitContainsSpaceDir confirms a space-containing PATH dir survives
-// into the systemd unit (spaces are valid in an Environment= value).
-func TestGenerateUnitContainsSpaceDir(t *testing.T) {
+// TestGenerateUnitPATHIsQuoted asserts the Environment= assignment is double-
+// quoted per systemd syntax. Without quoting, a value with a space would be
+// split by systemd's Environment= parser.
+func TestGenerateUnitPATHIsQuoted(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	unit, err := generateUnit()
+	if err != nil {
+		t.Fatalf("generateUnit: %v", err)
+	}
+	pathLine := envPATHLine(unit)
+	if pathLine == "" {
+		t.Fatalf("no quoted Environment=\"PATH= line found:\n%s", unit)
+	}
+	// The value must be enclosed in double quotes: Environment="PATH=...".
+	if !strings.HasSuffix(pathLine, `"`) {
+		t.Errorf("Environment= assignment is not closed with a double quote: %q", pathLine)
+	}
+}
+
+// TestGenerateUnitSpaceDirNotSplit confirms a space-containing PATH dir survives
+// INSIDE the quotes — it must appear intact, not truncated at the space. With an
+// unquoted assignment systemd would treat the post-space remainder as a second
+// KEY=VALUE pair.
+func TestGenerateUnitSpaceDirNotSplit(t *testing.T) {
 	t.Setenv("PATH", "/opt/My Tools/bin")
 	unit, err := generateUnit()
 	if err != nil {
 		t.Fatalf("generateUnit: %v", err)
 	}
-	if !strings.Contains(unit, "/opt/My Tools/bin") {
-		t.Errorf("space-containing dir not preserved in unit:\n%s", unit)
+	pathLine := envPATHLine(unit)
+	if pathLine == "" {
+		t.Fatalf("no quoted Environment=\"PATH= line found:\n%s", unit)
+	}
+	// The full space-containing dir must be present, and it must sit BEFORE the
+	// closing quote (i.e. inside the quoted value, not split out).
+	if !strings.Contains(pathLine, "/opt/My Tools/bin") {
+		t.Errorf("space-containing dir not preserved in unit line: %q", pathLine)
+	}
+	inner := strings.TrimPrefix(pathLine, `Environment="`)
+	inner = strings.TrimSuffix(inner, `"`)
+	if !strings.Contains(inner, "/opt/My Tools/bin") {
+		t.Errorf("space-containing dir escaped the quoted value: %q", pathLine)
+	}
+}
+
+// TestGenerateUnitNoSecondAssignmentViaSpace asserts a crafted PATH entry cannot
+// produce a second systemd environment assignment. With the value quoted, an
+// entry like " FOO=bar" stays part of the single PATH value and is never parsed
+// as its own KEY=VALUE pair.
+func TestGenerateUnitNoSecondAssignmentViaSpace(t *testing.T) {
+	t.Setenv("PATH", "/good/bin: FOO=bar:/also/good")
+	unit, err := generateUnit()
+	if err != nil {
+		t.Fatalf("generateUnit: %v", err)
+	}
+	pathLine := envPATHLine(unit)
+	if pathLine == "" {
+		t.Fatalf("no quoted Environment=\"PATH= line found:\n%s", unit)
+	}
+	// The crafted token must remain inside the quoted PATH value, never breaking
+	// out as a standalone assignment on the line.
+	inner := strings.TrimPrefix(pathLine, `Environment="`)
+	inner = strings.TrimSuffix(inner, `"`)
+	if !strings.Contains(inner, "FOO=bar") {
+		t.Errorf("crafted token vanished instead of being contained: %q", pathLine)
+	}
+	// The line must still be a single Environment= directive (only one '=' worth
+	// of directive name): it must start with Environment=" and not contain an
+	// unescaped quote that would prematurely close the value.
+	body := inner
+	// A stray unescaped double-quote inside the value would let an attacker close
+	// the quote and append a directive; ensure none survived unescaped.
+	for i := 0; i < len(body); i++ {
+		if body[i] == '"' && (i == 0 || body[i-1] != '\\') {
+			t.Errorf("unescaped double-quote inside Environment value allows breakout: %q", pathLine)
+			break
+		}
+	}
+}
+
+// TestGenerateUnitEscapesQuoteAndBackslash asserts a value carrying a double-
+// quote or backslash is escaped so it cannot break out of the quoted assignment.
+func TestGenerateUnitEscapesQuoteAndBackslash(t *testing.T) {
+	// /x" + "\nEnvironment=EVIL=1 style breakout attempt (quote + backslash). The
+	// newline itself is dropped upstream as a control char; the quote/backslash
+	// must be escaped.
+	t.Setenv("PATH", `/good/bin:/x"q\b:/also/good`)
+	unit, err := generateUnit()
+	if err != nil {
+		t.Fatalf("generateUnit: %v", err)
+	}
+	if strings.Contains(unit, "Environment=EVIL=1") {
+		t.Errorf("quote-breakout produced a forged assignment:\n%s", unit)
+	}
+	pathLine := envPATHLine(unit)
+	if pathLine == "" {
+		t.Fatalf("no quoted Environment=\"PATH= line found:\n%s", unit)
+	}
+	// The embedded double-quote must be backslash-escaped inside the value.
+	if !strings.Contains(pathLine, `\"q`) {
+		t.Errorf("embedded double-quote not escaped: %q", pathLine)
+	}
+	// The embedded backslash must be doubled.
+	if !strings.Contains(pathLine, `q\\b`) {
+		t.Errorf("embedded backslash not escaped: %q", pathLine)
+	}
+}
+
+// TestGenerateUnitEscapesPercent asserts a '%' in a PATH entry is doubled to
+// '%%' so systemd does not treat it as a specifier (e.g. %h, %i).
+func TestGenerateUnitEscapesPercent(t *testing.T) {
+	t.Setenv("PATH", "/good/bin:/opt/100%cool/bin")
+	unit, err := generateUnit()
+	if err != nil {
+		t.Fatalf("generateUnit: %v", err)
+	}
+	pathLine := envPATHLine(unit)
+	if pathLine == "" {
+		t.Fatalf("no quoted Environment=\"PATH= line found:\n%s", unit)
+	}
+	if !strings.Contains(pathLine, "/opt/100%%cool/bin") {
+		t.Errorf("percent not escaped to %%%% in Environment value: %q", pathLine)
 	}
 }

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -60,6 +60,35 @@ func TestBuildServicePATH(t *testing.T) {
 			t.Errorf("/usr/bin appeared %d times, want 1: %q", seen["/usr/bin"], got)
 		}
 	})
+
+	t.Run("entries with control chars are dropped (no line injection)", func(t *testing.T) {
+		// A PATH entry containing a newline would inject extra lines into the
+		// generated systemd unit / corrupt the plist. It must be dropped while the
+		// well-formed entries survive. (Fix 2)
+		install := "/good/tools" + sep + "/evil\nEnvironment=FOO=bar" + sep + "/also/good"
+		got := buildServicePATH(install, home)
+		if strings.ContainsAny(got, "\n\r\t") {
+			t.Errorf("buildServicePATH leaked a control char: %q", got)
+		}
+		if strings.Contains(got, "Environment=FOO=bar") {
+			t.Errorf("control-char entry was not dropped (line-injection risk): %q", got)
+		}
+		if !strings.Contains(got, "/good/tools") || !strings.Contains(got, "/also/good") {
+			t.Errorf("well-formed entries should survive control-char neighbor: %q", got)
+		}
+		// Whole result must remain a single logical line.
+		if len(strings.Split(got, "\n")) != 1 {
+			t.Errorf("service PATH must stay one line, got multiple: %q", got)
+		}
+	})
+
+	t.Run("space-containing dir is preserved", func(t *testing.T) {
+		install := "/Applications/My Tools/bin"
+		got := buildServicePATH(install, home)
+		if !strings.Contains(got, "/Applications/My Tools/bin") {
+			t.Errorf("space-containing dir should be preserved: %q", got)
+		}
+	})
 }
 
 func TestResolveBinaryPathFrom(t *testing.T) {

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -3,8 +3,64 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestBuildServicePATH(t *testing.T) {
+	sep := string(os.PathListSeparator)
+	home := "/home/tester"
+
+	t.Run("captured install PATH comes first and is preserved", func(t *testing.T) {
+		install := "/custom/tools" + sep + "/opt/homebrew/bin"
+		got := buildServicePATH(install, home)
+		parts := strings.Split(got, sep)
+		if parts[0] != "/custom/tools" {
+			t.Errorf("expected captured dir first, got %q (full: %q)", parts[0], got)
+		}
+		// The install-time PATH entries must all be present.
+		if !strings.Contains(got, "/custom/tools") {
+			t.Errorf("captured PATH dir missing: %q", got)
+		}
+	})
+
+	t.Run("common provider locations are always included", func(t *testing.T) {
+		got := buildServicePATH("/custom/tools", home)
+		for _, want := range []string{
+			"/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin",
+			filepath.Join(home, ".claude", "local"),
+			filepath.Join(home, ".local", "bin"),
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("expected default dir %q in PATH, got %q", want, got)
+			}
+		}
+	})
+
+	t.Run("empty install PATH still yields a usable default PATH", func(t *testing.T) {
+		got := buildServicePATH("", home)
+		for _, want := range []string{"/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("expected default dir %q with empty install PATH, got %q", want, got)
+			}
+		}
+	})
+
+	t.Run("no duplicate entries", func(t *testing.T) {
+		// Install PATH already contains a default dir — it must not appear twice.
+		got := buildServicePATH("/usr/local/bin"+sep+"/usr/bin", home)
+		seen := map[string]int{}
+		for _, p := range strings.Split(got, sep) {
+			seen[p]++
+		}
+		if seen["/usr/local/bin"] != 1 {
+			t.Errorf("/usr/local/bin appeared %d times, want 1: %q", seen["/usr/local/bin"], got)
+		}
+		if seen["/usr/bin"] != 1 {
+			t.Errorf("/usr/bin appeared %d times, want 1: %q", seen["/usr/bin"], got)
+		}
+	})
+}
 
 func TestResolveBinaryPathFrom(t *testing.T) {
 	tmp := t.TempDir()

--- a/internal/hooks/autostart.go
+++ b/internal/hooks/autostart.go
@@ -106,19 +106,26 @@ func SpawnDetachedServe() (int, error) {
 	cmd.Stdin = devNull
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 
+	return startAndReap(cmd)
+}
+
+// startAndReap starts cmd and launches a background goroutine that Wait()s on it,
+// returning the spawned PID. It is the production start+reap path shared by
+// SpawnDetachedServe (and isolated here so it can be tested directly).
+//
+// The child is expected to be fully detached (its own session via Setsid) and to
+// persist after we exit. But we remain its PARENT until we exit, so if it crashes
+// on boot it becomes a ZOMBIE we own. A zombie answers signal-0 liveness probes
+// as ALIVE, which would mask a crash-on-boot during `continuity restart`'s verify
+// poll (the bare verifier would fall through to a soft timeout instead of the
+// hard verifyFailedDead). The background Wait() reaps a crashed child promptly so
+// ProcessAlive(pid) reports false once it's gone. This is non-blocking: the
+// goroutine waits, the caller returns immediately and may exit at will — once the
+// parent exits, init/launchd reaps any orphan anyway.
+func startAndReap(cmd *exec.Cmd) (int, error) {
 	if err := cmd.Start(); err != nil {
 		return 0, fmt.Errorf("spawn: %w", err)
 	}
-	// The child is fully detached (its own session via Setsid) and persists
-	// after we exit. But we are still its PARENT until we exit, so if it crashes
-	// on boot it becomes a ZOMBIE we own. A zombie answers signal-0 liveness
-	// probes as ALIVE, which would mask a crash-on-boot during `continuity
-	// restart`'s verify poll (the bare verifier would fall through to a soft
-	// timeout instead of the hard verifyFailedDead). Reap it in the background so
-	// a crashed child is collected promptly and ProcessAlive(pid) reports false
-	// once it's gone. This is non-blocking: the goroutine waits, the caller (the
-	// autostart hook) returns immediately and may exit at will — once the parent
-	// exits, init/launchd reaps the orphan anyway.
 	pid := cmd.Process.Pid
 	go func() { _ = cmd.Wait() }()
 	return pid, nil

--- a/internal/hooks/autostart.go
+++ b/internal/hooks/autostart.go
@@ -109,6 +109,17 @@ func SpawnDetachedServe() (int, error) {
 	if err := cmd.Start(); err != nil {
 		return 0, fmt.Errorf("spawn: %w", err)
 	}
-	// Don't wait on the child — it's fully detached.
-	return cmd.Process.Pid, nil
+	// The child is fully detached (its own session via Setsid) and persists
+	// after we exit. But we are still its PARENT until we exit, so if it crashes
+	// on boot it becomes a ZOMBIE we own. A zombie answers signal-0 liveness
+	// probes as ALIVE, which would mask a crash-on-boot during `continuity
+	// restart`'s verify poll (the bare verifier would fall through to a soft
+	// timeout instead of the hard verifyFailedDead). Reap it in the background so
+	// a crashed child is collected promptly and ProcessAlive(pid) reports false
+	// once it's gone. This is non-blocking: the goroutine waits, the caller (the
+	// autostart hook) returns immediately and may exit at will — once the parent
+	// exits, init/launchd reaps the orphan anyway.
+	pid := cmd.Process.Pid
+	go func() { _ = cmd.Wait() }()
+	return pid, nil
 }

--- a/internal/hooks/autostart_test.go
+++ b/internal/hooks/autostart_test.go
@@ -33,29 +33,28 @@ func TestAutostartEnabledTrueWithMarker(t *testing.T) {
 	}
 }
 
-// TestReapedChildReportsNotAlive is the unit-level guard for Fix 1: a child we
-// started and then crashes must NOT linger as a zombie that signal-0 reports as
-// ALIVE. SpawnDetachedServe reaps its child via a background cmd.Wait(); this test
-// reproduces that pattern with a process that exits immediately and asserts
-// ProcessAlive(pid) eventually reports false.
+// TestStartAndReapCollectsCrashedChild pins the PRODUCTION reap: it calls the
+// real startAndReap helper (the same start+background-Wait() path SpawnDetachedServe
+// uses) with a short-lived command and asserts ProcessAlive(pid) reports false
+// once the process exits. A crashed child must NOT linger as a zombie that
+// signal-0 reports ALIVE — that would mask a crash-on-boot as a soft timeout in
+// `continuity restart`.
 //
-// Without the reap, the crashed child stays a zombie owned by this (parent)
-// process and proc.Signal(0) returns nil (ALIVE), which is exactly what masks a
-// crash-on-boot as a soft timeout in `continuity restart`. The companion test in
+// This fails if the production `go cmd.Wait()` reap inside startAndReap is
+// removed: the exited child would remain a zombie we parent and ProcessAlive
+// would keep returning true until the deadline trips. The companion
 // TestZombieChildReportsAliveWithoutReap documents that failing baseline.
-func TestReapedChildReportsNotAlive(t *testing.T) {
-	cmd := exec.Command("sh", "-c", "exit 1")
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start child: %v", err)
+func TestStartAndReapCollectsCrashedChild(t *testing.T) {
+	// Short-lived command standing in for a crash-on-boot.
+	pid, err := startAndReap(exec.Command("sh", "-c", "exit 1"))
+	if err != nil {
+		t.Fatalf("startAndReap: %v", err)
 	}
-	pid := cmd.Process.Pid
-	// This is the SpawnDetachedServe reap behavior under test.
-	go func() { _ = cmd.Wait() }()
 
 	deadline := time.Now().Add(2 * time.Second)
 	for ProcessAlive(pid) {
 		if time.Now().After(deadline) {
-			t.Fatalf("reaped child pid %d still reported alive; reap did not collect the zombie", pid)
+			t.Fatalf("reaped child pid %d still reported alive; production reap did not collect the zombie", pid)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/internal/hooks/autostart_test.go
+++ b/internal/hooks/autostart_test.go
@@ -4,8 +4,10 @@ package hooks
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestAutostartEnabledFalseByDefault(t *testing.T) {
@@ -28,6 +30,55 @@ func TestAutostartEnabledTrueWithMarker(t *testing.T) {
 
 	if !AutostartEnabled() {
 		t.Error("AutostartEnabled() should be true when marker file exists")
+	}
+}
+
+// TestReapedChildReportsNotAlive is the unit-level guard for Fix 1: a child we
+// started and then crashes must NOT linger as a zombie that signal-0 reports as
+// ALIVE. SpawnDetachedServe reaps its child via a background cmd.Wait(); this test
+// reproduces that pattern with a process that exits immediately and asserts
+// ProcessAlive(pid) eventually reports false.
+//
+// Without the reap, the crashed child stays a zombie owned by this (parent)
+// process and proc.Signal(0) returns nil (ALIVE), which is exactly what masks a
+// crash-on-boot as a soft timeout in `continuity restart`. The companion test in
+// TestZombieChildReportsAliveWithoutReap documents that failing baseline.
+func TestReapedChildReportsNotAlive(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	pid := cmd.Process.Pid
+	// This is the SpawnDetachedServe reap behavior under test.
+	go func() { _ = cmd.Wait() }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for ProcessAlive(pid) {
+		if time.Now().After(deadline) {
+			t.Fatalf("reaped child pid %d still reported alive; reap did not collect the zombie", pid)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestZombieChildReportsAliveWithoutReap documents the BUG the reap fixes: an
+// UN-reaped exited child remains a zombie that ProcessAlive (signal 0) reports as
+// alive. It is the inverse of the production behavior and exists so the regression
+// is legible — if a future change made unwaited children disappear on their own,
+// this would surface it.
+func TestZombieChildReportsAliveWithoutReap(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	pid := cmd.Process.Pid
+	// Intentionally do NOT Wait() — the exited child becomes a zombie we own.
+	t.Cleanup(func() { _ = cmd.Wait() }) // reap at test end to avoid leaking it
+
+	// Give it time to exit; without reaping it lingers as a zombie.
+	time.Sleep(200 * time.Millisecond)
+	if !ProcessAlive(pid) {
+		t.Skip("platform reaped the unwaited child on its own; zombie-as-alive behavior not reproducible here")
 	}
 }
 

--- a/internal/hooks/kill_path.go
+++ b/internal/hooks/kill_path.go
@@ -41,10 +41,27 @@ var pidSignaller = func(pid int) error {
 	return osStopPID(pid)
 }
 
-// serverRespawner relaunches a detached serve. Injectable.
-var serverRespawner = func() error {
-	_, err := SpawnDetachedServe()
-	return err
+// processAlive reports whether the given pid currently exists (best-effort, via
+// signal 0 on unix). Injectable so the restart verify path can be tested without
+// real processes. A pid <= 0 is never alive.
+var processAlive = func(pid int) bool {
+	return osProcessAlive(pid)
+}
+
+// ProcessAlive is the exported best-effort liveness check used by the restart
+// command to detect a respawned bare child that has already died (a real
+// crash-on-boot) versus one that is merely slow to bind. It routes through the
+// injectable processAlive so tests can stub it.
+func ProcessAlive(pid int) bool {
+	return processAlive(pid)
+}
+
+// serverRespawner relaunches a detached serve and returns the new child's pid.
+// Injectable. The pid lets callers (continuity restart's bare path) liveness-poll
+// the exact child they spawned so a crash-on-boot can be detected as a real
+// failure rather than a slow startup.
+var serverRespawner = func() (int, error) {
+	return SpawnDetachedServe()
 }
 
 // ConfirmKillTarget runs the full pre-signal safety gate against the server the
@@ -96,8 +113,10 @@ func ConfirmKillTarget(c *Client, expectPID int) (*HealthStatus, error) {
 // ConfirmAndBounce is the full safe bounce: confirm the kill target, signal it,
 // then respawn a detached serve. It is the shared implementation behind both
 // `continuity restart`'s bare bounce and the hook auto-bounce, so the safety
-// gate can never be bypassed by one caller. Returns an error (without having
-// signalled) if the pre-signal gate fails.
+// gate can never be bypassed by one caller. Returns the respawned child's pid
+// (0 on any failure) and an error (without having signalled) if the pre-signal
+// gate fails. The pid lets the bare-path caller liveness-poll the exact child it
+// spawned so a crash-on-boot is detectable as a real failure.
 //
 // It serializes the entire critical section (revalidate -> signal -> respawn)
 // under the per-user restart lock so two concurrent bounces can never race the
@@ -107,22 +126,23 @@ func ConfirmKillTarget(c *Client, expectPID int) (*HealthStatus, error) {
 // calling this, so the prompt is never held inside the lock. If the lock is held
 // by another live bounce this returns *errRestartLockHeld (see
 // IsRestartLockHeld) WITHOUT signalling.
-func ConfirmAndBounce(c *Client, expectPID int) error {
+func ConfirmAndBounce(c *Client, expectPID int) (int, error) {
 	unlock, err := acquireRestartLock()
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer unlock()
 
 	live, err := ConfirmKillTarget(c, expectPID)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if err := pidSignaller(live.PID); err != nil {
-		return fmt.Errorf("stop server (pid %d): %w", live.PID, err)
+		return 0, fmt.Errorf("stop server (pid %d): %w", live.PID, err)
 	}
-	if err := serverRespawner(); err != nil {
-		return fmt.Errorf("respawn server: %w", err)
+	newPID, err := serverRespawner()
+	if err != nil {
+		return 0, fmt.Errorf("respawn server: %w", err)
 	}
-	return nil
+	return newPID, nil
 }

--- a/internal/hooks/kill_path_test.go
+++ b/internal/hooks/kill_path_test.go
@@ -26,9 +26,9 @@ func withInjectedKillPath(t *testing.T, h *killPathHarness, fetch func(*Client) 
 		h.signals = append(h.signals, pid)
 		return nil
 	}
-	serverRespawner = func() error {
+	serverRespawner = func() (int, error) {
 		h.respawns++
-		return nil
+		return 12345, nil
 	}
 }
 
@@ -57,7 +57,7 @@ func TestConfirmAndBounce_SpoofedHealthRefusedNoSignal(t *testing.T) {
 		func(*Client) (*HealthStatus, error) { return spoof, nil },
 		indeterminateExe,
 	)
-	err := ConfirmAndBounce(&Client{}, 4242)
+	_, err := ConfirmAndBounce(&Client{}, 4242)
 	if err == nil {
 		t.Fatal("expected refusal for spoofed health, got nil")
 	}
@@ -76,7 +76,7 @@ func TestConfirmAndBounce_StrongIdentityIndeterminateExePasses(t *testing.T) {
 		func(*Client) (*HealthStatus, error) { return strongHealth(4242), nil },
 		indeterminateExe,
 	)
-	if err := ConfirmAndBounce(&Client{}, 4242); err != nil {
+	if _, err := ConfirmAndBounce(&Client{}, 4242); err != nil {
 		t.Fatalf("strong identity should pass, got %v", err)
 	}
 	if len(h.signals) != 1 || h.signals[0] != 4242 {
@@ -93,7 +93,7 @@ func TestConfirmAndBounce_ExeMatchPasses(t *testing.T) {
 		func(*Client) (*HealthStatus, error) { return strongHealth(99), nil },
 		matchingExe,
 	)
-	if err := ConfirmAndBounce(&Client{}, 99); err != nil {
+	if _, err := ConfirmAndBounce(&Client{}, 99); err != nil {
 		t.Fatalf("confirmed exe match should pass, got %v", err)
 	}
 	if len(h.signals) != 1 || h.signals[0] != 99 {
@@ -109,7 +109,7 @@ func TestConfirmAndBounce_ExeMismatchRefusedNoSignal(t *testing.T) {
 		func(*Client) (*HealthStatus, error) { return strongHealth(4242), nil },
 		mismatchExe,
 	)
-	err := ConfirmAndBounce(&Client{}, 4242)
+	_, err := ConfirmAndBounce(&Client{}, 4242)
 	if err == nil {
 		t.Fatal("expected refusal on exe mismatch, got nil")
 	}
@@ -126,7 +126,7 @@ func TestConfirmAndBounce_RevalidationPidMismatchAborts(t *testing.T) {
 		func(*Client) (*HealthStatus, error) { return strongHealth(5555), nil }, // live pid != expected
 		matchingExe,
 	)
-	err := ConfirmAndBounce(&Client{}, 4242) // we intended to kill 4242
+	_, err := ConfirmAndBounce(&Client{}, 4242) // we intended to kill 4242
 	if err == nil {
 		t.Fatal("expected abort on pid mismatch, got nil")
 	}
@@ -143,7 +143,7 @@ func TestConfirmAndBounce_RevalidationDisappearedAborts(t *testing.T) {
 		func(*Client) (*HealthStatus, error) { return nil, errors.New("connection refused") },
 		matchingExe,
 	)
-	err := ConfirmAndBounce(&Client{}, 4242)
+	_, err := ConfirmAndBounce(&Client{}, 4242)
 	if err == nil {
 		t.Fatal("expected abort when health disappears, got nil")
 	}
@@ -160,7 +160,7 @@ func TestConfirmAndBounce_RevalidationLostIdentityAborts(t *testing.T) {
 		func(*Client) (*HealthStatus, error) { return &HealthStatus{Status: "nginx"}, nil },
 		matchingExe,
 	)
-	err := ConfirmAndBounce(&Client{}, 4242)
+	_, err := ConfirmAndBounce(&Client{}, 4242)
 	if err == nil {
 		t.Fatal("expected abort when revalidated identity is lost, got nil")
 	}
@@ -175,7 +175,7 @@ func TestConfirmAndBounce_InvalidPidRefused(t *testing.T) {
 		func(*Client) (*HealthStatus, error) { return strongHealth(1), nil },
 		matchingExe,
 	)
-	if err := ConfirmAndBounce(&Client{}, 0); err == nil {
+	if _, err := ConfirmAndBounce(&Client{}, 0); err == nil {
 		t.Fatal("expected refusal for pid 0")
 	}
 	if len(h.signals) != 0 {

--- a/internal/hooks/restart_lock_test.go
+++ b/internal/hooks/restart_lock_test.go
@@ -135,7 +135,7 @@ func TestConfirmAndBounce_RefusesWhenLockHeldNoSignal(t *testing.T) {
 		matchingExe,
 	)
 
-	err := ConfirmAndBounce(&Client{}, 4242)
+	_, err := ConfirmAndBounce(&Client{}, 4242)
 	if err == nil {
 		t.Fatal("expected refusal when restart lock is held")
 	}
@@ -162,7 +162,7 @@ func TestConfirmAndBounce_AcquiresAndReleasesLock(t *testing.T) {
 		func(*Client) (*HealthStatus, error) { return strongHealth(4242), nil },
 		matchingExe,
 	)
-	if err := ConfirmAndBounce(&Client{}, 4242); err != nil {
+	if _, err := ConfirmAndBounce(&Client{}, 4242); err != nil {
 		t.Fatalf("bounce should succeed, got %v", err)
 	}
 	if _, statErr := os.Stat(lockPath); !os.IsNotExist(statErr) {

--- a/internal/hooks/skew_detect.go
+++ b/internal/hooks/skew_detect.go
@@ -110,7 +110,7 @@ func surfaceServerSkewFromHealth(client *Client, hs *HealthStatus) {
 		// (TOCTOU) and best-effort exe-matches immediately before signalling, so
 		// the hook can never SIGTERM a process it hasn't strongly confirmed is
 		// continuity.
-		if err := ConfirmAndBounce(client, hs.PID); err != nil {
+		if _, err := ConfirmAndBounce(client, hs.PID); err != nil {
 			if IsRestartLockHeld(err) {
 				// Another restart/bounce is already handling it; skip silently-ish.
 				// Non-fatal by construction — the concurrent bounce does the work.

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"fmt"
+	"os/exec"
 
 	"github.com/lazypower/continuity/internal/config"
 )
@@ -50,4 +51,21 @@ func NewClient(cfg config.LLMConfig) (Client, error) {
 	default:
 		return nil, fmt.Errorf("unknown LLM provider: %q", cfg.Provider)
 	}
+}
+
+// ProviderBinaryUnresolved reports the external CLI binary a provider needs when
+// that binary is NOT resolvable on the current $PATH, or "" when the provider
+// needs no external binary (or its binary is present). It lets serve print one
+// clear startup warning instead of a per-extraction failure buried in the log —
+// the common service-managed case where launchd/systemd lacks the login PATH
+// (issue #41). Providers that don't shell out (anthropic, ollama-over-HTTP)
+// return "".
+func ProviderBinaryUnresolved(cfg config.LLMConfig) string {
+	if cfg.Provider != "claude-cli" {
+		return ""
+	}
+	if _, err := exec.LookPath("claude"); err != nil {
+		return "claude"
+	}
+	return ""
 }

--- a/internal/store/migration_e2e_test.go
+++ b/internal/store/migration_e2e_test.go
@@ -488,6 +488,114 @@ func TestMigrationE2E_IdempotentSecondBoot(t *testing.T) {
 	}
 }
 
+// =========================================================================
+// FK-cascade regression — the risky table-rebuild migrations must NOT wipe
+// mem_vectors (issue #40)
+// =========================================================================
+
+// seedVectorRow inserts a mem_vectors row referencing the given node_id with a
+// distinguishable embedding BLOB. mem_vectors exists from v4; this exercises
+// the FK ON DELETE CASCADE relationship that a careless DROP TABLE mem_nodes
+// (in the v6/v9 rebuilds) would trigger.
+func seedVectorRow(t *testing.T, dbPath string, nodeID int64) {
+	t.Helper()
+	withSeedDB(t, dbPath, func(db *sql.DB) error {
+		_, err := db.Exec(`
+			INSERT INTO mem_vectors (node_id, embedding, model, dimensions, created_at)
+			VALUES (?, ?, ?, ?, ?)
+		`, nodeID, []byte{0xde, 0xad, 0xbe, 0xef}, "test-model", 4, seedConst)
+		return err
+	})
+}
+
+// insertNodeReturningID inserts one mem_node and returns its rowid so a
+// mem_vectors row can reference it.
+func insertNodeReturningID(t *testing.T, dbPath, uri string) int64 {
+	t.Helper()
+	sqlDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open for node insert: %v", err)
+	}
+	defer sqlDB.Close()
+	res, err := sqlDB.Exec(`
+		INSERT INTO mem_nodes (uri, node_type, category, created_at, updated_at)
+		VALUES (?, 'leaf', 'profile', ?, ?)
+	`, uri, seedConst, seedConst)
+	if err != nil {
+		t.Fatalf("insert node: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last insert id: %v", err)
+	}
+	return id
+}
+
+// assertVectorSurvives reopens the DB and asserts exactly one mem_vectors row
+// exists for nodeID after migration. Without the FK-off-on-pinned-conn fix, the
+// v6/v9 DROP TABLE mem_nodes cascade-deletes it and this count is 0.
+func assertVectorSurvives(t *testing.T, dbPath string, nodeID int64) {
+	t.Helper()
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen after migration: %v", err)
+	}
+	defer db.Close()
+	var n int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM mem_vectors WHERE node_id = ?`, nodeID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count mem_vectors: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("mem_vectors row for node %d = %d, want 1 "+
+			"(risky rebuild cascade-deleted the embedding cache — FK was not "+
+			"disabled on the migration's pinned connection)", nodeID, n)
+	}
+}
+
+// TestMigrationE2E_V9RebuildPreservesVectors is the regression test for issue
+// #40: the v9 full-table rebuild DROPs mem_nodes, and with FK enforcement on
+// that cascade-deletes every mem_vectors row (FK ON DELETE CASCADE, v4). We
+// build a DB at v8 (mem_vectors present, pre-v9-rebuild), seed a node + a
+// vector referencing it, migrate forward through v9 via Open(), and assert the
+// vector survives. Fails before the fix (count 0), passes after.
+func TestMigrationE2E_V9RebuildPreservesVectors(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := buildDBAtVersion(t, dir, 8)
+
+	nodeID := insertNodeReturningID(t, dbPath, "mem://user/profile/v8-with-vector")
+	seedVectorRow(t, dbPath, nodeID)
+
+	// Migrate forward through the v9 rebuild.
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open (migrate to head): %v", err)
+	}
+	db.Close()
+
+	assertVectorSurvives(t, dbPath, nodeID)
+}
+
+// TestMigrationE2E_V6RebuildPreservesVectors covers the earlier risky rebuild
+// (v6). Build at v5 (mem_vectors present from v4), seed a node + vector, migrate
+// forward through both v6 and v9 rebuilds, and assert the vector survives both.
+func TestMigrationE2E_V6RebuildPreservesVectors(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := buildDBAtVersion(t, dir, 5)
+
+	nodeID := insertNodeReturningID(t, dbPath, "mem://user/profile/v5-with-vector")
+	seedVectorRow(t, dbPath, nodeID)
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open (migrate to head): %v", err)
+	}
+	db.Close()
+
+	assertVectorSurvives(t, dbPath, nodeID)
+}
+
 // envGet pulls a single KEY=VAL out of an env vector (the env slice returned
 // by testharness.HermeticEnv). Used so the idempotency test can recover the
 // kernel-allocated port for its second-boot wait.

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 	"os"
 )
@@ -122,9 +124,13 @@ CREATE TABLE mem_vectors (
 		Version:     6,
 		Description: "mem_nodes: add moments category",
 		Risky:       true, // full-table rebuild via INSERT SELECT *; column-order parity is by developer discipline
+		// NOTE: This rebuild does DROP TABLE mem_nodes, which would cascade-
+		// delete mem_vectors (FK ON DELETE CASCADE, v4) if foreign keys were
+		// enforced. FK-off is enforced by the migration RUNNER on a pinned
+		// connection (see migrate()), NOT by an in-SQL `PRAGMA foreign_keys=OFF`
+		// — that pragma is a no-op inside a transaction and on the wrong pooled
+		// connection. Do NOT re-add it here; it is an inert trap.
 		SQL: `
-PRAGMA foreign_keys=OFF;
-
 CREATE TABLE mem_nodes_new (
     id             INTEGER PRIMARY KEY,
     uri            TEXT NOT NULL UNIQUE,
@@ -161,8 +167,6 @@ ALTER TABLE mem_nodes_new RENAME TO mem_nodes;
 CREATE INDEX idx_nodes_parent    ON mem_nodes(parent_uri);
 CREATE INDEX idx_nodes_category  ON mem_nodes(category);
 CREATE INDEX idx_nodes_relevance ON mem_nodes(relevance DESC);
-
-PRAGMA foreign_keys=ON;
 `,
 	},
 	{
@@ -183,9 +187,12 @@ ALTER TABLE mem_nodes ADD COLUMN superseded_by TEXT;
 		Version:     9,
 		Description: "mem_nodes: add feedback and reference categories (issue #24)",
 		Risky:       true, // full-table rebuild via INSERT SELECT *; column-order parity is by developer discipline
+		// NOTE: FK-off during this DROP-TABLE rebuild is enforced by the
+		// migration RUNNER on a pinned connection (see migrate()), NOT by an
+		// in-SQL `PRAGMA foreign_keys=OFF` — that pragma is inert inside a
+		// transaction and would otherwise let DROP TABLE mem_nodes cascade-
+		// delete mem_vectors. Do NOT re-add it here.
 		SQL: `
-PRAGMA foreign_keys=OFF;
-
 CREATE TABLE mem_nodes_new (
     id             INTEGER PRIMARY KEY,
     uri            TEXT NOT NULL UNIQUE,
@@ -227,8 +234,6 @@ ALTER TABLE mem_nodes_new RENAME TO mem_nodes;
 CREATE INDEX idx_nodes_parent    ON mem_nodes(parent_uri);
 CREATE INDEX idx_nodes_category  ON mem_nodes(category);
 CREATE INDEX idx_nodes_relevance ON mem_nodes(relevance DESC);
-
-PRAGMA foreign_keys=ON;
 `,
 	},
 }
@@ -340,38 +345,11 @@ func (db *DB) migrate() error {
 			)
 		}
 
-		tx, err := db.Begin()
-		if err != nil {
+		if err := db.applyMigration(m); err != nil {
 			if snapPath != "" {
-				_ = os.Remove(snapPath) // migration won't run; snapshot is dead weight
+				_ = os.Remove(snapPath) // migration failed/rolled back; snapshot is dead weight
 			}
-			return fmt.Errorf("begin migration %d: %w", m.Version, err)
-		}
-
-		if _, err := tx.Exec(m.SQL); err != nil {
-			tx.Rollback()
-			if snapPath != "" {
-				_ = os.Remove(snapPath)
-			}
-			return fmt.Errorf("migration %d (%s): %w", m.Version, m.Description, err)
-		}
-
-		if _, err := tx.Exec(
-			"INSERT INTO schema_versions (version, description) VALUES (?, ?)",
-			m.Version, m.Description,
-		); err != nil {
-			tx.Rollback()
-			if snapPath != "" {
-				_ = os.Remove(snapPath)
-			}
-			return fmt.Errorf("record migration %d: %w", m.Version, err)
-		}
-
-		if err := tx.Commit(); err != nil {
-			if snapPath != "" {
-				_ = os.Remove(snapPath)
-			}
-			return fmt.Errorf("commit migration %d: %w", m.Version, err)
+			return err
 		}
 
 		// Migration committed. Now enroll the snapshot in the tracking
@@ -388,6 +366,89 @@ func (db *DB) migrate() error {
 		}
 	}
 
+	return nil
+}
+
+// applyMigration runs a single migration's SQL plus its schema_versions stamp
+// inside one transaction, then commits.
+//
+// Risky (table-rebuild) migrations DROP TABLE mem_nodes, which would cascade-
+// delete mem_vectors (FK ON DELETE CASCADE, v4) if foreign keys were enforced.
+// SQLite's `PRAGMA foreign_keys` is a no-op inside a transaction, and the
+// connection pool may hand the tx a different connection than a pooled
+// db.Exec("PRAGMA ...") touched — so the only correct way to disable FK
+// enforcement for the rebuild is to pin a single *sql.Conn, toggle FK OFF on
+// it OUTSIDE any transaction, run the migration tx on that SAME conn, then
+// restore FK ON before releasing it. We always restore FK and close the conn,
+// even on error, so a mid-migration failure never leaves the pool with FK off.
+//
+// Non-risky migrations (ALTER TABLE ADD COLUMN, CREATE TABLE) don't depend on
+// FK state, so they keep the simpler pooled db.Begin() path.
+func (db *DB) applyMigration(m migration) error {
+	if !m.Risky {
+		tx, err := db.Begin()
+		if err != nil {
+			return fmt.Errorf("begin migration %d: %w", m.Version, err)
+		}
+		if err := runMigrationTx(tx, m); err != nil {
+			tx.Rollback()
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit migration %d: %w", m.Version, err)
+		}
+		return nil
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire pinned conn for migration %d: %w", m.Version, err)
+	}
+	// Guarantee FK is restored and the pinned conn is returned, even if the
+	// migration fails partway. Restoring FK here (not just on the happy path)
+	// is what keeps a failed risky migration from poisoning the pool.
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "PRAGMA foreign_keys=ON")
+		conn.Close()
+	}()
+
+	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys=OFF"); err != nil {
+		return fmt.Errorf("disable foreign_keys for migration %d: %w", m.Version, err)
+	}
+
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin migration %d: %w", m.Version, err)
+	}
+	if err := runMigrationTx(tx, m); err != nil {
+		tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit migration %d: %w", m.Version, err)
+	}
+	return nil
+}
+
+// txExec is the subset of tx behavior runMigrationTx needs — satisfied by both
+// *sql.Tx (non-risky path) and the tx from a pinned conn's BeginTx (risky path).
+type txExec interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
+// runMigrationTx applies the migration body and records its schema_versions row.
+// Caller owns commit/rollback.
+func runMigrationTx(tx txExec, m migration) error {
+	if _, err := tx.Exec(m.SQL); err != nil {
+		return fmt.Errorf("migration %d (%s): %w", m.Version, m.Description, err)
+	}
+	if _, err := tx.Exec(
+		"INSERT INTO schema_versions (version, description) VALUES (?, ?)",
+		m.Version, m.Description,
+	); err != nil {
+		return fmt.Errorf("record migration %d: %w", m.Version, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Draft for final review. Closes #39, #40, #41. Off `main`. The bugs surfaced from actually running `continuity restart` post-0.7.0 upgrade.

## Fixes

**#40 — risky migrations cascade-wiped the embedding cache** (data path)
v6/v9 rebuilds carried `PRAGMA foreign_keys=OFF` *inside* the migration tx, where it's a no-op — so FK enforcement stayed ON and `DROP TABLE mem_nodes` cascade-deleted every `mem_vectors` row. Now risky migrations run on a **pinned `*sql.Conn`** with `foreign_keys` toggled OFF/ON *outside* the tx on that same connection (a `defer` restores it + closes the conn on every path, so a failed migration never leaves the pool FK-off). Inert in-SQL pragmas removed. Regression tests seed a vector and assert it survives the v6 and v9 rebuilds (fail without the fix). No user-data loss either way — this is the derived cache + an inert-safeguard fix.

**#39 — `continuity restart` reported false failure**
The first restart after an upgrade migrates + `VACUUM INTO`-snapshots the DB *before* the listener binds (plus launchd/systemd relaunch latency), blowing the old flat 10 s health poll → false failure + a cobra usage dump. Now: 60 s default + `--timeout`, `SilenceUsage`, a pure `decideVerify` (confirmed / failed-dead [bare child crashed on boot — the only hard failure] / timed-out-soft / keep-waiting), bare-child liveness via a reaped pid, and a soft non-failing timeout message that explains the migration can take longer. Managed restarts never hard-fail on a missed deadline.

**#41 — service-managed server couldn't find `claude` on `$PATH`**
Extraction was silently failing under launchd (login PATH not inherited). `install-service` now bakes a usable PATH into the plist (`EnvironmentVariables`, XML-escaped) / systemd unit (quoted `Environment="PATH=..."`, escaped) from the install-time PATH + common dirs; control-char entries dropped. `serve` prints one startup warning when the provider binary is unresolvable. (Existing managed installs must re-run `install-service` to refresh.)

## Validation
codex adversarial review, 2 rounds. Round 1 confirmed the migration FK fix structurally sound + restart logic correct; flagged a zombie-masks-crash gap and raw PATH interpolation → fixed. Round 2 confirmed those sound; flagged unquoted systemd `Environment=` (space-dir split) + a false-confidence reap test → fixed. Triaged with judgment (proportionate to a single-user localhost tool). `go test -tags noembed ./...` green; vet + darwin/linux/windows builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)