### PR TITLE
feat: Memory Health dashboard — usage metrics in the web UI

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -198,6 +198,28 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Daily metrics rollup: snapshot health buckets + cumulative access on a
+	// timer so the Memory Health trend lines accrue. Read-only against memories;
+	// it only writes the metrics_daily ledger. Stops on shutdown.
+	rollupStop := make(chan struct{})
+	go func() {
+		if err := db.RollupDailySnapshot(); err != nil {
+			fmt.Fprintf(os.Stderr, "metrics rollup (startup): %v\n", err)
+		}
+		t := time.NewTicker(1 * time.Hour)
+		defer t.Stop()
+		for {
+			select {
+			case <-rollupStop:
+				return
+			case <-t.C:
+				if err := db.RollupDailySnapshot(); err != nil {
+					fmt.Fprintf(os.Stderr, "metrics rollup: %v\n", err)
+				}
+			}
+		}
+	}()
+
 	// Graceful shutdown
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
@@ -212,6 +234,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}()
 
 	<-done
+	close(rollupStop)
 	fmt.Fprintln(os.Stderr, "\nshutting down...")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lazypower/continuity/internal/store"
+)
+
+// TestMetricsEndpoint verifies the /api/metrics route is wired through the
+// router and returns the Memory Health payload as JSON.
+func TestMetricsEndpoint(t *testing.T) {
+	srv := testServer(t)
+
+	for i, uri := range []string{
+		"mem://user/patterns/a",
+		"mem://user/cases/b",
+		"mem://user/cases/c",
+	} {
+		if err := srv.db.CreateNode(&store.MemNode{
+			URI: uri, NodeType: "leaf", Category: []string{"patterns", "cases", "cases"}[i],
+			L0Abstract: "x",
+		}); err != nil {
+			t.Fatalf("create %s: %v", uri, err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/metrics", nil)
+	req.Host = "127.0.0.1"
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q, want application/json", ct)
+	}
+
+	var m store.Metrics
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+	}
+	if m.Summary.ActiveTotal != 3 {
+		t.Errorf("active_total = %d, want 3", m.Summary.ActiveTotal)
+	}
+	if len(m.Categories) != 2 {
+		t.Errorf("categories = %d, want 2 (patterns, cases)", len(m.Categories))
+	}
+	// cases (2) should sort before patterns (1).
+	if m.Categories[0].Category != "cases" {
+		t.Errorf("categories[0] = %q, want cases (highest count first)", m.Categories[0].Category)
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -536,6 +536,19 @@ func (s *Server) handleTimeline(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(out)
 }
 
+// handleMetrics returns the read-only Memory Health payload. Decay is computed
+// live from timestamps; this endpoint never mutates the store (no DecayAllNodes).
+func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	m, err := s.db.ComputeMetrics()
+	if err != nil {
+		log.Printf("metrics: %v", err)
+		jsonError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(m)
+}
+
 func (s *Server) handleProfile(w http.ResponseWriter, r *http.Request) {
 	relProfile, err := s.db.GetNodeByURI("mem://user/profile/communication")
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -69,6 +69,7 @@ func (s *Server) routes() {
 		r.Get("/profile", s.handleProfile)
 		r.Get("/tree", s.handleTree)
 		r.Get("/timeline", s.handleTimeline)
+		r.Get("/metrics", s.handleMetrics)
 
 		// Stub routes — return 501 until implemented
 		r.Get("/sessions", stub("sessions"))

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -33,8 +34,8 @@ func TestSchemaVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SchemaVersion: %v", err)
 	}
-	if v != 9 {
-		t.Errorf("SchemaVersion = %d, want 9", v)
+	if v != headVersion() {
+		t.Errorf("SchemaVersion = %d, want head %d", v, headVersion())
 	}
 }
 
@@ -188,10 +189,10 @@ func TestMigrate_RejectsFutureSchemaVersion(t *testing.T) {
 	// rather than the exact text so phrasing tweaks remain frictionless.
 	msg := err.Error()
 	for _, substr := range []string{
-		"9999",                // the version we found
-		"max 9",               // the version we support (head is 9 today)
-		"upgrade continuity",  // explicit remediation
-		"restore a backup",    // alternative remediation
+		"9999",                               // the version we found
+		fmt.Sprintf("max %d", headVersion()), // the version we support
+		"upgrade continuity",                 // explicit remediation
+		"restore a backup",                   // alternative remediation
 	} {
 		if !strings.Contains(msg, substr) {
 			t.Errorf("error message missing %q\nfull message: %s", substr, msg)
@@ -241,8 +242,8 @@ func TestMigrationsIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SchemaVersion: %v", err)
 	}
-	if v != 9 {
-		t.Errorf("SchemaVersion after re-migrate = %d, want 9", v)
+	if v != headVersion() {
+		t.Errorf("SchemaVersion after re-migrate = %d, want head %d", v, headVersion())
 	}
 }
 

--- a/internal/store/metrics.go
+++ b/internal/store/metrics.go
@@ -1,0 +1,293 @@
+package store
+
+import (
+	"sort"
+	"time"
+)
+
+// Metrics tuning constants. These define the freshness bands and list sizes for
+// the Memory Health dashboard. Single-user scale — tune freely.
+const (
+	// Relevance bands. A node's *effective* relevance is computed live from
+	// timestamps (read-only) rather than read from the stored column, so the
+	// dashboard never depends on a decay sweep having run.
+	freshThreshold = 0.7 // effective >= this  → fresh
+	staleThreshold = 0.4 // effective <  this  → stale
+	cliffCeiling   = 0.5 // [staleThreshold, cliffCeiling) → near the decay cliff
+
+	metricsRecentDays  = 30 // window for "recent" retractions
+	neverRetrievedDays = 30 // never-retrieved + older than this → needs attention
+	metricsTopN        = 10 // list sizes for needs-attention / critical sections
+
+	histogramBins  = 18   // relevance distribution bins across [0.1, 1.0]
+	histogramFloor = 0.1  // relevance floor (matches decay floor)
+	histogramWidth = 0.05 // (1.0 - 0.1) / 18
+
+	dayMs = int64(24 * 60 * 60 * 1000)
+)
+
+// HistBin is one bucket of the relevance distribution. Lo/Hi are the band edges;
+// Count is how many active memories fall in it. Drives the D3 decay histogram.
+type HistBin struct {
+	Lo    float64 `json:"lo"`
+	Hi    float64 `json:"hi"`
+	Count int     `json:"count"`
+}
+
+// MetricNode is a memory surfaced in a dashboard list, carrying the live
+// effective relevance (not the stored column) plus the signals a human needs to
+// decide whether it deserves attention.
+type MetricNode struct {
+	URI         string  `json:"uri"`
+	Category    string  `json:"category"`
+	L0Abstract  string  `json:"l0_abstract"`
+	Relevance   float64 `json:"relevance"` // live effective relevance, floored at 0.1
+	AccessCount int     `json:"access_count"`
+	LastAccess  *int64  `json:"last_access,omitempty"`
+	CreatedAt   int64   `json:"created_at"`
+	AgeDays     int     `json:"age_days"`
+}
+
+// CategoryShare is one category's slice of the active memory base. Sorted desc
+// by count, it doubles as the by-category breakdown and the imbalance signal.
+type CategoryShare struct {
+	Category string  `json:"category"`
+	Count    int     `json:"count"`
+	Share    float64 `json:"share"` // count / active_total, 0..1
+}
+
+// Metrics is the full read-only payload for the Memory Health dashboard.
+// Computed live; viewing it never mutates the store.
+type Metrics struct {
+	GeneratedAt int64 `json:"generated_at"` // unix ms
+
+	Summary struct {
+		ActiveTotal       int     `json:"active_total"`
+		RetractedTotal    int     `json:"retracted_total"`
+		Fresh             int     `json:"fresh"`
+		Fading            int     `json:"fading"`
+		Stale             int     `json:"stale"`
+		NeverRetrieved    int     `json:"never_retrieved"`
+		RetractionRate    float64 `json:"retraction_rate"`    // retracted / (active+retracted)
+		RecentRetractions int     `json:"recent_retractions"` // tombstoned within metricsRecentDays
+	} `json:"summary"`
+
+	Categories []CategoryShare `json:"categories"`
+
+	// Relevance distribution across active memories (fine-grained bins), for the
+	// D3 decay histogram. Bands: stale < 0.4, fading < 0.7, fresh >= 0.7.
+	Histogram []HistBin `json:"histogram"`
+
+	NeedsAttention struct {
+		// Load-bearing but decaying: frequently retrieved yet effective relevance
+		// has fallen below fresh. Fix these first.
+		StaleHighRetrieval []MetricNode `json:"stale_high_retrieval"`
+		// Created but never retrieved, older than neverRetrievedDays. Noise or buried value.
+		NeverRetrievedOld []MetricNode `json:"never_retrieved_old"`
+		// Approaching the stale threshold but not yet stale — act before they fade.
+		NearDecayCliff []MetricNode `json:"near_decay_cliff"`
+		// Retracted without a superseded_by successor — untidy cleanup.
+		OrphanedTombstones []MetricNode `json:"orphaned_tombstones"`
+	} `json:"needs_attention"`
+
+	// Most-retrieved memories, shown with live relevance + last access (not bare count).
+	Critical []MetricNode `json:"critical"`
+
+	// Trend over the last metricsDailyWindow days — powers the effectiveness
+	// sparkline. Captures are real now; retrievals/buckets accrue from snapshots.
+	Daily []DailyPoint `json:"daily"`
+}
+
+// ComputeMetrics builds the Memory Health payload in a single pass over all
+// leaf nodes. Decay is computed live from timestamps (read-only) — this method
+// never writes, so opening the dashboard cannot change what it measures.
+func (db *DB) ComputeMetrics() (*Metrics, error) {
+	leaves, err := db.ListLeavesIncludingRetracted()
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UnixMilli()
+	m := &Metrics{GeneratedAt: now}
+
+	catCounts := map[string]int{}
+	histCounts := make([]int, histogramBins)
+	var active, neverRetrieved []MetricNode
+
+	for i := range leaves {
+		n := &leaves[i]
+
+		if n.IsRetracted() {
+			m.Summary.RetractedTotal++
+			if n.TombstonedAt != nil && now-*n.TombstonedAt <= int64(metricsRecentDays)*dayMs {
+				m.Summary.RecentRetractions++
+			}
+			if n.SupersededBy == "" {
+				m.NeedsAttention.OrphanedTombstones = append(m.NeedsAttention.OrphanedTombstones, toMetricNode(n, now))
+			}
+			continue
+		}
+
+		// Live (active) node.
+		m.Summary.ActiveTotal++
+		catCounts[n.Category]++
+		eff := effectiveRelevance(n, now)
+		mn := toMetricNode(n, now)
+		mn.Relevance = eff
+		active = append(active, mn)
+
+		bin := int((eff - histogramFloor) / histogramWidth)
+		if bin < 0 {
+			bin = 0
+		}
+		if bin >= histogramBins {
+			bin = histogramBins - 1
+		}
+		histCounts[bin]++
+
+		switch {
+		case eff >= freshThreshold:
+			m.Summary.Fresh++
+		case eff < staleThreshold:
+			m.Summary.Stale++
+		default:
+			m.Summary.Fading++
+		}
+
+		if eff >= staleThreshold && eff < cliffCeiling {
+			m.NeedsAttention.NearDecayCliff = append(m.NeedsAttention.NearDecayCliff, mn)
+		}
+
+		if n.AccessCount == 0 {
+			m.Summary.NeverRetrieved++
+			if now-n.CreatedAt >= int64(neverRetrievedDays)*dayMs {
+				neverRetrieved = append(neverRetrieved, mn)
+			}
+		} else if eff < freshThreshold {
+			// Retrieved at least once but no longer fresh — load-bearing and decaying.
+			m.NeedsAttention.StaleHighRetrieval = append(m.NeedsAttention.StaleHighRetrieval, mn)
+		}
+	}
+
+	// Retraction rate over the lifetime of the base.
+	if total := m.Summary.ActiveTotal + m.Summary.RetractedTotal; total > 0 {
+		m.Summary.RetractionRate = float64(m.Summary.RetractedTotal) / float64(total)
+	}
+
+	// Category shares, sorted desc by count (doubles as the imbalance signal).
+	m.Categories = make([]CategoryShare, 0, len(catCounts))
+	for cat, c := range catCounts {
+		share := 0.0
+		if m.Summary.ActiveTotal > 0 {
+			share = float64(c) / float64(m.Summary.ActiveTotal)
+		}
+		m.Categories = append(m.Categories, CategoryShare{Category: cat, Count: c, Share: share})
+	}
+	sort.Slice(m.Categories, func(i, j int) bool {
+		if m.Categories[i].Count != m.Categories[j].Count {
+			return m.Categories[i].Count > m.Categories[j].Count
+		}
+		return m.Categories[i].Category < m.Categories[j].Category
+	})
+
+	// Relevance histogram bins for the D3 decay distribution.
+	m.Histogram = make([]HistBin, histogramBins)
+	for i := 0; i < histogramBins; i++ {
+		lo := histogramFloor + float64(i)*histogramWidth
+		m.Histogram[i] = HistBin{Lo: lo, Hi: lo + histogramWidth, Count: histCounts[i]}
+	}
+
+	// Critical: most-retrieved active memories, then by live relevance as tiebreak.
+	// Exclude session-injected categories (moments, session): they ride into every
+	// session, so their access_count measures injection frequency, not how
+	// load-bearing the knowledge is. Critical should surface working knowledge.
+	m.Critical = make([]MetricNode, 0, len(active))
+	for _, mn := range active {
+		if mn.Category == "moments" || mn.Category == "session" {
+			continue
+		}
+		m.Critical = append(m.Critical, mn)
+	}
+	sort.Slice(m.Critical, func(i, j int) bool {
+		if m.Critical[i].AccessCount != m.Critical[j].AccessCount {
+			return m.Critical[i].AccessCount > m.Critical[j].AccessCount
+		}
+		return m.Critical[i].Relevance > m.Critical[j].Relevance
+	})
+	m.Critical = topMetricNodes(m.Critical, metricsTopN)
+
+	// Order the needs-attention lists by urgency, then cap them. Sort each source
+	// slice directly before assigning back.
+	na := &m.NeedsAttention
+	sort.Slice(na.StaleHighRetrieval, func(i, j int) bool {
+		return na.StaleHighRetrieval[i].AccessCount > na.StaleHighRetrieval[j].AccessCount
+	})
+	sort.Slice(neverRetrieved, func(i, j int) bool {
+		return neverRetrieved[i].AgeDays > neverRetrieved[j].AgeDays
+	})
+	sort.Slice(na.NearDecayCliff, func(i, j int) bool {
+		return na.NearDecayCliff[i].Relevance < na.NearDecayCliff[j].Relevance
+	})
+	sort.Slice(na.OrphanedTombstones, func(i, j int) bool {
+		return na.OrphanedTombstones[i].AgeDays > na.OrphanedTombstones[j].AgeDays
+	})
+
+	na.NeverRetrievedOld = topMetricNodes(neverRetrieved, metricsTopN)
+	na.StaleHighRetrieval = topMetricNodes(na.StaleHighRetrieval, metricsTopN)
+	na.NearDecayCliff = topMetricNodes(na.NearDecayCliff, metricsTopN)
+	na.OrphanedTombstones = topMetricNodes(na.OrphanedTombstones, metricsTopN)
+
+	daily, err := db.BuildDailySeries(metricsDailyWindow)
+	if err != nil {
+		return nil, err
+	}
+	m.Daily = daily
+
+	return m, nil
+}
+
+// effectiveRelevance computes a node's current relevance live from its
+// timestamps using the same 90-day half-life as DecayAllNodes, floored at 0.1.
+// Decay-exempt nodes (relational profile, moments) keep their stored relevance.
+func effectiveRelevance(n *MemNode, now int64) float64 {
+	if n.URI == "mem://user/profile/communication" || n.Category == "moments" {
+		return n.Relevance
+	}
+	refTime := n.CreatedAt
+	if n.LastAccess != nil {
+		refTime = *n.LastAccess
+	}
+	elapsed := float64(now - refTime)
+	if elapsed <= 0 {
+		return 1.0
+	}
+	halfLifeMs := float64(90 * 24 * 60 * 60 * 1000)
+	v := pow05(elapsed / halfLifeMs)
+	if v < 0.1 {
+		return 0.1
+	}
+	if v > 1.0 {
+		return 1.0
+	}
+	return v
+}
+
+func toMetricNode(n *MemNode, now int64) MetricNode {
+	return MetricNode{
+		URI:         n.URI,
+		Category:    n.Category,
+		L0Abstract:  n.L0Abstract,
+		Relevance:   n.Relevance,
+		AccessCount: n.AccessCount,
+		LastAccess:  n.LastAccess,
+		CreatedAt:   n.CreatedAt,
+		AgeDays:     int((now - n.CreatedAt) / dayMs),
+	}
+}
+
+func topMetricNodes(xs []MetricNode, n int) []MetricNode {
+	if len(xs) > n {
+		return xs[:n]
+	}
+	return xs
+}

--- a/internal/store/metrics_daily.go
+++ b/internal/store/metrics_daily.go
@@ -1,0 +1,189 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+const metricsDailyWindow = 30 // days of trend history surfaced to the dashboard
+
+// DailyPoint is one day on the Memory Health trend. Captures are derived live
+// from created_at (so full history is available immediately); retrievals and the
+// freshness buckets come from daily snapshots, so they accrue going forward and
+// are only meaningful where HasSnapshot is true.
+type DailyPoint struct {
+	Date        string `json:"date"` // 'YYYY-MM-DD' (UTC)
+	Captures    int    `json:"captures"`
+	Retrievals  int    `json:"retrievals"`
+	ActiveTotal int    `json:"active_total"`
+	Fresh       int    `json:"fresh"`
+	Fading      int    `json:"fading"`
+	Stale       int    `json:"stale"`
+	HasSnapshot bool   `json:"has_snapshot"`
+}
+
+func utcDate(t time.Time) string { return t.UTC().Format("2006-01-02") }
+
+// RollupDailySnapshot records today's health buckets + cumulative access total.
+// Idempotent: re-running on the same day overwrites that day's row, so an hourly
+// tick keeps "today" current. This writes a snapshot row but never touches any
+// memory — the no-mutate-on-view contract is about the measured nodes, not the
+// trend ledger, and this runs on a timer rather than on a dashboard read.
+func (db *DB) RollupDailySnapshot() error {
+	m, err := db.ComputeMetrics()
+	if err != nil {
+		return err
+	}
+
+	var totalAccess int64
+	if err := db.QueryRow(
+		`SELECT COALESCE(SUM(access_count), 0) FROM mem_nodes WHERE node_type = 'leaf'`,
+	).Scan(&totalAccess); err != nil {
+		return fmt.Errorf("sum access: %w", err)
+	}
+
+	now := time.Now().UTC()
+	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).UnixMilli()
+	var captures int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM mem_nodes WHERE node_type = 'leaf' AND created_at >= ?`, dayStart,
+	).Scan(&captures); err != nil {
+		return fmt.Errorf("count captures: %w", err)
+	}
+
+	catCounts := map[string]int{}
+	for _, c := range m.Categories {
+		catCounts[c.Category] = c.Count
+	}
+	catJSON, _ := json.Marshal(catCounts)
+
+	_, err = db.Exec(`
+		INSERT INTO metrics_daily
+			(date, active_total, retracted_total, fresh, fading, stale, never_retrieved,
+			 total_access, captures, category_counts, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(date) DO UPDATE SET
+			active_total=excluded.active_total, retracted_total=excluded.retracted_total,
+			fresh=excluded.fresh, fading=excluded.fading, stale=excluded.stale,
+			never_retrieved=excluded.never_retrieved, total_access=excluded.total_access,
+			captures=excluded.captures, category_counts=excluded.category_counts,
+			updated_at=excluded.updated_at
+	`, utcDate(now), m.Summary.ActiveTotal, m.Summary.RetractedTotal,
+		m.Summary.Fresh, m.Summary.Fading, m.Summary.Stale, m.Summary.NeverRetrieved,
+		totalAccess, captures, string(catJSON), now.UnixMilli())
+	if err != nil {
+		return fmt.Errorf("upsert metrics_daily: %w", err)
+	}
+	return nil
+}
+
+// BuildDailySeries returns the last `days` days of trend points. Captures come
+// from created_at (full history); retrievals are day-over-day diffs of the
+// snapshotted cumulative access total; freshness buckets come from snapshots.
+func (db *DB) BuildDailySeries(days int) ([]DailyPoint, error) {
+	if days < 1 {
+		days = 1
+	}
+	now := time.Now().UTC()
+	startDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, -(days - 1))
+	startMs := startDay.UnixMilli()
+
+	// Captures per day, derived from created_at (covers all history in-window).
+	capByDate := map[string]int{}
+	rows, err := db.Query(`
+		SELECT date(created_at/1000, 'unixepoch') AS d, COUNT(*)
+		FROM mem_nodes
+		WHERE node_type = 'leaf' AND created_at >= ?
+		GROUP BY d
+	`, startMs)
+	if err != nil {
+		return nil, fmt.Errorf("captures by date: %w", err)
+	}
+	for rows.Next() {
+		var d string
+		var c int
+		if err := rows.Scan(&d, &c); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		capByDate[d] = c
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// All snapshots up to today, ordered, so retrievals = diff of total_access.
+	type snap struct {
+		active, fresh, fading, stale int
+		totalAccess                  int64
+	}
+	snapByDate := map[string]snap{}
+	retrievalsByDate := map[string]int{}
+	startDate := utcDate(startDay)
+
+	// Seed the diff baseline from the most recent snapshot BEFORE the window, so
+	// the snapshot read stays O(window) instead of O(all history) as the ledger
+	// grows. retrievals-per-day is a day-over-day diff of cumulative access; the
+	// first in-window day diffs against this baseline.
+	var prevAccess int64
+	var havePrev bool
+	switch err := db.QueryRow(
+		`SELECT total_access FROM metrics_daily WHERE date < ? ORDER BY date DESC LIMIT 1`, startDate,
+	).Scan(&prevAccess); err {
+	case nil:
+		havePrev = true
+	case sql.ErrNoRows:
+		// No prior snapshot; the first in-window day simply has no retrievals figure.
+	default:
+		return nil, fmt.Errorf("seed retrievals baseline: %w", err)
+	}
+
+	srows, err := db.Query(`
+		SELECT date, active_total, fresh, fading, stale, total_access
+		FROM metrics_daily WHERE date >= ? ORDER BY date ASC
+	`, startDate)
+	if err != nil {
+		return nil, fmt.Errorf("read snapshots: %w", err)
+	}
+	for srows.Next() {
+		var d string
+		var s snap
+		if err := srows.Scan(&d, &s.active, &s.fresh, &s.fading, &s.stale, &s.totalAccess); err != nil {
+			srows.Close()
+			return nil, err
+		}
+		snapByDate[d] = s
+		if havePrev {
+			diff := int(s.totalAccess - prevAccess)
+			if diff < 0 {
+				diff = 0
+			}
+			retrievalsByDate[d] = diff
+		}
+		prevAccess = s.totalAccess
+		havePrev = true
+	}
+	srows.Close()
+	if err := srows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]DailyPoint, 0, days)
+	for i := 0; i < days; i++ {
+		d := utcDate(startDay.AddDate(0, 0, i))
+		p := DailyPoint{Date: d, Captures: capByDate[d]}
+		if s, ok := snapByDate[d]; ok {
+			p.HasSnapshot = true
+			p.ActiveTotal = s.active
+			p.Fresh = s.fresh
+			p.Fading = s.fading
+			p.Stale = s.stale
+			p.Retrievals = retrievalsByDate[d]
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}

--- a/internal/store/metrics_daily_test.go
+++ b/internal/store/metrics_daily_test.go
@@ -1,0 +1,142 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDailySeries_BaselineFromBeforeWindow proves the bounded snapshot read
+// still computes correct retrieval diffs: a snapshot OUTSIDE the window must
+// still seed the first in-window day's day-over-day diff.
+func TestDailySeries_BaselineFromBeforeWindow(t *testing.T) {
+	db := testDB(t)
+	now := time.Now().UTC()
+
+	older := now.AddDate(0, 0, -5).Format("2006-01-02") // outside a 2-day window
+	today := now.Format("2006-01-02")
+	if _, err := db.Exec(`INSERT INTO metrics_daily (date, total_access, updated_at) VALUES (?, ?, ?)`,
+		older, 10, now.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO metrics_daily (date, total_access, updated_at) VALUES (?, ?, ?)`,
+		today, 18, now.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+
+	series, err := db.BuildDailySeries(2) // window = [yesterday, today]; older row excluded
+	if err != nil {
+		t.Fatalf("BuildDailySeries: %v", err)
+	}
+	var todayPt *DailyPoint
+	for i := range series {
+		if series[i].Date == today {
+			todayPt = &series[i]
+		}
+	}
+	if todayPt == nil {
+		t.Fatal("today not in 2-day window")
+	}
+	// 18 (today) − 10 (pre-window baseline) = 8, even though the older row is
+	// outside the window and never scanned by the main query.
+	if todayPt.Retrievals != 8 {
+		t.Errorf("today retrievals = %d, want 8 (18−10 via pre-window baseline)", todayPt.Retrievals)
+	}
+}
+
+func TestRollupAndDailySeries(t *testing.T) {
+	db := testDB(t)
+	now := time.Now().UTC()
+	day := int64(24 * 60 * 60 * 1000)
+
+	mk := func(uri string) {
+		if err := db.CreateNode(&MemNode{URI: uri, NodeType: "leaf", Category: "patterns", L0Abstract: "x"}); err != nil {
+			t.Fatalf("create %s: %v", uri, err)
+		}
+	}
+	mk("mem://user/patterns/a")
+	mk("mem://user/patterns/b")
+	mk("mem://user/patterns/c")
+	// Backdate one capture 5 days into the window.
+	created5d := now.AddDate(0, 0, -5)
+	if _, err := db.Exec(`UPDATE mem_nodes SET created_at=? WHERE uri=?`,
+		created5d.UnixMilli(), "mem://user/patterns/c"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Captures are derived from created_at — full history, no snapshot needed.
+	series, err := db.BuildDailySeries(30)
+	if err != nil {
+		t.Fatalf("BuildDailySeries: %v", err)
+	}
+	if len(series) != 30 {
+		t.Fatalf("series len = %d, want 30", len(series))
+	}
+	totalCap := 0
+	for _, p := range series {
+		totalCap += p.Captures
+	}
+	if totalCap != 3 {
+		t.Errorf("total captures = %d, want 3", totalCap)
+	}
+	// The backdated capture lands on its own UTC date.
+	wantDate := created5d.Format("2006-01-02")
+	var found bool
+	for _, p := range series {
+		if p.Date == wantDate && p.Captures == 1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("backdated capture not found on %s", wantDate)
+	}
+
+	// Seed a prior-day snapshot, give a node access, roll up today → retrievals diff.
+	yesterday := now.AddDate(0, 0, -1).Format("2006-01-02")
+	if _, err := db.Exec(`INSERT INTO metrics_daily (date, total_access, updated_at) VALUES (?, ?, ?)`,
+		yesterday, 5, now.UnixMilli()-day); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE mem_nodes SET access_count=8 WHERE uri=?`, "mem://user/patterns/a"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.RollupDailySnapshot(); err != nil {
+		t.Fatalf("RollupDailySnapshot: %v", err)
+	}
+
+	// Today's snapshot must exist with the live active total + cumulative access.
+	var active int
+	var totalAccess int64
+	today := now.Format("2006-01-02")
+	if err := db.QueryRow(`SELECT active_total, total_access FROM metrics_daily WHERE date=?`, today).
+		Scan(&active, &totalAccess); err != nil {
+		t.Fatalf("read today snapshot: %v", err)
+	}
+	if active != 3 {
+		t.Errorf("snapshot active_total = %d, want 3", active)
+	}
+	if totalAccess != 8 {
+		t.Errorf("snapshot total_access = %d, want 8", totalAccess)
+	}
+
+	// Retrievals for today = today's total_access (8) − yesterday's (5) = 3.
+	series2, err := db.BuildDailySeries(30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var todayPt *DailyPoint
+	for i := range series2 {
+		if series2[i].Date == today {
+			todayPt = &series2[i]
+		}
+	}
+	if todayPt == nil {
+		t.Fatal("today not in series")
+	}
+	if !todayPt.HasSnapshot {
+		t.Error("today should have a snapshot")
+	}
+	if todayPt.Retrievals != 3 {
+		t.Errorf("today retrievals = %d, want 3 (8−5)", todayPt.Retrievals)
+	}
+}

--- a/internal/store/metrics_test.go
+++ b/internal/store/metrics_test.go
@@ -1,0 +1,190 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// TestComputeMetrics exercises the freshness bands, needs-attention lists, and
+// retraction accounting against a hand-built memory base with controlled ages.
+func TestComputeMetrics(t *testing.T) {
+	db := testDB(t)
+	now := time.Now().UnixMilli()
+	day := int64(24 * 60 * 60 * 1000)
+
+	// backdate forces created_at + last_access to ageDays in the past so decay is
+	// computed from a known reference time. setAccess overrides access_count.
+	mk := func(uri, category string) {
+		if err := db.CreateNode(&MemNode{URI: uri, NodeType: "leaf", Category: category, L0Abstract: "x"}); err != nil {
+			t.Fatalf("create %s: %v", uri, err)
+		}
+	}
+	backdate := func(uri string, ageDays int64) {
+		ts := now - ageDays*day
+		if _, err := db.Exec(`UPDATE mem_nodes SET created_at=?, last_access=? WHERE uri=?`, ts, ts, uri); err != nil {
+			t.Fatalf("backdate %s: %v", uri, err)
+		}
+	}
+	setAccess := func(uri string, n int) {
+		if _, err := db.Exec(`UPDATE mem_nodes SET access_count=? WHERE uri=?`, n, uri); err != nil {
+			t.Fatalf("setAccess %s: %v", uri, err)
+		}
+	}
+
+	// Fresh, never retrieved (age 0 → not "old").
+	mk("mem://user/patterns/fresh", "patterns")
+
+	// Stale, old, never retrieved → stale band + never_retrieved_old.
+	mk("mem://user/patterns/stale-orphan", "patterns")
+	backdate("mem://user/patterns/stale-orphan", 200)
+
+	// Load-bearing but decaying: retrieved a lot, ~0.40 effective → stale + stale_high_retrieval.
+	mk("mem://user/cases/load-bearing", "cases")
+	backdate("mem://user/cases/load-bearing", 120)
+	setAccess("mem://user/cases/load-bearing", 42)
+
+	// Near the decay cliff: 99 days → 0.5^1.1 ≈ 0.466, in [0.4,0.5). Retrieved once.
+	mk("mem://user/cases/cliff", "cases")
+	backdate("mem://user/cases/cliff", 99)
+	setAccess("mem://user/cases/cliff", 3)
+
+	// Moments are decay-exempt: old but stays fresh (stored relevance 1.0).
+	mk("mem://user/moments/exempt", "moments")
+	backdate("mem://user/moments/exempt", 200)
+
+	// Retracted with a successor → counted, recent, NOT orphaned.
+	mk("mem://user/events/superseded", "events")
+	if _, err := db.Exec(`UPDATE mem_nodes SET tombstoned_at=?, superseded_by=? WHERE uri=?`,
+		now-5*day, "mem://user/events/newer", "mem://user/events/superseded"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Retracted without a successor → orphaned tombstone.
+	mk("mem://user/events/orphan-tomb", "events")
+	if _, err := db.Exec(`UPDATE mem_nodes SET tombstoned_at=? WHERE uri=?`,
+		now-2*day, "mem://user/events/orphan-tomb"); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := db.ComputeMetrics()
+	if err != nil {
+		t.Fatalf("ComputeMetrics: %v", err)
+	}
+
+	// Active = fresh, stale-orphan, load-bearing, cliff, moments = 5.
+	if m.Summary.ActiveTotal != 5 {
+		t.Errorf("active_total = %d, want 5", m.Summary.ActiveTotal)
+	}
+	if m.Summary.RetractedTotal != 2 {
+		t.Errorf("retracted_total = %d, want 2", m.Summary.RetractedTotal)
+	}
+	if m.Summary.RecentRetractions != 2 {
+		t.Errorf("recent_retractions = %d, want 2", m.Summary.RecentRetractions)
+	}
+
+	// Fresh band: fresh node + exempt moments = 2.
+	if m.Summary.Fresh != 2 {
+		t.Errorf("fresh = %d, want 2 (fresh + exempt moments)", m.Summary.Fresh)
+	}
+	// Stale band: stale-orphan + load-bearing = 2.
+	if m.Summary.Stale != 2 {
+		t.Errorf("stale = %d, want 2", m.Summary.Stale)
+	}
+	// Cliff node is fading (0.466 between stale and fresh).
+	if m.Summary.Fading != 1 {
+		t.Errorf("fading = %d, want 1", m.Summary.Fading)
+	}
+
+	// Never retrieved: fresh, stale-orphan, cliff has access, load-bearing has access,
+	// moments never retrieved. → fresh, stale-orphan, moments = 3.
+	if m.Summary.NeverRetrieved != 3 {
+		t.Errorf("never_retrieved = %d, want 3", m.Summary.NeverRetrieved)
+	}
+
+	// Retraction rate = 2 / 7.
+	if got := m.Summary.RetractionRate; got < 0.28 || got > 0.29 {
+		t.Errorf("retraction_rate = %f, want ~0.2857", got)
+	}
+
+	// Needs-attention lists.
+	if !hasURI(m.NeedsAttention.NeverRetrievedOld, "mem://user/patterns/stale-orphan") {
+		t.Error("stale-orphan should be in never_retrieved_old")
+	}
+	if hasURI(m.NeedsAttention.NeverRetrievedOld, "mem://user/patterns/fresh") {
+		t.Error("fresh (age 0) should NOT be in never_retrieved_old")
+	}
+	if !hasURI(m.NeedsAttention.StaleHighRetrieval, "mem://user/cases/load-bearing") {
+		t.Error("load-bearing should be in stale_high_retrieval")
+	}
+	if !hasURI(m.NeedsAttention.NearDecayCliff, "mem://user/cases/cliff") {
+		t.Error("cliff should be in near_decay_cliff")
+	}
+	if !hasURI(m.NeedsAttention.OrphanedTombstones, "mem://user/events/orphan-tomb") {
+		t.Error("orphan-tomb should be in orphaned_tombstones")
+	}
+	if hasURI(m.NeedsAttention.OrphanedTombstones, "mem://user/events/superseded") {
+		t.Error("superseded (has successor) should NOT be orphaned")
+	}
+
+	// Critical: most-retrieved first.
+	if len(m.Critical) == 0 || m.Critical[0].URI != "mem://user/cases/load-bearing" {
+		t.Errorf("critical[0] = %+v, want load-bearing on top", m.Critical)
+	}
+
+	// Histogram bins cover every active memory exactly once.
+	histSum := 0
+	for _, b := range m.Histogram {
+		histSum += b.Count
+	}
+	if histSum != m.Summary.ActiveTotal {
+		t.Errorf("histogram sum = %d, want active_total %d", histSum, m.Summary.ActiveTotal)
+	}
+
+	// Categories present and shares sum to ~1.0.
+	var sum float64
+	for _, c := range m.Categories {
+		sum += c.Share
+	}
+	if sum < 0.99 || sum > 1.01 {
+		t.Errorf("category shares sum = %f, want ~1.0", sum)
+	}
+}
+
+// TestComputeMetrics_ReadOnly verifies that computing metrics never mutates the
+// store — relevance and access_count must be identical before and after.
+func TestComputeMetrics_ReadOnly(t *testing.T) {
+	db := testDB(t)
+	if err := db.CreateNode(&MemNode{URI: "mem://user/patterns/p", NodeType: "leaf", Category: "patterns", L0Abstract: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UnixMilli()
+	day := int64(24 * 60 * 60 * 1000)
+	if _, err := db.Exec(`UPDATE mem_nodes SET created_at=?, last_access=?, relevance=1.0, access_count=7 WHERE uri=?`,
+		now-150*day, now-150*day, "mem://user/patterns/p"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.ComputeMetrics(); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := db.GetNodeByURI("mem://user/patterns/p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n.Relevance != 1.0 {
+		t.Errorf("relevance mutated to %f; ComputeMetrics must be read-only", n.Relevance)
+	}
+	if n.AccessCount != 7 {
+		t.Errorf("access_count mutated to %d; ComputeMetrics must be read-only", n.AccessCount)
+	}
+}
+
+func hasURI(xs []MetricNode, uri string) bool {
+	for _, x := range xs {
+		if x.URI == uri {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/migration_e2e_test.go
+++ b/internal/store/migration_e2e_test.go
@@ -183,8 +183,10 @@ func fetchMemoryByURI(t *testing.T, serverURL, uri string) map[string]any {
 	return out
 }
 
-// assertSchemaV9 reopens the DB and asserts SchemaVersion() returns the
-// current head version (9). Inline so call sites read top-down.
+// assertSchemaV9 reopens the DB and asserts SchemaVersion() returns the current
+// head version. (Named for v9, the rebuild this suite was written around; it
+// tracks head so additive migrations don't break it.) Inline so call sites read
+// top-down.
 func assertSchemaV9(t *testing.T, dbPath string) {
 	t.Helper()
 	db, err := Open(dbPath)
@@ -196,8 +198,8 @@ func assertSchemaV9(t *testing.T, dbPath string) {
 	if err != nil {
 		t.Fatalf("SchemaVersion: %v", err)
 	}
-	if v != 9 {
-		t.Errorf("schema_version = %d, want 9 (have %d migrations)", v, len(migrations))
+	if v != headVersion() {
+		t.Errorf("schema_version = %d, want head %d (have %d migrations)", v, headVersion(), len(migrations))
 	}
 }
 

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -236,6 +236,28 @@ CREATE INDEX idx_nodes_category  ON mem_nodes(category);
 CREATE INDEX idx_nodes_relevance ON mem_nodes(relevance DESC);
 `,
 	},
+	{
+		Version:     10,
+		Description: "metrics_daily: daily health snapshot for Memory Health trend lines",
+		// Additive table; no user data touched. total_access is the cumulative
+		// SUM(access_count) snapshotted daily — day-over-day diffs yield retrievals
+		// per day without logging per-touch events or mutating hot paths.
+		SQL: `
+CREATE TABLE metrics_daily (
+    date            TEXT PRIMARY KEY,            -- 'YYYY-MM-DD' (UTC)
+    active_total    INTEGER NOT NULL DEFAULT 0,
+    retracted_total INTEGER NOT NULL DEFAULT 0,
+    fresh           INTEGER NOT NULL DEFAULT 0,
+    fading          INTEGER NOT NULL DEFAULT 0,
+    stale           INTEGER NOT NULL DEFAULT 0,
+    never_retrieved INTEGER NOT NULL DEFAULT 0,
+    total_access    INTEGER NOT NULL DEFAULT 0,  -- SUM(access_count); daily retrievals = diff vs prior day
+    captures        INTEGER NOT NULL DEFAULT 0,  -- memories created that day
+    category_counts TEXT,                        -- JSON {category: count}
+    updated_at      INTEGER NOT NULL
+);
+`,
+	},
 }
 
 // headVersion is the highest schema version this binary knows how to apply.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -7,6 +7,16 @@
     "": {
       "name": "continuity-ui",
       "version": "0.0.1",
+      "dependencies": {
+        "@types/d3-array": "^3.2.2",
+        "@types/d3-scale": "^4.0.9",
+        "@types/d3-selection": "^3.0.11",
+        "@types/d3-shape": "^3.1.8",
+        "d3-array": "^3.2.4",
+        "d3-scale": "^4.0.2",
+        "d3-selection": "^3.0.0",
+        "d3-shape": "^3.2.0"
+      },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@tailwindcss/vite": "^4.1.3",
@@ -1180,6 +1190,48 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1235,6 +1287,118 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/debug": {
@@ -1394,6 +1558,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-reference": {
       "version": "3.0.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,5 +15,15 @@
     "tailwindcss": "^4.1.3",
     "typescript": "^5.7.3",
     "vite": "^6.3.1"
+  },
+  "dependencies": {
+    "@types/d3-array": "^3.2.2",
+    "@types/d3-scale": "^4.0.9",
+    "@types/d3-selection": "^3.0.11",
+    "@types/d3-shape": "^3.1.8",
+    "d3-array": "^3.2.4",
+    "d3-scale": "^4.0.2",
+    "d3-selection": "^3.0.0",
+    "d3-shape": "^3.2.0"
   }
 }

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { activeTab } from './lib/stores';
   import Header from './components/Header.svelte';
+  import HealthPanel from './components/HealthPanel.svelte';
   import TreeBrowser from './components/TreeBrowser.svelte';
   import SearchPanel from './components/SearchPanel.svelte';
   import ProfilePanel from './components/ProfilePanel.svelte';
@@ -9,7 +10,9 @@
 <div class="min-h-screen">
   <Header />
   <main>
-    {#if $activeTab === 'tree'}
+    {#if $activeTab === 'health'}
+      <HealthPanel />
+    {:else if $activeTab === 'tree'}
       <TreeBrowser />
     {:else if $activeTab === 'search'}
       <SearchPanel />

--- a/ui/src/components/DecayHistogram.svelte
+++ b/ui/src/components/DecayHistogram.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+  import { scaleLinear } from 'd3-scale';
+  import { area, line, curveCatmullRom } from 'd3-shape';
+  import { max } from 'd3-array';
+  import type { HistBin } from '../lib/types';
+  import { FRESH_THRESHOLD, STALE_THRESHOLD } from '../lib/types';
+
+  interface Props {
+    bins: HistBin[];
+  }
+  let { bins }: Props = $props();
+
+  // Fixed drawing space; the SVG scales to its container via viewBox.
+  const W = 760;
+  const H = 240;
+  const M = { top: 16, right: 16, bottom: 30, left: 32 };
+  const iw = W - M.left - M.right;
+  const ih = H - M.top - M.bottom;
+
+  const lo = $derived(bins.length ? bins[0].lo : 0.1);
+  const hi = $derived(bins.length ? bins[bins.length - 1].hi : 1.0);
+  const maxCount = $derived(Math.max(1, max(bins, (b) => b.count) ?? 1));
+
+  const x = $derived(scaleLinear().domain([lo, hi]).range([M.left, M.left + iw]));
+  const y = $derived(scaleLinear().domain([0, maxCount]).range([M.top + ih, M.top]));
+
+  // Smooth ridge over bin centers, anchored to the baseline at both edges so the
+  // area reads as a single shape rather than disconnected bars.
+  type Pt = { v: number; c: number };
+  const pts = $derived<Pt[]>([
+    { v: lo, c: 0 },
+    ...bins.map((b) => ({ v: (b.lo + b.hi) / 2, c: b.count })),
+    { v: hi, c: 0 },
+  ]);
+
+  const areaPath = $derived(
+    area<Pt>()
+      .x((p) => x(p.v))
+      .y0(M.top + ih)
+      .y1((p) => y(p.c))
+      .curve(curveCatmullRom.alpha(0.5))(pts) ?? '',
+  );
+  const linePath = $derived(
+    line<Pt>()
+      .x((p) => x(p.v))
+      .y((p) => y(p.c))
+      .curve(curveCatmullRom.alpha(0.5))(pts) ?? '',
+  );
+
+  // Gradient stop offsets (%) for the band thresholds, positioned by relevance.
+  const span = $derived(hi - lo || 1);
+  const staleOff = $derived(((STALE_THRESHOLD - lo) / span) * 100);
+  const freshOff = $derived(((FRESH_THRESHOLD - lo) / span) * 100);
+
+  // Hover: snap to nearest bin.
+  let hover = $state<{ bin: HistBin; cx: number } | null>(null);
+  function onMove(e: PointerEvent) {
+    const svg = e.currentTarget as SVGSVGElement;
+    const r = svg.getBoundingClientRect();
+    const px = ((e.clientX - r.left) / r.width) * W; // back to viewBox space
+    const rel = x.invert(px);
+    let best: HistBin | null = null;
+    let bestD = Infinity;
+    for (const b of bins) {
+      const c = (b.lo + b.hi) / 2;
+      const d = Math.abs(c - rel);
+      if (d < bestD) {
+        bestD = d;
+        best = b;
+      }
+    }
+    if (best) hover = { bin: best, cx: x((best.lo + best.hi) / 2) };
+  }
+  function onLeave() {
+    hover = null;
+  }
+
+  const ticks = [0.1, 0.4, 0.7, 1.0];
+</script>
+
+<div class="relative">
+  <svg
+    viewBox="0 0 {W} {H}"
+    class="w-full"
+    style="height: auto"
+    role="img"
+    aria-label="Relevance distribution of active memories"
+    onpointermove={onMove}
+    onpointerleave={onLeave}
+  >
+    <defs>
+      <linearGradient id="decay-grad" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0%" stop-color="var(--color-cases)" />
+        <stop offset="{staleOff}%" stop-color="var(--color-cases)" />
+        <stop offset="{staleOff}%" stop-color="var(--color-events)" />
+        <stop offset="{freshOff}%" stop-color="var(--color-events)" />
+        <stop offset="{freshOff}%" stop-color="var(--color-preferences)" />
+        <stop offset="100%" stop-color="var(--color-preferences)" />
+      </linearGradient>
+    </defs>
+
+    <!-- Faint band regions behind the ridge -->
+    <rect x={x(lo)} y={M.top} width={x(STALE_THRESHOLD) - x(lo)} height={ih}
+      fill="var(--color-cases)" opacity="0.05" />
+    <rect x={x(STALE_THRESHOLD)} y={M.top} width={x(FRESH_THRESHOLD) - x(STALE_THRESHOLD)} height={ih}
+      fill="var(--color-events)" opacity="0.05" />
+    <rect x={x(FRESH_THRESHOLD)} y={M.top} width={x(hi) - x(FRESH_THRESHOLD)} height={ih}
+      fill="var(--color-preferences)" opacity="0.05" />
+
+    <!-- baseline -->
+    <line x1={M.left} y1={M.top + ih} x2={M.left + iw} y2={M.top + ih}
+      stroke="var(--border)" stroke-width="1" />
+
+    <!-- the ridge -->
+    <path d={areaPath} fill="url(#decay-grad)" opacity="0.32" />
+    <path d={linePath} fill="none" stroke="url(#decay-grad)" stroke-width="2" />
+
+    <!-- threshold guides -->
+    {#each [STALE_THRESHOLD, FRESH_THRESHOLD] as t}
+      <line x1={x(t)} y1={M.top} x2={x(t)} y2={M.top + ih}
+        stroke="var(--border-hover)" stroke-width="1" stroke-dasharray="3 3" opacity="0.6" />
+    {/each}
+
+    <!-- hover marker -->
+    {#if hover}
+      <line x1={hover.cx} y1={M.top} x2={hover.cx} y2={M.top + ih}
+        stroke="var(--color-accent)" stroke-width="1" opacity="0.7" />
+      <circle cx={hover.cx} cy={y(hover.bin.count)} r="3.5"
+        fill="var(--color-accent)" />
+    {/if}
+
+    <!-- x ticks -->
+    {#each ticks as t}
+      <text x={x(t)} y={M.top + ih + 18} text-anchor="middle"
+        class="axis-label">{t.toFixed(1)}</text>
+    {/each}
+    <!-- y max label -->
+    <text x={M.left - 6} y={M.top + 8} text-anchor="end" class="axis-label">{maxCount}</text>
+
+    <!-- band captions -->
+    <text x={(x(lo) + x(STALE_THRESHOLD)) / 2} y={M.top + 12} text-anchor="middle"
+      class="band-label" fill="var(--color-cases)">stale</text>
+    <text x={(x(STALE_THRESHOLD) + x(FRESH_THRESHOLD)) / 2} y={M.top + 12} text-anchor="middle"
+      class="band-label" fill="var(--color-events)">fading</text>
+    <text x={(x(FRESH_THRESHOLD) + x(hi)) / 2} y={M.top + 12} text-anchor="middle"
+      class="band-label" fill="var(--color-preferences)">fresh</text>
+  </svg>
+
+  {#if hover}
+    <div class="tooltip" style="left: {(hover.cx / W) * 100}%">
+      <span class="tip-count">{hover.bin.count}</span>
+      <span class="tip-range">relevance {hover.bin.lo.toFixed(2)}–{hover.bin.hi.toFixed(2)}</span>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .axis-label {
+    font-size: 10px;
+    font-family: ui-monospace, monospace;
+    fill: var(--text-secondary);
+    opacity: 0.55;
+  }
+  .band-label {
+    font-size: 9px;
+    font-family: ui-monospace, monospace;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    opacity: 0.7;
+  }
+  .tooltip {
+    position: absolute;
+    top: -4px;
+    transform: translateX(-50%);
+    pointer-events: none;
+    background: var(--bg-card-hover);
+    border: 1px solid var(--border-hover);
+    border-radius: 6px;
+    padding: 4px 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    white-space: nowrap;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  }
+  .tip-count {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .tip-range {
+    font-size: 10px;
+    font-family: ui-monospace, monospace;
+    color: var(--text-secondary);
+  }
+</style>

--- a/ui/src/components/EffectivenessSparkline.svelte
+++ b/ui/src/components/EffectivenessSparkline.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  import { scaleLinear } from 'd3-scale';
+  import { area, line, curveMonotoneX } from 'd3-shape';
+  import { max } from 'd3-array';
+  import type { DailyPoint } from '../lib/types';
+
+  interface Props {
+    daily: DailyPoint[];
+  }
+  let { daily }: Props = $props();
+
+  const W = 760;
+  const H = 110;
+  const M = { top: 14, right: 12, bottom: 18, left: 28 };
+  const iw = W - M.left - M.right;
+  const ih = H - M.top - M.bottom;
+
+  const totalCaptures = $derived(daily.reduce((s, d) => s + d.captures, 0));
+  const totalRetrievals = $derived(daily.reduce((s, d) => s + d.retrievals, 0));
+  const hasRetrievals = $derived(daily.some((d) => d.has_snapshot && d.retrievals > 0));
+
+  // Shared y-axis: comparing capture vs retrieval volume is the whole point.
+  const yMax = $derived(Math.max(1, max(daily, (d) => Math.max(d.captures, d.retrievals)) ?? 1));
+  const x = $derived(
+    scaleLinear().domain([0, Math.max(1, daily.length - 1)]).range([M.left, M.left + iw]),
+  );
+  const y = $derived(scaleLinear().domain([0, yMax]).range([M.top + ih, M.top]));
+
+  const capArea = $derived(
+    area<DailyPoint>()
+      .x((_, i) => x(i))
+      .y0(M.top + ih)
+      .y1((d) => y(d.captures))
+      .curve(curveMonotoneX)(daily) ?? '',
+  );
+  const capLine = $derived(
+    line<DailyPoint>()
+      .x((_, i) => x(i))
+      .y((d) => y(d.captures))
+      .curve(curveMonotoneX)(daily) ?? '',
+  );
+  const retLine = $derived(
+    line<DailyPoint>()
+      .x((_, i) => x(i))
+      .y((d) => y(d.retrievals))
+      .curve(curveMonotoneX)(daily) ?? '',
+  );
+
+  let hover = $state<{ d: DailyPoint; cx: number } | null>(null);
+  function onMove(e: PointerEvent) {
+    const svg = e.currentTarget as SVGSVGElement;
+    const r = svg.getBoundingClientRect();
+    const px = ((e.clientX - r.left) / r.width) * W;
+    let i = Math.round(x.invert(px));
+    if (i < 0) i = 0;
+    if (i > daily.length - 1) i = daily.length - 1;
+    if (daily[i]) hover = { d: daily[i], cx: x(i) };
+  }
+  function onLeave() {
+    hover = null;
+  }
+
+  const firstDate = $derived(daily.length ? daily[0].date.slice(5) : '');
+  const lastDate = $derived(daily.length ? daily[daily.length - 1].date.slice(5) : '');
+</script>
+
+<div class="relative">
+  <div class="flex items-center gap-4 mb-1 text-[10px] font-mono">
+    <span style="color: var(--color-patterns)">● {totalCaptures} captures</span>
+    <span style="color: var(--color-accent)" class:dim={!hasRetrievals}>
+      ● {totalRetrievals} retrievals{hasRetrievals ? '' : ' (accruing)'}
+    </span>
+    <span class="ml-auto text-[var(--text-secondary)] opacity-50">last {daily.length}d</span>
+  </div>
+
+  <svg
+    viewBox="0 0 {W} {H}"
+    class="w-full"
+    style="height: auto"
+    role="img"
+    aria-label="Captures and retrievals per day"
+    onpointermove={onMove}
+    onpointerleave={onLeave}
+  >
+    <line x1={M.left} y1={M.top + ih} x2={M.left + iw} y2={M.top + ih}
+      stroke="var(--border)" stroke-width="1" />
+
+    <path d={capArea} fill="var(--color-patterns)" opacity="0.12" />
+    <path d={capLine} fill="none" stroke="var(--color-patterns)" stroke-width="2" />
+    <path d={retLine} fill="none" stroke="var(--color-accent)" stroke-width="1.5"
+      stroke-dasharray={hasRetrievals ? 'none' : '3 3'} opacity={hasRetrievals ? 0.95 : 0.4} />
+
+    {#if hover}
+      <line x1={hover.cx} y1={M.top} x2={hover.cx} y2={M.top + ih}
+        stroke="var(--color-accent)" stroke-width="1" opacity="0.5" />
+      <circle cx={hover.cx} cy={y(hover.d.captures)} r="3" fill="var(--color-patterns)" />
+      <circle cx={hover.cx} cy={y(hover.d.retrievals)} r="3" fill="var(--color-accent)" />
+    {/if}
+
+    <text x={M.left} y={H - 4} class="axis-label" text-anchor="start">{firstDate}</text>
+    <text x={M.left + iw} y={H - 4} class="axis-label" text-anchor="end">{lastDate}</text>
+    <text x={M.left - 6} y={M.top + 8} class="axis-label" text-anchor="end">{yMax}</text>
+  </svg>
+
+  {#if hover}
+    <div class="tooltip" style="left: {(hover.cx / W) * 100}%">
+      <span class="tip-date">{hover.d.date}</span>
+      <span style="color: var(--color-patterns)">{hover.d.captures} captured</span>
+      <span style="color: var(--color-accent)">
+        {hover.d.has_snapshot ? `${hover.d.retrievals} retrieved` : 'no snapshot'}
+      </span>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .axis-label {
+    font-size: 9px;
+    font-family: ui-monospace, monospace;
+    fill: var(--text-secondary);
+    opacity: 0.5;
+  }
+  .dim {
+    opacity: 0.55;
+  }
+  .tooltip {
+    position: absolute;
+    top: 18px;
+    transform: translateX(-50%);
+    pointer-events: none;
+    background: var(--bg-card-hover);
+    border: 1px solid var(--border-hover);
+    border-radius: 6px;
+    padding: 4px 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    white-space: nowrap;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    font-size: 10px;
+    font-family: ui-monospace, monospace;
+  }
+  .tip-date {
+    color: var(--text-secondary);
+    margin-bottom: 1px;
+  }
+</style>

--- a/ui/src/components/Header.svelte
+++ b/ui/src/components/Header.svelte
@@ -3,6 +3,7 @@
   import ThemeToggle from './ThemeToggle.svelte';
 
   const tabs: { id: Tab; label: string; icon: string }[] = [
+    { id: 'health', label: 'Health', icon: '\u2665' },
     { id: 'tree', label: 'Tree', icon: '\u25C8' },
     { id: 'search', label: 'Search', icon: '\u26B2' },
     { id: 'profile', label: 'Profile', icon: '\u2666' },

--- a/ui/src/components/HealthPanel.svelte
+++ b/ui/src/components/HealthPanel.svelte
@@ -1,0 +1,352 @@
+<script lang="ts">
+  import { fetchMetrics } from '../lib/api';
+  import type { MetricsResponse, MetricNode } from '../lib/types';
+  import { categoryColors, bandColor, type Category } from '../lib/types';
+  import DecayHistogram from './DecayHistogram.svelte';
+  import EffectivenessSparkline from './EffectivenessSparkline.svelte';
+
+  let data = $state<MetricsResponse | null>(null);
+  let loading = $state(true);
+  let error = $state('');
+
+  async function load() {
+    loading = true;
+    error = '';
+    try {
+      data = await fetchMetrics();
+    } catch (e) {
+      error = String(e);
+      data = null;
+    } finally {
+      loading = false;
+    }
+  }
+  load();
+
+  function catColor(cat: string): string {
+    return categoryColors[cat as Category] || 'var(--text-secondary)';
+  }
+  function slug(u: string): string {
+    const p = u.replace('mem://', '').split('/');
+    return p[p.length - 1] || u;
+  }
+  function pct(n: number): number {
+    return Math.round(n * 100);
+  }
+  function ageLabel(days: number): string {
+    if (days < 1) return 'today';
+    if (days === 1) return '1d';
+    if (days < 30) return `${days}d`;
+    if (days < 365) return `${Math.round(days / 30)}mo`;
+    return `${(days / 365).toFixed(1)}y`;
+  }
+
+  // Current-state verdict (no trend history yet — that arrives with metrics_daily).
+  const verdict = $derived.by(() => {
+    if (!data) return '';
+    const s = data.summary;
+    if (s.active_total === 0) return 'No memories yet.';
+    const staleFrac = s.stale / s.active_total;
+    const freshFrac = s.fresh / s.active_total;
+    if (staleFrac > 0.4) return 'Drifting stale — a lot of memory is fading out of reach.';
+    if (freshFrac > 0.6) return 'Healthy — most memory is fresh and reachable.';
+    return 'Stable — a healthy core with some fading at the edges.';
+  });
+
+  function nn<T>(xs: T[] | null): T[] {
+    return xs ?? [];
+  }
+</script>
+
+<div class="p-6 max-w-5xl mx-auto">
+  <div class="flex items-baseline justify-between mb-1">
+    <h2 class="text-lg font-semibold">Memory Health</h2>
+    {#if data}
+      <span class="text-xs font-mono text-[var(--text-secondary)] opacity-50">
+        {data.summary.active_total} active · {data.summary.retracted_total} retracted
+      </span>
+    {/if}
+  </div>
+
+  {#if error}
+    <p class="text-red-400 text-sm bg-red-400/10 px-4 py-3 rounded-lg mt-4">{error}</p>
+  {:else if loading}
+    <div class="text-center py-16">
+      <span class="loading-pulse text-[var(--color-accent)] text-2xl">♥</span>
+      <p class="text-[var(--text-secondary)] text-sm mt-2">Reading your memory…</p>
+    </div>
+  {:else if data}
+    <p class="text-sm text-[var(--text-secondary)] mb-5">{verdict}</p>
+
+    <!-- Stat tiles -->
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-5">
+      <div class="tile">
+        <span class="tile-label">Active</span>
+        <span class="tile-num">{data.summary.active_total}</span>
+        <span class="tile-sub">{data.summary.never_retrieved} never retrieved</span>
+      </div>
+
+      <div class="tile">
+        <span class="tile-label">Freshness</span>
+        <div class="seg mt-1.5">
+          {#each [['fresh', data.summary.fresh, 'var(--color-preferences)'], ['fading', data.summary.fading, 'var(--color-events)'], ['stale', data.summary.stale, 'var(--color-cases)']] as [, n, c]}
+            {#if (n as number) > 0}
+              <div class="seg-part" style="flex: {n}; background: {c}" title="{n}"></div>
+            {/if}
+          {/each}
+        </div>
+        <div class="flex gap-2.5 mt-1.5 text-[10px] font-mono text-[var(--text-secondary)]">
+          <span style="color: var(--color-preferences)">{data.summary.fresh} fresh</span>
+          <span style="color: var(--color-events)">{data.summary.fading} fading</span>
+          <span style="color: var(--color-cases)">{data.summary.stale} stale</span>
+        </div>
+      </div>
+
+      <div class="tile">
+        <span class="tile-label">Retraction rate</span>
+        <span class="tile-num">{pct(data.summary.retraction_rate)}<span class="text-base opacity-50">%</span></span>
+        <span class="tile-sub">{data.summary.recent_retractions} in last 30d</span>
+      </div>
+
+      <div class="tile">
+        <span class="tile-label">Categories</span>
+        <span class="tile-num">{data.categories.length}</span>
+        <span class="tile-sub">
+          {#if data.categories.length}top: {data.categories[0].category} ({pct(data.categories[0].share)}%){/if}
+        </span>
+      </div>
+    </div>
+
+    <!-- Hero: decay distribution -->
+    <div class="card mb-5">
+      <div class="flex items-baseline justify-between mb-2">
+        <h3 class="card-title">Decay distribution</h3>
+        <span class="text-[10px] font-mono text-[var(--text-secondary)] opacity-50">
+          where {data.summary.active_total} active memories sit on the relevance spectrum
+        </span>
+      </div>
+      <DecayHistogram bins={data.histogram} />
+    </div>
+
+    <!-- Category breakdown -->
+    <div class="card mb-5">
+      <h3 class="card-title mb-3">By category</h3>
+      <div class="space-y-2">
+        {#each data.categories as c}
+          <div class="flex items-center gap-3">
+            <span class="w-24 text-xs font-mono shrink-0" style="color: {catColor(c.category)}">{c.category}</span>
+            <div class="flex-1 h-2 rounded-full bg-[var(--border)] overflow-hidden">
+              <div class="h-full rounded-full" style="width: {pct(c.share)}%; background: {catColor(c.category)}; opacity: 0.75"></div>
+            </div>
+            <span class="w-8 text-right text-xs font-mono text-[var(--text-secondary)]">{c.count}</span>
+          </div>
+        {/each}
+      </div>
+    </div>
+
+    <!-- Needs attention -->
+    {#snippet attn(title: string, hint: string, items: MetricNode[], metric: (n: MetricNode) => string)}
+      <div class="card">
+        <h3 class="card-title">{title}</h3>
+        <p class="text-[10px] text-[var(--text-secondary)] opacity-60 mb-2.5">{hint}</p>
+        {#if items.length === 0}
+          <p class="text-xs text-[var(--text-secondary)] opacity-50 italic py-2">nothing here — clean</p>
+        {:else}
+          <div class="space-y-1.5">
+            {#each items as n}
+              <div class="attn-row">
+                <span class="dot" style="background: {catColor(n.category)}"></span>
+                <span class="attn-slug" title={n.uri}>{slug(n.uri)}</span>
+                <span class="attn-l0">{n.l0_abstract}</span>
+                <span class="attn-metric">{metric(n)}</span>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/snippet}
+
+    <h3 class="text-sm font-semibold text-[var(--text-secondary)] uppercase tracking-wide mb-3 mt-7">Needs attention</h3>
+    <div class="grid md:grid-cols-2 gap-3 mb-5">
+      {@render attn(
+        'Load-bearing & decaying',
+        'retrieved often but no longer fresh — refresh these first',
+        nn(data.needs_attention.stale_high_retrieval),
+        (n) => `${n.access_count}× · ${pct(n.relevance)}%`,
+      )}
+      {@render attn(
+        'Never retrieved & old',
+        'captured but never pulled into a session — noise or buried value',
+        nn(data.needs_attention.never_retrieved_old),
+        (n) => ageLabel(n.age_days),
+      )}
+      {@render attn(
+        'Near the decay cliff',
+        'approaching stale — act before they fade out of reach',
+        nn(data.needs_attention.near_decay_cliff),
+        (n) => `${pct(n.relevance)}%`,
+      )}
+      {@render attn(
+        'Orphaned tombstones',
+        'retracted without a successor — untidy supersession',
+        nn(data.needs_attention.orphaned_tombstones),
+        (n) => ageLabel(n.age_days),
+      )}
+    </div>
+
+    <!-- Critical -->
+    <div class="card mb-5">
+      <h3 class="card-title mb-1">Critical memories</h3>
+      <p class="text-[10px] text-[var(--text-secondary)] opacity-60 mb-3">most retrieved — your load-bearing core</p>
+      {#if nn(data.critical).length === 0}
+        <p class="text-xs text-[var(--text-secondary)] opacity-50 italic">nothing retrieved yet</p>
+      {:else}
+        <div class="space-y-1.5">
+          {#each nn(data.critical) as n, i}
+            <div class="crit-row">
+              <span class="crit-rank">{i + 1}</span>
+              <span class="dot" style="background: {catColor(n.category)}"></span>
+              <span class="attn-slug" title={n.uri}>{slug(n.uri)}</span>
+              <span class="attn-l0">{n.l0_abstract}</span>
+              <div class="crit-relbar"><div style="width: {pct(n.relevance)}%; background: {bandColor(n.relevance)}"></div></div>
+              <span class="crit-count">{n.access_count}×</span>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+    <!-- Footer: memory effectiveness over time -->
+    <div class="card">
+      <h3 class="card-title">Memory effectiveness</h3>
+      <p class="text-[10px] text-[var(--text-secondary)] opacity-60 mb-2">
+        captures vs retrievals per day — capture spikes above retrievals read as repeating yourself; a sustained retrieval dip reads as endemic drift, a one-off as gremlins
+      </p>
+      {#if nn(data.daily).length}
+        <EffectivenessSparkline daily={nn(data.daily)} />
+      {:else}
+        <p class="text-xs text-[var(--text-secondary)] opacity-50 italic py-2">no history yet</p>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .tile {
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px 14px;
+  }
+  .tile-label {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-secondary);
+    opacity: 0.7;
+  }
+  .tile-num {
+    font-size: 28px;
+    font-weight: 600;
+    line-height: 1.1;
+    margin-top: 2px;
+    color: var(--text-primary);
+  }
+  .tile-sub {
+    font-size: 11px;
+    font-family: ui-monospace, monospace;
+    color: var(--text-secondary);
+    opacity: 0.6;
+    margin-top: 2px;
+  }
+  .seg {
+    display: flex;
+    height: 8px;
+    border-radius: 4px;
+    overflow: hidden;
+    gap: 2px;
+    background: var(--border);
+  }
+  .seg-part {
+    height: 100%;
+  }
+  .card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 16px 18px;
+  }
+  .card-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .attn-row,
+  .crit-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    border-radius: 6px;
+    font-size: 12px;
+  }
+  .attn-row:hover,
+  .crit-row:hover {
+    background: var(--bg-card-hover);
+  }
+  .attn-slug {
+    font-family: ui-monospace, monospace;
+    font-size: 11px;
+    color: var(--text-primary);
+    flex-shrink: 0;
+    max-width: 30%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .attn-l0 {
+    flex: 1;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+  .attn-metric,
+  .crit-count {
+    font-family: ui-monospace, monospace;
+    font-size: 11px;
+    color: var(--text-secondary);
+    flex-shrink: 0;
+    text-align: right;
+  }
+  .crit-rank {
+    font-family: ui-monospace, monospace;
+    font-size: 10px;
+    color: var(--text-secondary);
+    opacity: 0.5;
+    width: 14px;
+    flex-shrink: 0;
+  }
+  .crit-relbar {
+    width: 56px;
+    height: 3px;
+    border-radius: 2px;
+    background: var(--border);
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+  .crit-relbar > div {
+    height: 100%;
+    border-radius: 2px;
+    opacity: 0.8;
+  }
+</style>

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { TreeResponse, SearchResponse, ProfileResponse, HealthResponse } from './types';
+import type { TreeResponse, SearchResponse, ProfileResponse, HealthResponse, MetricsResponse } from './types';
 
 const BASE = '/api';
 
@@ -33,4 +33,8 @@ export function fetchSearch(
 
 export function fetchProfile(): Promise<ProfileResponse> {
   return get('/profile');
+}
+
+export function fetchMetrics(): Promise<MetricsResponse> {
+  return get('/metrics');
 }

--- a/ui/src/lib/stores.ts
+++ b/ui/src/lib/stores.ts
@@ -1,8 +1,8 @@
 import { writable } from 'svelte/store';
 
-export type Tab = 'tree' | 'search' | 'profile';
+export type Tab = 'health' | 'tree' | 'search' | 'profile';
 
-export const activeTab = writable<Tab>('tree');
+export const activeTab = writable<Tab>('health');
 
 // Default to dark mode (matches the brand), respect saved preference
 function getInitialDarkMode(): boolean {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -59,7 +59,9 @@ export interface HealthResponse {
   db: boolean;
 }
 
-export type Category = 'profile' | 'preferences' | 'feedback' | 'entities' | 'events' | 'patterns' | 'cases' | 'reference';
+export type Category =
+  | 'profile' | 'preferences' | 'feedback' | 'entities' | 'events'
+  | 'patterns' | 'cases' | 'reference' | 'moments' | 'session';
 
 export const categoryColors: Record<Category, string> = {
   profile: 'var(--color-profile)',
@@ -70,4 +72,82 @@ export const categoryColors: Record<Category, string> = {
   patterns: 'var(--color-patterns)',
   cases: 'var(--color-cases)',
   reference: 'var(--color-reference)',
+  moments: 'var(--color-accent)',
+  session: 'var(--text-secondary)',
 };
+
+// ── Memory Health metrics (GET /api/metrics) ─────────────────────────────────
+
+export interface MetricNode {
+  uri: string;
+  category: string;
+  l0_abstract: string;
+  relevance: number;
+  access_count: number;
+  last_access?: number;
+  created_at: number;
+  age_days: number;
+}
+
+export interface CategoryShare {
+  category: string;
+  count: number;
+  share: number;
+}
+
+export interface HistBin {
+  lo: number;
+  hi: number;
+  count: number;
+}
+
+export interface DailyPoint {
+  date: string; // 'YYYY-MM-DD'
+  captures: number;
+  retrievals: number;
+  active_total: number;
+  fresh: number;
+  fading: number;
+  stale: number;
+  has_snapshot: boolean;
+}
+
+export interface MetricsResponse {
+  generated_at: number;
+  summary: {
+    active_total: number;
+    retracted_total: number;
+    fresh: number;
+    fading: number;
+    stale: number;
+    never_retrieved: number;
+    retraction_rate: number;
+    recent_retractions: number;
+  };
+  categories: CategoryShare[];
+  histogram: HistBin[];
+  needs_attention: {
+    stale_high_retrieval: MetricNode[] | null;
+    never_retrieved_old: MetricNode[] | null;
+    near_decay_cliff: MetricNode[] | null;
+    orphaned_tombstones: MetricNode[] | null;
+  };
+  critical: MetricNode[] | null;
+  daily: DailyPoint[] | null;
+}
+
+// Freshness band thresholds — must match internal/store/metrics.go.
+export const FRESH_THRESHOLD = 0.7;
+export const STALE_THRESHOLD = 0.4;
+
+export function bandColor(relevance: number): string {
+  if (relevance >= FRESH_THRESHOLD) return 'var(--color-preferences)'; // emerald = healthy
+  if (relevance < STALE_THRESHOLD) return 'var(--color-cases)'; // rose = stale
+  return 'var(--color-events)'; // amber = fading
+}
+
+export function bandLabel(relevance: number): string {
+  if (relevance >= FRESH_THRESHOLD) return 'fresh';
+  if (relevance < STALE_THRESHOLD) return 'stale';
+  return 'fading';
+}


### PR DESCRIPTION
## What

A read-only **Memory Health** view in the viewer — see where your memories sit on the decay spectrum, what needs attention, and how capture/retrieval activity trends over time. Single-user observability that lives entirely in the human UI.

## Highlights

**Backend**
- `GET /api/metrics` — single read-only payload. Decay computed live from timestamps; **never writes**, so opening the dashboard can't change what it measures.
- Summary buckets (fresh/fading/stale), category shares, an 18-bin relevance histogram, needs-attention lists (load-bearing & decaying, never-retrieved & old, near decay cliff, orphaned tombstones), and most-retrieved knowledge.
- "Most retrieved" **excludes session-injected categories** (moments/session) so `access_count` reflects load-bearing knowledge, not injection frequency.
- **Schema v10** (additive, non-risky): `metrics_daily` ledger. Retrievals/day = day-over-day diff of snapshotted `SUM(access_count)` — no hot-path writes, no `TouchNode` change. Captures/day derived live from `created_at`. Hourly rollup on a serve ticker; snapshot read bounded to the window; one upserted row/day (self-limiting).

**UI**
- New **Memory Health** tab (default landing) with a D3 decay-distribution ridge and a captures-vs-retrievals effectiveness sparkline.

**Tests**
- Metrics aggregation, read-only guard, daily rollup + retrieval-diff (incl. pre-window baseline), and the `/api/metrics` endpoint. De-pinned migration version assertions from hardcoded `9` → `headVersion()` so additive migrations don't break them.

## Principle

Per-memory telemetry stays in the human UI — **never injected into agent context**. Viewing is read-only by contract.

## Notes

- "Load-bearing" == retrieval frequency (there's no citation graph; out of scope).
- Release notes drafted as v0.8.0 "Vital Signs."

🤖 Generated with [Claude Code](https://claude.com/claude-code)