### PR TITLE
Bind vector identity to the corpus: end the silent re-embed migration

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,0 +1,517 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/lazypower/continuity/internal/config"
+	"github.com/lazypower/continuity/internal/engine"
+	"github.com/lazypower/continuity/internal/hooks"
+	"github.com/lazypower/continuity/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var (
+	doctorJSON   bool
+	doctorRepair bool
+	doctorApply  bool
+)
+
+var doctorCmd = &cobra.Command{
+	Use:     "doctor",
+	Aliases: []string{"diagnose"},
+	Short:   "Diagnose memory index health (embedder/vector coherence)",
+	Long: `Diagnose checks whether the stored embedding vectors are coherent with the
+embedder the server actually runs. It is strictly read-only — it never writes,
+re-embeds, or touches access metrics. Repair is a separate, explicit step.
+
+Checks:
+  - active embedder + expected vector dimension
+  - stored vector model/dimension distribution
+  - missing vectors (leaves with no embedding)
+  - mixed-dimension vectors
+  - stale vectors from an older embedder
+  - a read-only retrieval smoke test (do nodes retrieve themselves?)`,
+	RunE: runDoctor,
+}
+
+func init() {
+	doctorCmd.Flags().BoolVar(&doctorJSON, "json", false, "Emit the report as JSON")
+	doctorCmd.Flags().BoolVar(&doctorRepair, "repair-vectors", false, "Re-embed stale/missing vectors to the active embedder (dry-run unless --apply)")
+	doctorCmd.Flags().BoolVar(&doctorApply, "apply", false, "With --repair-vectors: snapshot first, then actually re-embed")
+}
+
+// vectorGroup is one (model, dimensions) bucket of the stored corpus.
+type vectorGroup struct {
+	Model      string `json:"model"`
+	Dimensions int    `json:"dimensions"`
+	Count      int    `json:"count"`
+}
+
+// smokeResult summarizes the read-only self-retrieval probe.
+type smokeResult struct {
+	Sampled    int    `json:"sampled"`
+	SelfFound  int    `json:"self_found"`
+	TopK       int    `json:"top_k"`
+	MedianRank int    `json:"median_rank"` // -1 when not applicable
+	Note       string `json:"note,omitempty"`
+}
+
+// doctorReport is the full diagnosis. It carries no remediation — repair is a
+// separate, explicit command.
+type doctorReport struct {
+	ActiveEmbedder   string `json:"active_embedder"`   // what doctor resolves now (CLI-side)
+	DeclaredIdentity string `json:"declared_identity"` // corpus's bound vector identity
+	ExpectedDims     int    `json:"expected_dimensions"`
+
+	// What the RUNNING server actually embeds with (vs. doctor's fresh resolve).
+	// Closes the fresh-resolve blind spot: doctor reporting "healthy" while the
+	// live server serves a different vector space.
+	ServerReachable      bool   `json:"server_reachable"`
+	ServerActiveEmbedder string `json:"server_active_embedder"`
+	ServerIdentityLocked bool   `json:"server_identity_locked"`
+
+	TotalLeaves    int           `json:"total_leaves"`
+	TotalVectors   int           `json:"total_vectors"`
+	MissingVectors int           `json:"missing_vectors"`
+	Distribution   []vectorGroup `json:"vector_distribution"`
+	MixedDims      bool          `json:"mixed_dimensions"`
+	StaleVectors   int           `json:"stale_vectors"`
+	DimMismatch    int           `json:"dim_mismatch_vectors"`
+	Smoke          smokeResult   `json:"retrieval_smoke_test"`
+	Findings       []string      `json:"findings"`
+	Healthy        bool          `json:"healthy"`
+}
+
+// serverIdentity is what the running server reports about its live embedder.
+type serverIdentity struct {
+	Reachable      bool
+	ActiveEmbedder string
+	Locked         bool
+}
+
+// fetchServerIdentity asks the running server what it actually embeds with, via
+// /api/health. Best-effort: an unreachable server yields a zero value, and
+// doctor falls back to its own fresh resolve.
+func fetchServerIdentity() serverIdentity {
+	data, err := hooks.NewClient().Get("/api/health")
+	if err != nil {
+		return serverIdentity{}
+	}
+	var h struct {
+		ActiveEmbedder string `json:"active_embedder"`
+		Locked         bool   `json:"vector_identity_locked"`
+	}
+	if err := json.Unmarshal(data, &h); err != nil {
+		return serverIdentity{}
+	}
+	return serverIdentity{Reachable: true, ActiveEmbedder: h.ActiveEmbedder, Locked: h.Locked}
+}
+
+func runDoctor(cmd *cobra.Command, args []string) error {
+	db, err := openDB()
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	defer db.Close()
+
+	emb, err := resolveActiveEmbedder(db, config.Default())
+	if err != nil {
+		return fmt.Errorf("resolve embedder: %w", err)
+	}
+
+	if doctorRepair {
+		return runDoctorRepair(db, emb, doctorApply)
+	}
+
+	leaves, err := db.ListLeaves()
+	if err != nil {
+		return fmt.Errorf("list leaves: %w", err)
+	}
+	vectors, err := db.AllVectors()
+	if err != nil {
+		return fmt.Errorf("all vectors: %w", err)
+	}
+	declared, _, _ := db.VectorIdentity()
+
+	rep := buildDoctorReport(emb, leaves, vectors, declared, fetchServerIdentity())
+
+	if doctorJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(rep)
+	}
+	printDoctorReport(rep)
+	return nil
+}
+
+// runDoctorRepair re-embeds stale and missing vectors to the active embedder and
+// rebinds the corpus vector identity. It snapshots first and is dry-run unless
+// --apply is passed. Repair rewrites only derived vectors (mem_vectors) and the
+// identity marker — never memory content — but a restore point is taken anyway,
+// per data-safety-is-paramount.
+func runDoctorRepair(db *store.DB, emb engine.Embedder, apply bool) error {
+	if emb == nil {
+		return fmt.Errorf("no active embedder; cannot repair (start Ollama with nomic-embed-text, or allow the TF-IDF fallback)")
+	}
+	activeID := engine.EmbedderIdentity(emb)
+
+	leaves, err := db.ListLeaves()
+	if err != nil {
+		return fmt.Errorf("list leaves: %w", err)
+	}
+
+	// A leaf needs (re-)embedding if it has no vector, or a vector under a
+	// different model/dimension than the active embedder.
+	var todo []store.MemNode
+	for _, n := range leaves {
+		if n.L0Abstract == "" {
+			continue
+		}
+		v, err := db.GetVector(n.ID)
+		if err != nil {
+			return fmt.Errorf("get vector %s: %w", n.URI, err)
+		}
+		if v == nil || v.Model != emb.Model() || v.Dimensions != emb.Dimensions() {
+			todo = append(todo, n)
+		}
+	}
+
+	fmt.Printf("Repair plan: re-embed %d of %d leaves to identity %s\n", len(todo), len(leaves), activeID)
+	if !apply {
+		fmt.Println("\n[dry-run] No changes made. Re-run with --repair-vectors --apply to snapshot and repair.")
+		return nil
+	}
+
+	snap, err := db.SnapshotNow("pre-repair-vectors")
+	if err != nil {
+		return fmt.Errorf("snapshot before repair: %w", err)
+	}
+	if snap != "" {
+		fmt.Printf("Snapshot: %s\n", snap)
+	}
+
+	ctx := context.Background()
+	done := 0
+	for i := range todo {
+		vec, err := emb.Embed(ctx, todo[i].L0Abstract)
+		if err != nil {
+			return fmt.Errorf("embed %s: %w (repaired %d before failing; snapshot preserved)", todo[i].URI, err, done)
+		}
+		if err := db.SaveVector(todo[i].ID, vec, emb.Model()); err != nil {
+			return fmt.Errorf("save vector %s: %w", todo[i].URI, err)
+		}
+		done++
+	}
+	if err := db.SetVectorIdentity(activeID); err != nil {
+		return fmt.Errorf("set vector identity: %w", err)
+	}
+
+	fmt.Printf("Re-embedded %d nodes; corpus vector identity is now %s\n", done, activeID)
+	fmt.Println("Restart the server to clear the identity lock: continuity restart")
+	return nil
+}
+
+// resolveActiveEmbedder builds the embedder the server would use, by the same
+// env/probe logic as `serve` (resolveEmbedderChoice + ProbeOllama), so doctor
+// reports reality rather than a guess. Returns (nil, nil) for the "none"
+// choice. Read-only.
+func resolveActiveEmbedder(db *store.DB, cfg config.Config) (engine.Embedder, error) {
+	ollamaURL := cfg.LLM.OllamaURL
+	if ollamaURL == "" {
+		ollamaURL = "http://localhost:11434"
+	}
+	embeddingModel := cfg.LLM.EmbeddingModel
+	if embeddingModel == "" {
+		embeddingModel = "nomic-embed-text"
+	}
+
+	switch resolveEmbedderChoice(ollamaURL, embeddingModel) {
+	case "none":
+		return nil, nil
+	case "ollama":
+		return engine.NewOllamaEmbedder(ollamaURL, embeddingModel, 768), nil
+	case "tfidf":
+		return engine.NewTFIDFEmbedder(db, 512)
+	default: // auto: probe Ollama, fall back to TF-IDF
+		if engine.ProbeOllama(ollamaURL, embeddingModel) {
+			return engine.NewOllamaEmbedder(ollamaURL, embeddingModel, 768), nil
+		}
+		return engine.NewTFIDFEmbedder(db, 512)
+	}
+}
+
+func buildDoctorReport(emb engine.Embedder, leaves []store.MemNode, vectors []store.VectorRecord, declared string, srv serverIdentity) doctorReport {
+	rep := doctorReport{
+		TotalLeaves:          len(leaves),
+		TotalVectors:         len(vectors),
+		ActiveEmbedder:       "none",
+		DeclaredIdentity:     declared,
+		ServerReachable:      srv.Reachable,
+		ServerActiveEmbedder: srv.ActiveEmbedder,
+		ServerIdentityLocked: srv.Locked,
+	}
+	activeModel := ""
+	expectedDims := 0
+	if emb != nil {
+		rep.ActiveEmbedder = engine.EmbedderIdentity(emb)
+		activeModel = emb.Model()
+		expectedDims = emb.Dimensions()
+	}
+	rep.ExpectedDims = expectedDims
+
+	// Tally distribution + stale/mismatch counts, keyed by (model, dimensions).
+	type key struct {
+		model string
+		dims  int
+	}
+	groups := map[key]int{}
+	vecByNode := make(map[int64]store.VectorRecord, len(vectors))
+	dimsSeen := map[int]bool{}
+	for _, v := range vectors {
+		groups[key{v.Model, v.Dimensions}]++
+		vecByNode[v.NodeID] = v
+		dimsSeen[v.Dimensions] = true
+		if emb != nil {
+			if v.Model != activeModel {
+				rep.StaleVectors++
+			}
+			if v.Dimensions != expectedDims {
+				rep.DimMismatch++
+			}
+		}
+	}
+	for k, c := range groups {
+		rep.Distribution = append(rep.Distribution, vectorGroup{Model: k.model, Dimensions: k.dims, Count: c})
+	}
+	sort.Slice(rep.Distribution, func(i, j int) bool {
+		return rep.Distribution[i].Count > rep.Distribution[j].Count
+	})
+	rep.MixedDims = len(dimsSeen) > 1
+
+	// Missing vectors: leaves with no embedding row.
+	for _, n := range leaves {
+		if _, ok := vecByNode[n.ID]; !ok {
+			rep.MissingVectors++
+		}
+	}
+
+	rep.Smoke = smokeTest(emb, leaves, vectors)
+	rep.Findings, rep.Healthy = diagnose(rep)
+	return rep
+}
+
+// smokeTest samples up to 10 leaves and checks whether each retrieves ITSELF in
+// the top-K by raw cosine similarity against the stored vectors. It is strictly
+// read-only: it embeds query text and scores in-memory, never calling
+// Find/TouchNode, so it cannot pollute the access metrics it diagnoses. A low
+// self-retrieval rate means the active embedder is incoherent with the stored
+// vectors (e.g. a dimension mismatch makes cosine 0, so nothing matches).
+func smokeTest(emb engine.Embedder, leaves []store.MemNode, vectors []store.VectorRecord) smokeResult {
+	const topK = 5
+	res := smokeResult{TopK: topK, MedianRank: -1}
+	switch {
+	case emb == nil:
+		res.Note = "no embedder configured"
+		return res
+	case len(vectors) == 0:
+		res.Note = "no vectors stored"
+		return res
+	}
+
+	ctx := context.Background()
+	var ranks []int
+	probed := 0
+	for _, n := range sampleLeaves(leaves, 10) {
+		if n.L0Abstract == "" {
+			continue
+		}
+		probed++
+		qv, err := emb.Embed(ctx, n.L0Abstract)
+		if err != nil {
+			res.Note = "embed failed: " + err.Error()
+			res.Sampled = probed
+			return res
+		}
+		if rank := selfRank(qv, n.ID, vectors, topK); rank > 0 {
+			res.SelfFound++
+			ranks = append(ranks, rank)
+		}
+	}
+	res.Sampled = probed
+	if len(ranks) > 0 {
+		sort.Ints(ranks)
+		res.MedianRank = ranks[len(ranks)/2]
+	}
+	return res
+}
+
+// selfRank returns the 1-based rank of nodeID's own vector among the top-K most
+// similar vectors to qv, or 0 if it falls outside top-K (or scores 0).
+func selfRank(qv []float64, nodeID int64, vectors []store.VectorRecord, topK int) int {
+	type scored struct {
+		id  int64
+		sim float64
+	}
+	ranked := make([]scored, 0, len(vectors))
+	for _, v := range vectors {
+		ranked = append(ranked, scored{v.NodeID, engine.CosineSimilarity(qv, v.Embedding)})
+	}
+	sort.Slice(ranked, func(i, j int) bool { return ranked[i].sim > ranked[j].sim })
+	for i, s := range ranked {
+		if i >= topK {
+			break
+		}
+		if s.id == nodeID && s.sim > 0 {
+			return i + 1
+		}
+	}
+	return 0
+}
+
+// sampleLeaves returns up to n leaves spread evenly across the slice —
+// deterministic, no randomness, stable across runs.
+func sampleLeaves(leaves []store.MemNode, n int) []store.MemNode {
+	if len(leaves) <= n {
+		return leaves
+	}
+	out := make([]store.MemNode, 0, n)
+	step := float64(len(leaves)) / float64(n)
+	for i := 0; i < n; i++ {
+		out = append(out, leaves[int(float64(i)*step)])
+	}
+	return out
+}
+
+// diagnose turns the raw counts into human-readable findings and a verdict.
+func diagnose(rep doctorReport) ([]string, bool) {
+	var f []string
+	healthy := true
+
+	if rep.ActiveEmbedder == "none" {
+		f = append(f, "No embedder configured — semantic search is disabled.")
+		healthy = false
+	}
+	if rep.MissingVectors > 0 {
+		f = append(f, fmt.Sprintf("%d leaf node(s) have no embedding vector.", rep.MissingVectors))
+		healthy = false
+	}
+	if rep.MixedDims {
+		f = append(f, "Stored vectors have mixed dimensions — cosine similarity is meaningless across them.")
+		healthy = false
+	}
+	if rep.ActiveEmbedder != "none" && rep.DimMismatch > 0 {
+		f = append(f, fmt.Sprintf("%d vector(s) don't match the active embedder's dimension (%d) — they score 0 in search and are effectively invisible.", rep.DimMismatch, rep.ExpectedDims))
+		healthy = false
+	}
+	if rep.ActiveEmbedder != "none" && rep.StaleVectors > 0 {
+		f = append(f, fmt.Sprintf("%d vector(s) were embedded by a different model than the active embedder (%s).", rep.StaleVectors, rep.ActiveEmbedder))
+		healthy = false
+	}
+
+	// Live-server identity — the fresh-resolve blind spot. doctor resolves its
+	// own embedder; the running server may differ. Compare against what the
+	// server actually reports.
+	if rep.ServerReachable {
+		if rep.ServerIdentityLocked {
+			f = append(f, "The running server reports its vector identity is LOCKED — search is failing closed. Run `continuity doctor --repair-vectors --apply`, then `continuity restart`.")
+			healthy = false
+		}
+		if rep.DeclaredIdentity != "" && rep.ServerActiveEmbedder != "" && rep.ServerActiveEmbedder != rep.DeclaredIdentity {
+			f = append(f, fmt.Sprintf("The running server embeds with %s but the corpus identity is %s — restart the server (or repair) so they match.", rep.ServerActiveEmbedder, rep.DeclaredIdentity))
+			healthy = false
+		}
+	}
+	if rep.ActiveEmbedder != "none" && rep.DeclaredIdentity != "" && rep.ActiveEmbedder != rep.DeclaredIdentity {
+		f = append(f, fmt.Sprintf("The active embedder (%s) differs from the corpus's declared identity (%s) — re-embedding (repair) is required to switch vector spaces.", rep.ActiveEmbedder, rep.DeclaredIdentity))
+		healthy = false
+	}
+
+	switch {
+	case rep.Smoke.Sampled > 0 && rep.Smoke.SelfFound == 0:
+		f = append(f, fmt.Sprintf("Retrieval smoke test: 0/%d sampled nodes retrieved themselves — search is effectively broken against the active embedder.", rep.Smoke.Sampled))
+		healthy = false
+	case rep.Smoke.Sampled > 0 && rep.Smoke.SelfFound < rep.Smoke.Sampled:
+		f = append(f, fmt.Sprintf("Retrieval smoke test: only %d/%d nodes retrieved themselves in top-%d.", rep.Smoke.SelfFound, rep.Smoke.Sampled, rep.Smoke.TopK))
+	}
+
+	if healthy && len(f) == 0 {
+		f = append(f, "All checks passed — embedder and stored vectors are coherent.")
+	}
+	return f, healthy
+}
+
+func printDoctorReport(rep doctorReport) {
+	dash := func(s string) string {
+		if s == "" {
+			return "(none)"
+		}
+		return s
+	}
+
+	fmt.Println("continuity doctor — memory index health")
+	fmt.Println()
+	fmt.Printf("  active embedder:    %s\n", rep.ActiveEmbedder)
+	fmt.Printf("  declared identity:  %s\n", dash(rep.DeclaredIdentity))
+	if rep.ServerReachable {
+		locked := ""
+		if rep.ServerIdentityLocked {
+			locked = "  [LOCKED]"
+		}
+		fmt.Printf("  server embedder:    %s%s\n", dash(rep.ServerActiveEmbedder), locked)
+	} else {
+		fmt.Println("  server embedder:    (server not reachable)")
+	}
+	fmt.Printf("  expected dimension: %d\n", rep.ExpectedDims)
+	fmt.Printf("  leaf nodes:         %d\n", rep.TotalLeaves)
+	fmt.Printf("  stored vectors:     %d\n", rep.TotalVectors)
+	fmt.Println()
+
+	fmt.Println("  vector distribution:")
+	if len(rep.Distribution) == 0 {
+		fmt.Println("    (none)")
+	}
+	for _, g := range rep.Distribution {
+		marker := "ok"
+		if fmt.Sprintf("%s:%d", g.Model, g.Dimensions) != rep.ActiveEmbedder {
+			marker = "!!"
+		}
+		fmt.Printf("    [%s] %-30s dim=%-5d %d\n", marker, g.Model, g.Dimensions, g.Count)
+	}
+	fmt.Println()
+
+	fmt.Printf("  missing vectors:    %d\n", rep.MissingVectors)
+	fmt.Printf("  mixed dimensions:   %v\n", rep.MixedDims)
+	fmt.Printf("  stale vectors:      %d\n", rep.StaleVectors)
+	fmt.Printf("  dim mismatch:       %d\n", rep.DimMismatch)
+	fmt.Println()
+
+	s := rep.Smoke
+	if s.Note != "" {
+		fmt.Printf("  retrieval smoke:    %s\n", s.Note)
+	} else {
+		fmt.Printf("  retrieval smoke:    %d/%d nodes retrieved themselves (top-%d", s.SelfFound, s.Sampled, s.TopK)
+		if s.MedianRank > 0 {
+			fmt.Printf(", median rank %d", s.MedianRank)
+		}
+		fmt.Println(")")
+	}
+	fmt.Println()
+
+	if rep.Healthy {
+		fmt.Println("  VERDICT: healthy")
+	} else {
+		fmt.Println("  VERDICT: degraded")
+	}
+	for _, f := range rep.Findings {
+		fmt.Printf("    - %s\n", f)
+	}
+	if !rep.Healthy {
+		fmt.Println()
+		fmt.Println("  Repair is a separate, explicit step (snapshot-first, coming next):")
+		fmt.Println("    continuity doctor --repair-vectors")
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -124,7 +124,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	}
 
 	if doctorRepair {
-		return runDoctorRepair(db, emb, doctorApply)
+		return runDoctorRepair(db, emb, doctorApply, fetchServerIdentity())
 	}
 
 	leaves, err := db.ListLeaves()
@@ -153,7 +153,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 // --apply is passed. Repair rewrites only derived vectors (mem_vectors) and the
 // identity marker — never memory content — but a restore point is taken anyway,
 // per data-safety-is-paramount.
-func runDoctorRepair(db *store.DB, emb engine.Embedder, apply bool) error {
+func runDoctorRepair(db *store.DB, emb engine.Embedder, apply bool, srv serverIdentity) error {
 	if emb == nil {
 		return fmt.Errorf("no active embedder; cannot repair (start Ollama with nomic-embed-text, or allow the TF-IDF fallback)")
 	}
@@ -190,15 +190,19 @@ func runDoctorRepair(db *store.DB, emb engine.Embedder, apply bool) error {
 		return nil
 	}
 
-	// Refuse to repair under a live server that is running a DIFFERENT, unlocked
-	// embedder: it would keep writing its own-identity vectors against the corpus
-	// we just rebound, re-mixing it. Require the server stopped, locked, or in
-	// agreement before rewriting.
-	if srv := fetchServerIdentity(); srv.Reachable && !srv.Locked &&
-		srv.ActiveEmbedder != "" && srv.ActiveEmbedder != activeID {
-		return fmt.Errorf("the running server is embedding with %s (not locked) but repair targets %s; "+
-			"stop the server (or let it lock) before --apply, then `continuity restart` after — otherwise it "+
-			"would keep writing %s vectors into the repaired corpus", srv.ActiveEmbedder, activeID, srv.ActiveEmbedder)
+	// Refuse to repair under a live server unless it is STOPPED, LOCKED, or
+	// reports the SAME identity we're repairing to. A reachable, unlocked server
+	// that reports a different — or unknown (empty, e.g. an old pre-vector-identity
+	// binary still running mid-upgrade) — identity would keep writing its own
+	// vectors and re-mix the corpus right after the snapshot-first repair.
+	if srv.Reachable && !srv.Locked && srv.ActiveEmbedder != activeID {
+		reported := srv.ActiveEmbedder
+		if reported == "" {
+			reported = "unknown (a pre-vector-identity server still running?)"
+		}
+		return fmt.Errorf("a live server is reachable and unlocked, embedding as %s, but repair targets %s; "+
+			"stop the server (or upgrade+restart it so it locks or agrees) before --apply, then `continuity restart` "+
+			"after — otherwise it would keep writing into the repaired corpus", reported, activeID)
 	}
 
 	snap, err := db.SnapshotNow("pre-repair-vectors")

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -159,7 +159,11 @@ func runDoctorRepair(db *store.DB, emb engine.Embedder, apply bool) error {
 	}
 	activeID := engine.EmbedderIdentity(emb)
 
-	leaves, err := db.ListLeaves()
+	// Include RETRACTED leaves: their vectors are still used by the
+	// dedup-against-retracted gate, so leaving them in an old vector space after
+	// rebinding the corpus identity would blind that gate (different dimension)
+	// or feed it cross-space noise (same dimension).
+	leaves, err := db.ListLeavesIncludingRetracted()
 	if err != nil {
 		return fmt.Errorf("list leaves: %w", err)
 	}
@@ -194,15 +198,30 @@ func runDoctorRepair(db *store.DB, emb engine.Embedder, apply bool) error {
 		fmt.Printf("Snapshot: %s\n", snap)
 	}
 
+	// Phase 1: embed everything FIRST, writing nothing. An embedding failure
+	// (e.g. Ollama drops) then leaves the corpus completely untouched rather than
+	// half-migrated.
 	ctx := context.Background()
-	done := 0
+	type pendingWrite struct {
+		id  int64
+		vec []float64
+	}
+	writes := make([]pendingWrite, 0, len(todo))
 	for i := range todo {
 		vec, err := emb.Embed(ctx, todo[i].L0Abstract)
 		if err != nil {
-			return fmt.Errorf("embed %s: %w (repaired %d before failing; snapshot preserved)", todo[i].URI, err, done)
+			return fmt.Errorf("embed %s: %w (no vectors were written; snapshot at %s)", todo[i].URI, err, snap)
 		}
-		if err := db.SaveVector(todo[i].ID, vec, emb.Model()); err != nil {
-			return fmt.Errorf("save vector %s: %w", todo[i].URI, err)
+		writes = append(writes, pendingWrite{todo[i].ID, vec})
+	}
+
+	// Phase 2: commit the new vectors, then rebind the identity last so a
+	// mid-write failure never leaves the identity pointing at a space the
+	// vectors don't fully occupy.
+	done := 0
+	for _, w := range writes {
+		if err := db.SaveVector(w.id, w.vec, emb.Model()); err != nil {
+			return fmt.Errorf("save vector (wrote %d/%d; snapshot at %s): %w", done, len(writes), snap, err)
 		}
 		done++
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -190,6 +190,17 @@ func runDoctorRepair(db *store.DB, emb engine.Embedder, apply bool) error {
 		return nil
 	}
 
+	// Refuse to repair under a live server that is running a DIFFERENT, unlocked
+	// embedder: it would keep writing its own-identity vectors against the corpus
+	// we just rebound, re-mixing it. Require the server stopped, locked, or in
+	// agreement before rewriting.
+	if srv := fetchServerIdentity(); srv.Reachable && !srv.Locked &&
+		srv.ActiveEmbedder != "" && srv.ActiveEmbedder != activeID {
+		return fmt.Errorf("the running server is embedding with %s (not locked) but repair targets %s; "+
+			"stop the server (or let it lock) before --apply, then `continuity restart` after — otherwise it "+
+			"would keep writing %s vectors into the repaired corpus", srv.ActiveEmbedder, activeID, srv.ActiveEmbedder)
+	}
+
 	snap, err := db.SnapshotNow("pre-repair-vectors")
 	if err != nil {
 		return fmt.Errorf("snapshot before repair: %w", err)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -44,7 +44,7 @@ func TestDoctorRepairDryRunMakesNoChanges(t *testing.T) {
 	db, id := repairTestDB(t)
 	emb := repairStubEmbedder{model: "new-model", dims: 64}
 
-	if err := runDoctorRepair(db, emb, false); err != nil { // dry-run
+	if err := runDoctorRepair(db, emb, false, serverIdentity{}); err != nil { // dry-run, no server
 		t.Fatal(err)
 	}
 	v, _ := db.GetVector(id)
@@ -56,11 +56,36 @@ func TestDoctorRepairDryRunMakesNoChanges(t *testing.T) {
 	}
 }
 
+// TestDoctorRepairRefusesUnderLiveServer pins Codex round-4: --apply must refuse
+// when a reachable, unlocked server reports a different (or unknown/empty, e.g.
+// an old binary mid-upgrade) identity than the repair target.
+func TestDoctorRepairRefusesUnderLiveServer(t *testing.T) {
+	db, id := repairTestDB(t)
+	emb := repairStubEmbedder{model: "new-model", dims: 64}
+
+	// Different identity:
+	if err := runDoctorRepair(db, emb, true, serverIdentity{Reachable: true, ActiveEmbedder: "other:768"}); err == nil {
+		t.Fatal("apply must refuse under a live server with a different identity")
+	}
+	// Unknown/empty identity (old pre-vector-identity server):
+	if err := runDoctorRepair(db, emb, true, serverIdentity{Reachable: true, ActiveEmbedder: ""}); err == nil {
+		t.Fatal("apply must refuse under a reachable server reporting an unknown identity")
+	}
+	// Nothing should have been written.
+	if v, _ := db.GetVector(id); v == nil || v.Model != "old-model" {
+		t.Fatalf("refused repair must not write; got %+v", v)
+	}
+	// A LOCKED server is safe (not writing):
+	if err := runDoctorRepair(db, emb, true, serverIdentity{Reachable: true, Locked: true}); err != nil {
+		t.Fatalf("apply under a locked server should proceed: %v", err)
+	}
+}
+
 func TestDoctorRepairApplyReembedsAndRebinds(t *testing.T) {
 	db, id := repairTestDB(t)
 	emb := repairStubEmbedder{model: "new-model", dims: 64}
 
-	if err := runDoctorRepair(db, emb, true); err != nil { // apply
+	if err := runDoctorRepair(db, emb, true, serverIdentity{}); err != nil { // apply, no live server
 		t.Fatal(err)
 	}
 	v, _ := db.GetVector(id)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lazypower/continuity/internal/store"
+)
+
+type repairStubEmbedder struct {
+	model string
+	dims  int
+}
+
+func (s repairStubEmbedder) Embed(_ context.Context, text string) ([]float64, error) {
+	v := make([]float64, s.dims)
+	for i, r := range text {
+		v[i%s.dims] += float64(r)
+	}
+	return v, nil
+}
+func (s repairStubEmbedder) Model() string   { return s.model }
+func (s repairStubEmbedder) Dimensions() int { return s.dims }
+
+func repairTestDB(t *testing.T) (*store.DB, int64) {
+	t.Helper()
+	db, err := store.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	n := &store.MemNode{URI: "mem://agent/patterns/a", NodeType: "leaf", Category: "patterns", L0Abstract: "alpha"}
+	if err := db.CreateNode(n); err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+	got, _ := db.GetNodeByURI("mem://agent/patterns/a")
+	if err := db.SaveVector(got.ID, make([]float64, 512), "old-model"); err != nil {
+		t.Fatalf("SaveVector: %v", err)
+	}
+	return db, got.ID
+}
+
+func TestDoctorRepairDryRunMakesNoChanges(t *testing.T) {
+	db, id := repairTestDB(t)
+	emb := repairStubEmbedder{model: "new-model", dims: 64}
+
+	if err := runDoctorRepair(db, emb, false); err != nil { // dry-run
+		t.Fatal(err)
+	}
+	v, _ := db.GetVector(id)
+	if v == nil || v.Model != "old-model" {
+		t.Fatalf("dry-run must not change vectors, got %+v", v)
+	}
+	if _, ok, _ := db.VectorIdentity(); ok {
+		t.Fatal("dry-run must not bind a vector identity")
+	}
+}
+
+func TestDoctorRepairApplyReembedsAndRebinds(t *testing.T) {
+	db, id := repairTestDB(t)
+	emb := repairStubEmbedder{model: "new-model", dims: 64}
+
+	if err := runDoctorRepair(db, emb, true); err != nil { // apply
+		t.Fatal(err)
+	}
+	v, _ := db.GetVector(id)
+	if v == nil || v.Model != "new-model" || v.Dimensions != 64 {
+		t.Fatalf("apply must re-embed to the active embedder, got %+v", v)
+	}
+	if gotID, ok, _ := db.VectorIdentity(); !ok || gotID != "new-model:64" {
+		t.Fatalf("apply must rebind identity, got %q ok=%v", gotID, ok)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -32,4 +32,5 @@ func init() {
 	rootCmd.AddCommand(uninstallServiceCmd)
 	rootCmd.AddCommand(extractCmd)
 	rootCmd.AddCommand(snapshotCmd)
+	rootCmd.AddCommand(doctorCmd)
 }

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -145,17 +145,29 @@ func runServe(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		// Embed any nodes missing vectors
+		// Reconcile the active embedder against the corpus's declared vector
+		// identity BEFORE embedding anything. On mismatch we lock (search fails
+		// closed) and do NOT re-embed — that migration must be explicit. Only on
+		// a match do we fill truly-missing vectors.
 		if eng != nil && eng.Embedder != nil {
-			go func() {
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-				defer cancel()
-				if n, err := eng.EmbedMissing(ctx); err != nil {
-					fmt.Fprintf(os.Stderr, "embed missing: %v\n", err)
-				} else if n > 0 {
-					fmt.Fprintf(os.Stderr, "  embedded %d missing nodes\n", n)
-				}
-			}()
+			st, err := eng.ReconcileVectorIdentity(context.Background())
+			switch {
+			case err != nil:
+				fmt.Fprintf(os.Stderr, "warning: vector identity reconcile failed: %v\n", err)
+			case !st.Match:
+				fmt.Fprintf(os.Stderr, "\n⚠ %s\n\n", st.Reason)
+			default:
+				fmt.Fprintf(os.Stderr, "  vectors: %s\n", st.Action)
+				go func() {
+					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+					defer cancel()
+					if n, err := eng.EmbedMissing(ctx); err != nil {
+						fmt.Fprintf(os.Stderr, "embed missing: %v\n", err)
+					} else if n > 0 {
+						fmt.Fprintf(os.Stderr, "  embedded %d missing nodes\n", n)
+					}
+				}()
+			}
 		}
 	}
 

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -79,6 +79,7 @@ func init() {
 	searchCmd.Flags().BoolVar(&searchSmart, "smart", false, "Use LLM-assisted search")
 	searchCmd.Flags().IntVarP(&searchLimit, "limit", "n", 10, "Maximum number of results")
 	searchCmd.Flags().StringVarP(&searchCategory, "category", "c", "", "Filter by category")
+	searchCmd.Flags().BoolVar(&searchExplain, "explain", false, "Show score decomposition (similarity, relevance) per result")
 
 	// Profile flags
 	profileCmd.Flags().BoolVar(&profileVerbose, "verbose", false, "Show all profile and preference nodes")
@@ -103,6 +104,7 @@ var (
 	searchSmart    bool
 	searchLimit    int
 	searchCategory string
+	searchExplain  bool
 )
 
 var searchCmd = &cobra.Command{
@@ -162,6 +164,11 @@ func runSearch(cmd *cobra.Command, args []string) error {
 
 	for i, r := range resp.Results {
 		fmt.Printf("%d. [%.3f] %s\n", i+1, r.Score, r.URI)
+		if searchExplain {
+			// Score decomposition — so ranking can be inspected from the CLI
+			// instead of curling /api/search and parsing JSON by hand.
+			fmt.Printf("   score=%.3f = similarity=%.3f x relevance=%.3f (x category boost)\n", r.Score, r.Similarity, r.Relevance)
+		}
 		fmt.Printf("   %s [%s]\n", r.L0Abstract, r.Category)
 		if r.L1Overview != "" {
 			// Show first 200 chars of L1

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -383,12 +383,23 @@ func runDedup(cmd *cobra.Command, args []string) error {
 	eng := engine.New(db, nil)
 	eng.SetEmbedder(emb)
 
+	// Reconcile against the corpus's vector identity and FAIL CLOSED on a
+	// mismatch: dedup is destructive (it deletes nodes by cosine clustering and
+	// re-embeds), so running it against an incompatible vector space could
+	// cross-space-cluster and write foreign-identity vectors.
+	ctx := context.Background()
+	if _, err := eng.ReconcileVectorIdentity(ctx); err != nil {
+		return fmt.Errorf("reconcile vector identity: %w", err)
+	}
+	if locked, reason := eng.VectorIdentityLocked(); locked {
+		return fmt.Errorf("dedup refused — %s", reason)
+	}
+
 	if dedupDryRun {
 		fmt.Println("\n[dry-run] Would deduplicate — rerun without --dry-run to apply")
 		return nil
 	}
 
-	ctx := context.Background()
 	removed, err := eng.Dedup(ctx, dedupThreshold)
 	if err != nil {
 		return fmt.Errorf("dedup: %w", err)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -519,12 +519,13 @@ func (e *Engine) ExtractSignal(ctx context.Context, sessionID, prompt string) er
 		}
 		log.Printf("signal: stored %s [%s]", uri, c.Category)
 
-		// Embed if available
-		if e.Embedder != nil && node.L0Abstract != "" {
+		// Embed if available and not locked. While locked, the node stays Pending
+		// (no vector) rather than being written into an incompatible vector space.
+		if emb := e.embedderIfUnlocked(); emb != nil && node.L0Abstract != "" {
 			stored, err := e.DB.GetNodeByURI(node.URI)
 			if err == nil && stored != nil {
-				if vec, err := e.Embedder.Embed(ctx, stored.L0Abstract); err == nil {
-					e.DB.SaveVector(stored.ID, vec, e.Embedder.Model())
+				if vec, err := emb.Embed(ctx, stored.L0Abstract); err == nil {
+					e.DB.SaveVector(stored.ID, vec, emb.Model())
 				}
 			}
 		}
@@ -620,7 +621,10 @@ func (e *Engine) extractSession(sessionID, transcriptPath string, force bool) er
 		return nil
 	}
 
-	if err := extractMemories(e.DB, e.LLM, e.Embedder, sessionID, transcriptPath); err != nil {
+	// embedderIfUnlocked: while the vector identity is locked, extract still
+	// creates memory nodes but leaves them Pending (nil embedder => no vector),
+	// rather than writing into an incompatible vector space.
+	if err := extractMemories(e.DB, e.LLM, e.embedderIfUnlocked(), sessionID, transcriptPath); err != nil {
 		return fmt.Errorf("memory extraction: %w", err)
 	}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -49,17 +49,17 @@ func (e *Engine) SetEmbedder(emb Embedder) {
 	e.Embedder = emb
 }
 
-// EmbedNode generates and stores an embedding for a single node.
+// EmbedNode brings a node's stored vector in sync with its current content, or
+// removes a stale one. When the active embedder can't produce a vector
+// compatible with the corpus — none configured, or the vector identity is locked
+// — it DELETES any existing vector and leaves the node Pending. This is critical
+// on a content UPDATE: skipping the embed while leaving the old vector in place
+// would make search serve a vector describing the previous content once the
+// embedder returns (EmbedMissing only fills MISSING vectors). DeleteVector is a
+// no-op when none exists, so a fresh node simply stays Pending.
 func (e *Engine) EmbedNode(ctx context.Context, node *store.MemNode) error {
-	if e.Embedder == nil {
-		return nil
-	}
-	// Pending state: while the vector identity is locked, the active embedder is
-	// incompatible with the corpus. Do NOT embed new writes into a foreign vector
-	// space — leave the node pending (no vector). EmbedMissing fills it once a
-	// compatible embedder is active again (see ReconcileVectorIdentity).
-	if e.identityMismatch {
-		return nil
+	if e.Embedder == nil || e.identityMismatch {
+		return e.DB.DeleteVector(node.ID)
 	}
 	text := node.L0Abstract
 	if text == "" {
@@ -546,14 +546,15 @@ func (e *Engine) ExtractSignal(ctx context.Context, sessionID, prompt string) er
 		}
 		log.Printf("signal: stored %s [%s]", uri, c.Category)
 
-		// Embed if available and not locked. While locked, the node stays Pending
-		// (no vector) rather than being written into an incompatible vector space.
-		if emb := e.embedderIfUnlocked(); emb != nil && node.L0Abstract != "" {
-			stored, err := e.DB.GetNodeByURI(node.URI)
-			if err == nil && stored != nil {
+		// Keep the stored vector in sync; when locked/none, DELETE any stale vector
+		// so a content update can't leave search serving the previous content.
+		if stored, err := e.DB.GetNodeByURI(node.URI); err == nil && stored != nil {
+			if emb := e.embedderIfUnlocked(); emb != nil && stored.L0Abstract != "" {
 				if vec, err := emb.Embed(ctx, stored.L0Abstract); err == nil {
 					e.DB.SaveVector(stored.ID, vec, emb.Model())
 				}
+			} else {
+				e.DB.DeleteVector(stored.ID)
 			}
 		}
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -386,13 +386,13 @@ func (e *Engine) Remember(ctx context.Context, input RememberInput) (string, boo
 	storedURI := node.URI
 	log.Printf("remember: stored %s [%s] (created=%v)", storedURI, c.Category, created)
 
-	// Embed if available
-	if e.Embedder != nil && node.L0Abstract != "" {
-		stored, err := e.DB.GetNodeByURI(storedURI)
-		if err == nil && stored != nil {
-			if err := e.EmbedNode(ctx, stored); err != nil {
-				log.Printf("remember: embed %s: %v", storedURI, err)
-			}
+	// Reconcile the stored vector with the new content UNCONDITIONALLY: EmbedNode
+	// embeds when possible, or clears a stale vector when no compatible embedder
+	// is available (locked OR none) — so an update never leaves search serving a
+	// vector for the previous content.
+	if stored, err := e.DB.GetNodeByURI(storedURI); err == nil && stored != nil {
+		if err := e.EmbedNode(ctx, stored); err != nil {
+			log.Printf("remember: embed %s: %v", storedURI, err)
 		}
 	}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -18,6 +18,21 @@ type Engine struct {
 	LLM      llm.Client
 	Embedder Embedder
 	stopCh   chan struct{}
+
+	// Vector-identity lock. Set by ReconcileVectorIdentity when the active
+	// embedder's identity differs from the corpus's declared identity. While
+	// locked, search must fail closed rather than compare query vectors against
+	// a corpus embedded in a different vector space, and EmbedMissing must not
+	// run (no silent re-embed). Cleared only by an explicit repair.
+	identityMismatch bool
+	identityReason   string
+}
+
+// VectorIdentityLocked reports whether the active embedder is incompatible with
+// the corpus's declared vector identity. When true, reason explains the
+// mismatch and points the operator at repair; callers (search) must fail closed.
+func (e *Engine) VectorIdentityLocked() (bool, string) {
+	return e.identityMismatch, e.identityReason
 }
 
 // New creates a new Engine.
@@ -39,6 +54,13 @@ func (e *Engine) EmbedNode(ctx context.Context, node *store.MemNode) error {
 	if e.Embedder == nil {
 		return nil
 	}
+	// Pending state: while the vector identity is locked, the active embedder is
+	// incompatible with the corpus. Do NOT embed new writes into a foreign vector
+	// space — leave the node pending (no vector). EmbedMissing fills it once a
+	// compatible embedder is active again (see ReconcileVectorIdentity).
+	if e.identityMismatch {
+		return nil
+	}
 	text := node.L0Abstract
 	if text == "" {
 		return nil
@@ -51,9 +73,18 @@ func (e *Engine) EmbedNode(ctx context.Context, node *store.MemNode) error {
 	return e.DB.SaveVector(node.ID, vec, e.Embedder.Model())
 }
 
-// EmbedMissing embeds all leaf nodes that don't have a vector or whose model differs.
+// EmbedMissing embeds leaf nodes that have NO vector yet, using the active
+// embedder. It deliberately does NOT re-embed nodes whose stored model differs
+// from the active embedder: re-embedding an existing corpus into a new vector
+// space is a corpus migration and must be explicit (snapshot-first repair), not
+// a silent side effect of startup. Callers run this only when the active
+// embedder matches the corpus's declared vector identity (see
+// ReconcileVectorIdentity); while the identity is locked, it must not run.
 func (e *Engine) EmbedMissing(ctx context.Context) (int, error) {
 	if e.Embedder == nil {
+		return 0, nil
+	}
+	if e.identityMismatch {
 		return 0, nil
 	}
 
@@ -68,13 +99,15 @@ func (e *Engine) EmbedMissing(ctx context.Context) (int, error) {
 			continue
 		}
 
-		// Check if vector exists with current model
+		// Fill only truly-missing vectors. A vector that exists under a
+		// different model is STALE, not missing — leave it for explicit repair
+		// rather than silently re-embedding it into the active vector space.
 		existing, err := e.DB.GetVector(leaves[i].ID)
 		if err != nil {
 			log.Printf("embed missing: get vector for %s: %v", leaves[i].URI, err)
 			continue
 		}
-		if existing != nil && existing.Model == e.Embedder.Model() {
+		if existing != nil {
 			continue
 		}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -191,8 +191,15 @@ func (e *Engine) Dedup(ctx context.Context, threshold float64) (int, error) {
 		return 0, fmt.Errorf("load vectors: %w", err)
 	}
 
+	// Cluster only within the active identity — never delete a memory based on a
+	// cross-space cosine score against a stale foreign-identity vector (which can
+	// linger even when active==declared, e.g. after an interrupted repair).
+	activeID := EmbedderIdentity(e.Embedder)
 	vecMap := make(map[int64][]float64, len(vectors))
 	for _, v := range vectors {
+		if canonicalIdentity(v.Model, v.Dimensions) != activeID {
+			continue
+		}
 		vecMap[v.NodeID] = v.Embedding
 	}
 
@@ -327,6 +334,15 @@ func (e *Engine) Remember(ctx context.Context, input RememberInput) (string, boo
 		return "", false, validationErrorf("uri %s is retracted; choose a different slug", requestedURI)
 	}
 
+	// While the vector identity is locked, the retracted-memory safety gate
+	// cannot run (the active embedder is incompatible with the corpus). Fail
+	// CLOSED: refuse an unacknowledged write rather than risk re-introducing
+	// retracted (e.g. PII) content the gate would have caught. An explicit
+	// --acknowledge-retracted still overrides, matching the unlocked flow.
+	if !input.AcknowledgeRetracted && e.identityMismatch {
+		return "", false, validationErrorf("vector identity is locked — the retracted-memory check cannot run; resolve with `continuity doctor` (and --repair-vectors), or re-run with --acknowledge-retracted to write without the check")
+	}
+
 	// Dedup against retracted memories. Retracted memories must still participate
 	// in similarity matching, or retraction-because-PII is silently broken: the
 	// next session writes similar content, hits no match, re-introduces the leak.
@@ -400,6 +416,13 @@ const maxMoments = 10
 // most "covered" by the rest gets evicted.
 // Returns the URI of the evicted moment, or empty string if no eviction needed.
 func (e *Engine) evictRedundantMoment(ctx context.Context) (string, error) {
+	// While the vector identity is locked, do not run vector-based eviction:
+	// comparing moments across vector spaces could delete a real moment on
+	// cross-space noise rather than a genuinely redundant one.
+	if e.identityMismatch {
+		return "", nil
+	}
+
 	moments, err := e.DB.FindByCategory("moments")
 	if err != nil {
 		return "", fmt.Errorf("find moments: %w", err)
@@ -427,11 +450,15 @@ func (e *Engine) evictRedundantMoment(ctx context.Context) (string, error) {
 		node store.MemNode
 		vec  []float64
 	}
+	activeID := EmbedderIdentity(e.Embedder)
 	var pool []momentVec
 	for _, m := range moments {
 		v, err := e.DB.GetVector(m.ID)
 		if err != nil || v == nil {
 			continue
+		}
+		if canonicalIdentity(v.Model, v.Dimensions) != activeID {
+			continue // never compare across vector spaces
 		}
 		pool = append(pool, momentVec{m, v.Embedding})
 	}

--- a/internal/engine/extractor.go
+++ b/internal/engine/extractor.go
@@ -209,19 +209,21 @@ func extractMemories(db *store.DB, client llm.Client, embedder Embedder, session
 		}
 		log.Printf("extraction: stored %s [%s]", uri, c.Category)
 
-		// Embed the new node if embedder is available
-		if embedder != nil && node.L0Abstract != "" {
-			vec, err := embedder.Embed(ctx, node.L0Abstract)
-			if err != nil {
-				log.Printf("extraction: embed %s: %v", uri, err)
-			} else {
-				// Need to look up the node to get its ID (UpsertNode may have merged)
-				stored, err := db.GetNodeByURI(node.URI)
-				if err == nil && stored != nil {
-					if err := db.SaveVector(stored.ID, vec, embedder.Model()); err != nil {
-						log.Printf("extraction: save vector %s: %v", uri, err)
-					}
+		// Keep the stored vector in sync with the (possibly updated) content.
+		// UpsertNode may have merged into an existing node — look it up for its ID.
+		// When no usable embedder is available (locked / none), DELETE any existing
+		// vector instead of skipping: otherwise a content update leaves a stale
+		// vector that search would serve once the embedder returns (EmbedMissing
+		// only fills MISSING vectors). DeleteVector is a no-op for a fresh node.
+		if stored, err := db.GetNodeByURI(node.URI); err == nil && stored != nil {
+			if embedder != nil && node.L0Abstract != "" {
+				if vec, err := embedder.Embed(ctx, node.L0Abstract); err != nil {
+					log.Printf("extraction: embed %s: %v", uri, err)
+				} else if err := db.SaveVector(stored.ID, vec, embedder.Model()); err != nil {
+					log.Printf("extraction: save vector %s: %v", uri, err)
 				}
+			} else if err := db.DeleteVector(stored.ID); err != nil {
+				log.Printf("extraction: clear stale vector %s: %v", uri, err)
 			}
 		}
 	}

--- a/internal/engine/extractor.go
+++ b/internal/engine/extractor.go
@@ -58,6 +58,7 @@ func findSimilarNode(ctx context.Context, db *store.DB, embedder Embedder,
 	if err != nil {
 		return nil, 0, fmt.Errorf("embed candidate: %w", err)
 	}
+	activeID := EmbedderIdentity(embedder)
 
 	vectors, err := db.AllVectors()
 	if err != nil {
@@ -85,6 +86,9 @@ func findSimilarNode(ctx context.Context, db *store.DB, embedder Embedder,
 	bestSim := 0.0
 
 	for _, v := range vectors {
+		if canonicalIdentity(v.Model, v.Dimensions) != activeID {
+			continue // never compare across vector spaces
+		}
 		node, ok := nodeMap[v.NodeID]
 		if !ok || node.NodeType != "leaf" || node.Category != category {
 			continue

--- a/internal/engine/identity.go
+++ b/internal/engine/identity.go
@@ -1,0 +1,126 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// EmbedderIdentity is the corpus-binding identity of an embedder: model + output
+// dimension. Vectors are only comparable within the same identity. A finer
+// fingerprint for corpus-derived embedders (e.g. a TF-IDF vocabulary hash) is a
+// known refinement; model:dims already prevents the cross-model and
+// cross-dimension silent switches that are the primary failure mode.
+func EmbedderIdentity(emb Embedder) string {
+	if emb == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s:%d", emb.Model(), emb.Dimensions())
+}
+
+// ActiveIdentity returns the identity of the engine's active embedder, or "" if
+// none is configured. The health endpoint advertises this so doctor can compare
+// against what the running server actually embeds with, rather than re-resolving
+// a fresh embedder (which can differ from the live one).
+func (e *Engine) ActiveIdentity() string {
+	return EmbedderIdentity(e.Embedder)
+}
+
+// VectorIdentityStatus is the outcome of reconciling the active embedder against
+// the corpus's declared vector identity at startup.
+type VectorIdentityStatus struct {
+	Active   string // identity of the active embedder ("" if none)
+	Declared string // corpus's declared identity ("" if newly initialized)
+	Match    bool   // active embedder is compatible with the corpus
+	Action   string // human-readable summary of what reconciliation did
+	Reason   string // when !Match, the lock reason (with repair guidance)
+}
+
+// ReconcileVectorIdentity binds the corpus to a vector identity and checks the
+// active embedder against it, so the embedder can never be silently switched by
+// environment — the root cause of the silent re-embed migration.
+//
+//   - No active embedder        -> no-op (search is already unavailable).
+//   - Fresh corpus (no vectors,
+//     no declared identity)      -> adopt the active embedder's identity.
+//   - Declared identity absent
+//     but vectors exist          -> backfill the declaration from the DOMINANT stored
+//     identity (bind to the corpus's truth, not to
+//     whatever embedder happens to be up), then compare.
+//   - Active matches declared    -> Match; EmbedMissing may fill truly-missing vectors.
+//   - Active differs             -> LOCK: do not re-embed, search fails closed, an
+//     explicit snapshot-first repair is required.
+func (e *Engine) ReconcileVectorIdentity(ctx context.Context) (VectorIdentityStatus, error) {
+	st := VectorIdentityStatus{Active: EmbedderIdentity(e.Embedder)}
+	if e.Embedder == nil {
+		st.Action = "no active embedder; vector identity not reconciled"
+		return st, nil
+	}
+
+	declared, ok, err := e.DB.VectorIdentity()
+	if err != nil {
+		return st, err
+	}
+
+	if !ok {
+		counts, err := e.DB.VectorModelCounts()
+		if err != nil {
+			return st, err
+		}
+		if len(counts) == 0 {
+			// Fresh corpus: the active embedder defines the identity.
+			if err := e.DB.SetVectorIdentity(st.Active); err != nil {
+				return st, err
+			}
+			st.Declared, st.Match = st.Active, true
+			st.Action = fmt.Sprintf("initialized corpus vector identity to %s", st.Active)
+			return st, nil
+		}
+		declared = dominantIdentity(counts)
+		if err := e.DB.SetVectorIdentity(declared); err != nil {
+			return st, err
+		}
+		st.Action = fmt.Sprintf("backfilled corpus vector identity to %s (from stored vectors)", declared)
+	}
+	st.Declared = declared
+
+	if st.Active == declared {
+		st.Match = true
+		if st.Action == "" {
+			st.Action = fmt.Sprintf("active embedder matches corpus vector identity (%s)", declared)
+		}
+		e.identityMismatch, e.identityReason = false, ""
+		return st, nil
+	}
+
+	// Mismatch: lock. Never compare across vector spaces; never silently re-embed.
+	st.Match = false
+	st.Reason = fmt.Sprintf(
+		"vector identity mismatch: the corpus was embedded with %s but the active embedder is %s. "+
+			"Search is disabled to avoid comparing across vector spaces. Run `continuity doctor` to inspect, "+
+			"then `continuity doctor --repair-vectors` (snapshot-first) to re-embed the corpus to %s.",
+		declared, st.Active, st.Active)
+	st.Action = "LOCKED: active embedder incompatible with corpus vector identity"
+	e.identityMismatch, e.identityReason = true, st.Reason
+	return st, nil
+}
+
+// dominantIdentity returns the "model:dims" identity holding the most vectors,
+// with a deterministic tiebreak so reconciliation is stable across runs.
+func dominantIdentity(counts map[string]int) string {
+	type kv struct {
+		id string
+		n  int
+	}
+	pairs := make([]kv, 0, len(counts))
+	for id, n := range counts {
+		pairs = append(pairs, kv{id, n})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].n != pairs[j].n {
+			return pairs[i].n > pairs[j].n
+		}
+		return pairs[i].id < pairs[j].id
+	})
+	return pairs[0].id
+}

--- a/internal/engine/identity.go
+++ b/internal/engine/identity.go
@@ -4,18 +4,43 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 )
 
-// EmbedderIdentity is the corpus-binding identity of an embedder: model + output
-// dimension. Vectors are only comparable within the same identity. A finer
-// fingerprint for corpus-derived embedders (e.g. a TF-IDF vocabulary hash) is a
-// known refinement; model:dims already prevents the cross-model and
-// cross-dimension silent switches that are the primary failure mode.
+// canonicalIdentity maps a (model, dimensions) pair to a corpus-binding vector
+// identity. Vectors are only comparable within the same identity.
+//
+// TF-IDF is special-cased to model-only: its output dimension is corpus-derived
+// (the vocabulary size, which grows as memories are added), so binding the
+// dimension would self-lock the fallback on normal corpus growth — tfidf:1 on a
+// fresh DB, tfidf:N after a few writes. The dimension carries no identity signal
+// for a corpus-derived embedder, so it is dropped. Stable embedders (real
+// models) bind model:dims, which catches the cross-model and cross-dimension
+// switches that are the actual failure mode.
+func canonicalIdentity(model string, dims int) string {
+	if model == "tfidf" {
+		return "tfidf"
+	}
+	return fmt.Sprintf("%s:%d", model, dims)
+}
+
+// EmbedderIdentity is the corpus-binding identity of an embedder.
 func EmbedderIdentity(emb Embedder) string {
 	if emb == nil {
 		return ""
 	}
-	return fmt.Sprintf("%s:%d", emb.Model(), emb.Dimensions())
+	return canonicalIdentity(emb.Model(), emb.Dimensions())
+}
+
+// embedderIfUnlocked returns the active embedder, or nil when the vector
+// identity is locked. Embedding paths use this so that, while locked, new
+// memories are still created but left Pending (no vector) rather than written
+// into a vector space incompatible with the corpus.
+func (e *Engine) embedderIfUnlocked() Embedder {
+	if e.identityMismatch {
+		return nil
+	}
+	return e.Embedder
 }
 
 // ActiveIdentity returns the identity of the engine's active embedder, or "" if
@@ -43,14 +68,31 @@ type VectorIdentityStatus struct {
 //   - No active embedder        -> no-op (search is already unavailable).
 //   - Fresh corpus (no vectors,
 //     no declared identity)      -> adopt the active embedder's identity.
-//   - Declared identity absent
-//     but vectors exist          -> backfill the declaration from the DOMINANT stored
-//     identity (bind to the corpus's truth, not to
-//     whatever embedder happens to be up), then compare.
+//   - Declared absent, one stored
+//     identity                   -> backfill the declaration from it (bind to the
+//     corpus's truth, not whatever embedder is up).
+//   - Declared absent, MULTIPLE
+//     stored identities          -> LOCK: do not bless a majority; require repair.
 //   - Active matches declared    -> Match; EmbedMissing may fill truly-missing vectors.
 //   - Active differs             -> LOCK: do not re-embed, search fails closed, an
 //     explicit snapshot-first repair is required.
+//   - Reconciliation errors      -> LOCK (fail closed); never serve unproven.
+//
+// ReconcileVectorIdentity wraps the reconciliation logic with a fail-closed
+// guarantee: if reconciliation ERRORS (e.g. the DB read/write fails), the engine
+// is locked rather than left open, because an unproven embedder must never serve
+// search against the stored corpus.
 func (e *Engine) ReconcileVectorIdentity(ctx context.Context) (VectorIdentityStatus, error) {
+	st, err := e.reconcileVectorIdentity(ctx)
+	if err != nil {
+		e.identityMismatch = true
+		e.identityReason = "vector identity could not be reconciled (" + err.Error() +
+			") — search disabled (fail closed). Run `continuity doctor`."
+	}
+	return st, err
+}
+
+func (e *Engine) reconcileVectorIdentity(ctx context.Context) (VectorIdentityStatus, error) {
 	st := VectorIdentityStatus{Active: EmbedderIdentity(e.Embedder)}
 	if e.Embedder == nil {
 		st.Action = "no active embedder; vector identity not reconciled"
@@ -63,11 +105,17 @@ func (e *Engine) ReconcileVectorIdentity(ctx context.Context) (VectorIdentitySta
 	}
 
 	if !ok {
-		counts, err := e.DB.VectorModelCounts()
+		rows, err := e.DB.VectorModelCounts()
 		if err != nil {
 			return st, err
 		}
-		if len(counts) == 0 {
+		// Canonicalize stored vectors into identity buckets.
+		buckets := map[string]int{}
+		for _, r := range rows {
+			buckets[canonicalIdentity(r.Model, r.Dimensions)] += r.Count
+		}
+		switch len(buckets) {
+		case 0:
 			// Fresh corpus: the active embedder defines the identity.
 			if err := e.DB.SetVectorIdentity(st.Active); err != nil {
 				return st, err
@@ -75,12 +123,28 @@ func (e *Engine) ReconcileVectorIdentity(ctx context.Context) (VectorIdentitySta
 			st.Declared, st.Match = st.Active, true
 			st.Action = fmt.Sprintf("initialized corpus vector identity to %s", st.Active)
 			return st, nil
+		case 1:
+			for id := range buckets {
+				declared = id
+			}
+			if err := e.DB.SetVectorIdentity(declared); err != nil {
+				return st, err
+			}
+			st.Action = fmt.Sprintf("backfilled corpus vector identity to %s (from stored vectors)", declared)
+		default:
+			// Mixed corpus: do NOT silently bless a majority — a prior interrupted
+			// re-embed could have left a foreign identity in the lead. Fail closed
+			// and require explicit repair.
+			st.Match = false
+			st.Reason = fmt.Sprintf(
+				"corpus contains multiple vector identities (%s) — refusing to auto-pick one. "+
+					"Run `continuity doctor` to inspect, then `continuity doctor --repair-vectors --apply` "+
+					"(snapshot-first) to normalize the corpus to a single identity.",
+				strings.Join(sortedKeys(buckets), ", "))
+			st.Action = "LOCKED: mixed vector identities in corpus"
+			e.identityMismatch, e.identityReason = true, st.Reason
+			return st, nil
 		}
-		declared = dominantIdentity(counts)
-		if err := e.DB.SetVectorIdentity(declared); err != nil {
-			return st, err
-		}
-		st.Action = fmt.Sprintf("backfilled corpus vector identity to %s (from stored vectors)", declared)
 	}
 	st.Declared = declared
 
@@ -105,22 +169,12 @@ func (e *Engine) ReconcileVectorIdentity(ctx context.Context) (VectorIdentitySta
 	return st, nil
 }
 
-// dominantIdentity returns the "model:dims" identity holding the most vectors,
-// with a deterministic tiebreak so reconciliation is stable across runs.
-func dominantIdentity(counts map[string]int) string {
-	type kv struct {
-		id string
-		n  int
+// sortedKeys returns a map's keys sorted, for deterministic messages.
+func sortedKeys(m map[string]int) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
 	}
-	pairs := make([]kv, 0, len(counts))
-	for id, n := range counts {
-		pairs = append(pairs, kv{id, n})
-	}
-	sort.Slice(pairs, func(i, j int) bool {
-		if pairs[i].n != pairs[j].n {
-			return pairs[i].n > pairs[j].n
-		}
-		return pairs[i].id < pairs[j].id
-	})
-	return pairs[0].id
+	sort.Strings(keys)
+	return keys
 }

--- a/internal/engine/identity_test.go
+++ b/internal/engine/identity_test.go
@@ -69,11 +69,97 @@ func TestReconcileFreshCorpusInitializes(t *testing.T) {
 	if !st.Match {
 		t.Fatalf("fresh corpus should match: %+v", st)
 	}
-	if id, ok, _ := db.VectorIdentity(); !ok || id != "tfidf:512" {
-		t.Fatalf("identity not initialized: %q ok=%v", id, ok)
+	if id, ok, _ := db.VectorIdentity(); !ok || id != "tfidf" {
+		t.Fatalf("identity not initialized (tfidf is canonical model-only): %q ok=%v", id, ok)
 	}
 	if locked, _ := e.VectorIdentityLocked(); locked {
 		t.Fatal("fresh corpus must not lock")
+	}
+}
+
+// TestReconcileTFIDFStableAcrossDimChange pins Codex finding #1: TF-IDF's
+// corpus-derived dimension must not self-lock the fallback. Stored tfidf at one
+// dim + active tfidf at another must MATCH (canonical identity is model-only).
+func TestReconcileTFIDFStableAcrossDimChange(t *testing.T) {
+	db := memTestDB(t)
+	id := seedLeaf(t, db, "mem://agent/patterns/a", "alpha")
+	if err := db.SaveVector(id, make([]float64, 300), "tfidf"); err != nil {
+		t.Fatal(err)
+	}
+
+	e := New(db, nil)
+	e.SetEmbedder(stubEmbedder{model: "tfidf", dims: 400}) // different dim, same embedder
+
+	st, err := e.ReconcileVectorIdentity(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Match {
+		t.Fatalf("tfidf must not self-lock on dimension change: %+v", st)
+	}
+	if locked, _ := e.VectorIdentityLocked(); locked {
+		t.Fatal("tfidf dim change must not lock")
+	}
+	if got, _, _ := db.VectorIdentity(); got != "tfidf" {
+		t.Fatalf("tfidf identity must be model-only, got %q", got)
+	}
+}
+
+// TestReconcileMixedCorpusLocks pins Codex finding #4: a pre-identity corpus with
+// MULTIPLE stored identities must fail closed, not silently bless a majority.
+func TestReconcileMixedCorpusLocks(t *testing.T) {
+	db := memTestDB(t)
+	a := seedLeaf(t, db, "mem://agent/patterns/a", "alpha")
+	b := seedLeaf(t, db, "mem://agent/patterns/b", "beta")
+	if err := db.SaveVector(a, make([]float64, 768), "ollama:nomic-embed-text"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SaveVector(b, make([]float64, 512), "old-model"); err != nil {
+		t.Fatal(err)
+	}
+
+	e := New(db, nil)
+	e.SetEmbedder(stubEmbedder{model: "ollama:nomic-embed-text", dims: 768})
+
+	st, err := e.ReconcileVectorIdentity(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Match {
+		t.Fatal("mixed corpus must not match")
+	}
+	if locked, reason := e.VectorIdentityLocked(); !locked || reason == "" {
+		t.Fatalf("mixed corpus must lock with a reason: locked=%v", locked)
+	}
+	if _, ok, _ := db.VectorIdentity(); ok {
+		t.Fatal("mixed corpus must not auto-bind any identity")
+	}
+}
+
+// TestFindSkipsForeignIdentityVectors pins Codex finding #5: even after the lock
+// passes, a stored vector under a foreign identity must not be scored — here a
+// foreign vector identical to the query (cosine 1.0) must still be skipped.
+func TestFindSkipsForeignIdentityVectors(t *testing.T) {
+	db := memTestDB(t)
+	good := seedLeaf(t, db, "mem://agent/patterns/good", "hello world")
+	bad := seedLeaf(t, db, "mem://agent/patterns/bad", "hello world")
+
+	emb := stubEmbedder{model: "active", dims: 8}
+	vec, _ := emb.Embed(context.Background(), "hello world")
+	if err := db.SaveVector(good, vec, "active"); err != nil {
+		t.Fatal(err)
+	}
+	// Same vector, FOREIGN model — high cosine, but must be excluded from scoring.
+	if err := db.SaveVector(bad, vec, "foreign"); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Find(context.Background(), db, emb, "hello world", SearchOpts{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res) != 1 || res[0].Node.URI != "mem://agent/patterns/good" {
+		t.Fatalf("expected only the active-identity node, got %+v", res)
 	}
 }
 

--- a/internal/engine/identity_test.go
+++ b/internal/engine/identity_test.go
@@ -279,6 +279,24 @@ func TestEmbedNodePendingWhileLocked(t *testing.T) {
 	}
 }
 
+// TestFindRetractedMatchesSkipsWhenLocked pins Codex round-2 finding: the
+// retracted-resurrection safety gate must not compare across vector spaces while
+// the identity is locked — it skips (like no embedder) rather than scanning.
+func TestFindRetractedMatchesSkipsWhenLocked(t *testing.T) {
+	db := memTestDB(t)
+	e := New(db, nil)
+	e.SetEmbedder(stubEmbedder{model: "active", dims: 8})
+	e.identityMismatch = true // locked
+
+	matches, err := e.findRetractedMatches(context.Background(), "some candidate text", "patterns", 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if matches != nil {
+		t.Fatalf("locked retract gate must return no matches, got %d", len(matches))
+	}
+}
+
 func TestEmbedMissingFillsTrulyMissing(t *testing.T) {
 	db := memTestDB(t)
 	id := seedLeaf(t, db, "mem://agent/patterns/a", "alpha")

--- a/internal/engine/identity_test.go
+++ b/internal/engine/identity_test.go
@@ -328,6 +328,30 @@ func TestRememberFailsClosedWhenLocked(t *testing.T) {
 	}
 }
 
+// TestEmbedNodeClearsStaleVectorWhenLocked pins Codex round-5: when a content
+// update happens while locked, the OLD vector must be dropped (not left in place)
+// so search can't serve a vector for the previous content after the embedder
+// returns. EmbedMissing only fills MISSING vectors, so a survivor would be stale.
+func TestEmbedNodeClearsStaleVectorWhenLocked(t *testing.T) {
+	db := memTestDB(t)
+	id := seedLeaf(t, db, "mem://agent/patterns/a", "updated content")
+	if err := db.SaveVector(id, make([]float64, 8), "active"); err != nil { // vector for OLD content
+		t.Fatal(err)
+	}
+
+	e := New(db, nil)
+	e.SetEmbedder(stubEmbedder{model: "active", dims: 8})
+	e.identityMismatch = true // locked
+
+	node, _ := db.GetNodeByURI("mem://agent/patterns/a")
+	if err := e.EmbedNode(context.Background(), node); err != nil {
+		t.Fatal(err)
+	}
+	if v, _ := db.GetVector(id); v != nil {
+		t.Fatalf("locked EmbedNode must clear the stale vector, got %+v", v)
+	}
+}
+
 func TestEmbedMissingFillsTrulyMissing(t *testing.T) {
 	db := memTestDB(t)
 	id := seedLeaf(t, db, "mem://agent/patterns/a", "alpha")

--- a/internal/engine/identity_test.go
+++ b/internal/engine/identity_test.go
@@ -1,0 +1,214 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lazypower/continuity/internal/store"
+)
+
+// stubEmbedder is a deterministic, dependency-free embedder for tests. It owns a
+// declared model/dims so we can exercise identity reconciliation without Ollama
+// or a corpus-derived TF-IDF vocabulary.
+type stubEmbedder struct {
+	model string
+	dims  int
+}
+
+func (s stubEmbedder) Embed(_ context.Context, text string) ([]float64, error) {
+	v := make([]float64, s.dims)
+	for i, r := range text {
+		v[i%s.dims] += float64(r)
+	}
+	return v, nil
+}
+func (s stubEmbedder) Model() string   { return s.model }
+func (s stubEmbedder) Dimensions() int { return s.dims }
+
+func memTestDB(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func seedLeaf(t *testing.T, db *store.DB, uri, l0 string) int64 {
+	t.Helper()
+	n := &store.MemNode{URI: uri, NodeType: "leaf", Category: "patterns", L0Abstract: l0}
+	if err := db.CreateNode(n); err != nil {
+		t.Fatalf("CreateNode %s: %v", uri, err)
+	}
+	got, err := db.GetNodeByURI(uri)
+	if err != nil || got == nil {
+		t.Fatalf("GetNodeByURI %s: %v", uri, err)
+	}
+	return got.ID
+}
+
+func TestEmbedderIdentity(t *testing.T) {
+	if got := EmbedderIdentity(stubEmbedder{model: "ollama:nomic-embed-text", dims: 768}); got != "ollama:nomic-embed-text:768" {
+		t.Fatalf("identity = %q", got)
+	}
+	if got := EmbedderIdentity(nil); got != "" {
+		t.Fatalf("nil embedder identity = %q, want empty", got)
+	}
+}
+
+func TestReconcileFreshCorpusInitializes(t *testing.T) {
+	db := memTestDB(t)
+	e := New(db, nil)
+	e.SetEmbedder(stubEmbedder{model: "tfidf", dims: 512})
+
+	st, err := e.ReconcileVectorIdentity(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Match {
+		t.Fatalf("fresh corpus should match: %+v", st)
+	}
+	if id, ok, _ := db.VectorIdentity(); !ok || id != "tfidf:512" {
+		t.Fatalf("identity not initialized: %q ok=%v", id, ok)
+	}
+	if locked, _ := e.VectorIdentityLocked(); locked {
+		t.Fatal("fresh corpus must not lock")
+	}
+}
+
+func TestReconcileBackfillsFromStoredVectorsAndMatches(t *testing.T) {
+	db := memTestDB(t)
+	id := seedLeaf(t, db, "mem://agent/patterns/a", "alpha")
+	if err := db.SaveVector(id, make([]float64, 768), "ollama:nomic-embed-text"); err != nil {
+		t.Fatal(err)
+	}
+
+	e := New(db, nil)
+	e.SetEmbedder(stubEmbedder{model: "ollama:nomic-embed-text", dims: 768})
+
+	st, err := e.ReconcileVectorIdentity(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Match {
+		t.Fatalf("active matching stored vectors should match: %+v", st)
+	}
+	if got, ok, _ := db.VectorIdentity(); !ok || got != "ollama:nomic-embed-text:768" {
+		t.Fatalf("backfilled identity = %q ok=%v", got, ok)
+	}
+	if locked, _ := e.VectorIdentityLocked(); locked {
+		t.Fatal("matching corpus must not lock")
+	}
+}
+
+// TestReconcileMismatchLocks is the core regression: a server whose active
+// embedder differs from the corpus's vector space must LOCK (search fails
+// closed), must NOT silently re-embed, and must preserve the corpus's declared
+// identity rather than overwriting it with the active embedder's.
+func TestReconcileMismatchLocks(t *testing.T) {
+	db := memTestDB(t)
+	id := seedLeaf(t, db, "mem://agent/patterns/a", "alpha")
+	if err := db.SaveVector(id, make([]float64, 768), "ollama:nomic-embed-text"); err != nil {
+		t.Fatal(err)
+	}
+
+	e := New(db, nil)
+	e.SetEmbedder(stubEmbedder{model: "tfidf", dims: 512}) // incompatible with stored nomic/768
+
+	st, err := e.ReconcileVectorIdentity(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Match {
+		t.Fatal("incompatible active embedder must not match")
+	}
+	locked, reason := e.VectorIdentityLocked()
+	if !locked || reason == "" {
+		t.Fatalf("mismatch must lock with a reason: locked=%v reason=%q", locked, reason)
+	}
+
+	// No silent re-embed while locked.
+	n, err := e.EmbedMissing(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("locked EmbedMissing must embed nothing, embedded %d", n)
+	}
+	// Declared identity stays the corpus's truth, not the active embedder.
+	if got, _, _ := db.VectorIdentity(); got != "ollama:nomic-embed-text:768" {
+		t.Fatalf("declared identity must remain corpus truth, got %q", got)
+	}
+}
+
+// TestEmbedMissingDoesNotReembedStale pins the exact bug: a vector under an older
+// model must never be silently overwritten by EmbedMissing.
+func TestEmbedMissingDoesNotReembedStale(t *testing.T) {
+	db := memTestDB(t)
+	id := seedLeaf(t, db, "mem://agent/patterns/a", "alpha")
+	if err := db.SaveVector(id, make([]float64, 512), "old-model"); err != nil {
+		t.Fatal(err)
+	}
+
+	e := New(db, nil)
+	e.SetEmbedder(stubEmbedder{model: "new-model", dims: 64})
+
+	n, err := e.EmbedMissing(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("must not re-embed a stale vector, embedded %d", n)
+	}
+	v, _ := db.GetVector(id)
+	if v == nil || v.Model != "old-model" {
+		t.Fatalf("stale vector was overwritten: %+v", v)
+	}
+}
+
+// TestEmbedNodePendingWhileLocked verifies the Pending state: a write during an
+// incompatible-embedder period must not embed into the foreign vector space —
+// the node stays pending (no vector) for EmbedMissing to fill once compatible.
+func TestEmbedNodePendingWhileLocked(t *testing.T) {
+	db := memTestDB(t)
+	id := seedLeaf(t, db, "mem://agent/patterns/a", "alpha")
+	if err := db.SaveVector(id, make([]float64, 768), "ollama:nomic-embed-text"); err != nil {
+		t.Fatal(err)
+	}
+	newID := seedLeaf(t, db, "mem://agent/patterns/b", "beta")
+
+	e := New(db, nil)
+	e.SetEmbedder(stubEmbedder{model: "tfidf", dims: 512}) // incompatible with nomic/768
+	if _, err := e.ReconcileVectorIdentity(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	node, _ := db.GetNodeByURI("mem://agent/patterns/b")
+	if err := e.EmbedNode(context.Background(), node); err != nil {
+		t.Fatal(err)
+	}
+	if v, _ := db.GetVector(newID); v != nil {
+		t.Fatalf("locked EmbedNode must leave node pending (no vector), got %+v", v)
+	}
+}
+
+func TestEmbedMissingFillsTrulyMissing(t *testing.T) {
+	db := memTestDB(t)
+	id := seedLeaf(t, db, "mem://agent/patterns/a", "alpha")
+
+	e := New(db, nil)
+	e.SetEmbedder(stubEmbedder{model: "new-model", dims: 64})
+
+	n, err := e.EmbedMissing(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("should embed the 1 missing node, embedded %d", n)
+	}
+	v, _ := db.GetVector(id)
+	if v == nil || v.Model != "new-model" || v.Dimensions != 64 {
+		t.Fatalf("missing node not embedded correctly: %+v", v)
+	}
+}

--- a/internal/engine/identity_test.go
+++ b/internal/engine/identity_test.go
@@ -352,6 +352,27 @@ func TestEmbedNodeClearsStaleVectorWhenLocked(t *testing.T) {
 	}
 }
 
+// TestEmbedNodeClearsStaleVectorWhenNoEmbedder pins Codex round-6: the stale-on-
+// update invariant must also hold with NO embedder configured (not just locked),
+// since Remember now routes every write through EmbedNode unconditionally.
+func TestEmbedNodeClearsStaleVectorWhenNoEmbedder(t *testing.T) {
+	db := memTestDB(t)
+	id := seedLeaf(t, db, "mem://agent/patterns/a", "updated content")
+	if err := db.SaveVector(id, make([]float64, 8), "active"); err != nil {
+		t.Fatal(err)
+	}
+
+	e := New(db, nil) // no embedder configured
+
+	node, _ := db.GetNodeByURI("mem://agent/patterns/a")
+	if err := e.EmbedNode(context.Background(), node); err != nil {
+		t.Fatal(err)
+	}
+	if v, _ := db.GetVector(id); v != nil {
+		t.Fatalf("no-embedder EmbedNode must clear the stale vector, got %+v", v)
+	}
+}
+
 func TestEmbedMissingFillsTrulyMissing(t *testing.T) {
 	db := memTestDB(t)
 	id := seedLeaf(t, db, "mem://agent/patterns/a", "alpha")

--- a/internal/engine/identity_test.go
+++ b/internal/engine/identity_test.go
@@ -297,6 +297,37 @@ func TestFindRetractedMatchesSkipsWhenLocked(t *testing.T) {
 	}
 }
 
+// TestRememberFailsClosedWhenLocked pins Codex round-3: while the identity is
+// locked the retracted-PII gate can't run, so an unacknowledged write must be
+// REFUSED (not silently allowed); --acknowledge-retracted still overrides.
+func TestRememberFailsClosedWhenLocked(t *testing.T) {
+	db := memTestDB(t)
+	e := New(db, nil)
+	e.SetEmbedder(stubEmbedder{model: "active", dims: 8})
+	e.identityMismatch = true // locked
+
+	const body = "a sufficiently long overview body for validation"
+	if _, _, err := e.Remember(context.Background(), RememberInput{
+		Category: "patterns", Name: "alpha", Summary: "hello world", Body: body,
+	}); err == nil {
+		t.Fatal("locked Remember without --acknowledge-retracted must refuse")
+	}
+
+	uri, _, err := e.Remember(context.Background(), RememberInput{
+		Category: "patterns", Name: "beta", Summary: "hello world", Body: body, AcknowledgeRetracted: true,
+	})
+	if err != nil {
+		t.Fatalf("acknowledged locked Remember should proceed: %v", err)
+	}
+	// It must have stayed Pending — no vector written into the foreign space.
+	stored, _ := db.GetNodeByURI(uri)
+	if stored != nil {
+		if v, _ := db.GetVector(stored.ID); v != nil {
+			t.Fatalf("locked Remember must leave node Pending, got vector %+v", v)
+		}
+	}
+}
+
 func TestEmbedMissingFillsTrulyMissing(t *testing.T) {
 	db := memTestDB(t)
 	id := seedLeaf(t, db, "mem://agent/patterns/a", "alpha")

--- a/internal/engine/ranking_golden_test.go
+++ b/internal/engine/ranking_golden_test.go
@@ -1,0 +1,55 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lazypower/continuity/internal/store"
+)
+
+// TestFindRankingMechanism_CategoryBoost is a tier-1 golden: it uses the
+// deterministic stub embedder to pin the SCORING MECHANISM (not retrieval
+// quality). Two nodes with identical abstracts embed to identical vectors, so
+// their similarity and relevance are equal; the only differentiator is the
+// moments category boost (1.3x). This locks the ranking math that was previously
+// only inspectable by curling /api/search and reading it by hand.
+func TestFindRankingMechanism_CategoryBoost(t *testing.T) {
+	db := memTestDB(t)
+
+	mk := func(uri, category, l0 string) {
+		n := &store.MemNode{URI: uri, NodeType: "leaf", Category: category, L0Abstract: l0}
+		if err := db.CreateNode(n); err != nil {
+			t.Fatalf("CreateNode %s: %v", uri, err)
+		}
+	}
+	const text = "identical abstract text for both nodes"
+	mk("mem://user/moments/m", "moments", text)
+	mk("mem://agent/patterns/p", "patterns", text)
+
+	emb := stubEmbedder{model: "toy", dims: 32}
+	e := New(db, nil)
+	e.SetEmbedder(emb)
+	if _, err := e.ReconcileVectorIdentity(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.EmbedMissing(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Find(context.Background(), db, emb, text, SearchOpts{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("want 2 results, got %d", len(res))
+	}
+	if res[0].Node.Category != "moments" {
+		t.Fatalf("moments boost must rank moments first; got %s (%.4f) then %s (%.4f)",
+			res[0].Node.Category, res[0].Score, res[1].Node.Category, res[1].Score)
+	}
+	// Equal similarity and relevance, so the boosted score must be exactly 1.3x
+	// the unboosted one (categoryBoost("moments") == 1.3).
+	if got := res[0].Score / res[1].Score; got < 1.29 || got > 1.31 {
+		t.Fatalf("category boost ratio = %.4f, want ~1.30", got)
+	}
+}

--- a/internal/engine/retract.go
+++ b/internal/engine/retract.go
@@ -78,7 +78,10 @@ func hashURI(uri string) string {
 // The reason content of matched nodes is intentionally NOT consulted or returned —
 // callers receive URIs only and must use --include-retracted to fetch reasons.
 func (e *Engine) findRetractedMatches(ctx context.Context, candidateText, category string, threshold float64) ([]store.MemNode, error) {
-	if e.Embedder == nil || candidateText == "" {
+	// A locked identity means the active embedder is incompatible with the
+	// corpus, so this gate can't run meaningfully — treat it exactly like
+	// "no embedder configured" (skip) rather than comparing across vector spaces.
+	if e.Embedder == nil || candidateText == "" || e.identityMismatch {
 		return nil, nil
 	}
 
@@ -86,6 +89,7 @@ func (e *Engine) findRetractedMatches(ctx context.Context, candidateText, catego
 	if err != nil {
 		return nil, fmt.Errorf("embed candidate: %w", err)
 	}
+	activeID := EmbedderIdentity(e.Embedder)
 
 	vectors, err := e.DB.AllVectors()
 	if err != nil {
@@ -110,6 +114,9 @@ func (e *Engine) findRetractedMatches(ctx context.Context, candidateText, catego
 
 	var matches []store.MemNode
 	for _, v := range vectors {
+		if canonicalIdentity(v.Model, v.Dimensions) != activeID {
+			continue // never compare across vector spaces
+		}
 		node, ok := nodeMap[v.NodeID]
 		if !ok || node.NodeType != "leaf" || node.Category != category {
 			continue

--- a/internal/engine/search.go
+++ b/internal/engine/search.go
@@ -85,9 +85,21 @@ func Find(ctx context.Context, db *store.DB, embedder Embedder, query string, op
 		nodeMap[n.ID] = n
 	}
 
+	// Only score vectors that share the active embedder's identity. After the
+	// identity lock passes, the corpus may still contain a few stale rows from a
+	// prior embedder (e.g. an interrupted migration); comparing the query vector
+	// against those is a cross-space comparison that yields meaningless scores
+	// (or, on matching dimensions, plausible-looking noise). Skip them.
+	activeID := EmbedderIdentity(embedder)
+	skippedForeign := 0
+
 	// Score each vector
 	var results []SearchResult
 	for _, v := range vectors {
+		if canonicalIdentity(v.Model, v.Dimensions) != activeID {
+			skippedForeign++
+			continue
+		}
 		node, ok := nodeMap[v.NodeID]
 		if !ok {
 			continue
@@ -117,6 +129,10 @@ func Find(ctx context.Context, db *store.DB, embedder Embedder, query string, op
 				Similarity: similarity,
 			})
 		}
+	}
+
+	if skippedForeign > 0 {
+		log.Printf("search: skipped %d stored vector(s) not matching active identity %s (run `continuity doctor`)", skippedForeign, activeID)
 	}
 
 	// Sort by score descending

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -234,13 +234,13 @@ func (s *Server) handleGetMemory(w http.ResponseWriter, r *http.Request) {
 	// deliberate act, not a passive notification."
 	if node.IsRetracted() && !includeRetracted {
 		out := map[string]any{
-			"uri":            node.URI,
-			"category":       node.Category,
-			"node_type":      node.NodeType,
-			"retracted":      true,
-			"tombstoned_at":  *node.TombstonedAt,
-			"created_at":     node.CreatedAt,
-			"updated_at":     node.UpdatedAt,
+			"uri":           node.URI,
+			"category":      node.Category,
+			"node_type":     node.NodeType,
+			"retracted":     true,
+			"tombstoned_at": *node.TombstonedAt,
+			"created_at":    node.CreatedAt,
+			"updated_at":    node.UpdatedAt,
 		}
 		if node.SupersededBy != "" {
 			out["superseded_by"] = node.SupersededBy
@@ -318,9 +318,9 @@ func (s *Server) handleRemember(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusConflict)
 			json.NewEncoder(w).Encode(map[string]any{
-				"status":           "matches_retracted",
-				"matched_uris":     uris,
-				"hint":             "inspect each with `continuity show <uri> --include-retracted` before proceeding; pass --acknowledge-retracted to override",
+				"status":       "matches_retracted",
+				"matched_uris": uris,
+				"hint":         "inspect each with `continuity show <uri> --include-retracted` before proceeding; pass --acknowledge-retracted to override",
 			})
 			return
 		}
@@ -433,6 +433,17 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		json.NewEncoder(w).Encode(map[string]string{"error": "search not available — no embedder configured"})
+		return
+	}
+
+	// Fail closed on a vector-identity mismatch: the active embedder is
+	// incompatible with the corpus's vector space, so any similarity score would
+	// be meaningless (cosine across dimensions is 0). Surface the repair path
+	// instead of silently returning noise.
+	if locked, reason := s.engine.VectorIdentityLocked(); locked {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]string{"error": reason})
 		return
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,6 +99,16 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	// os.Executable is best-effort; an empty string is acceptable for clients.
 	exe, _ := os.Executable()
 
+	// Advertise the embedder the running server ACTUALLY uses (and whether the
+	// corpus vector identity is locked), so doctor compares against the live
+	// embedder instead of re-resolving a fresh one — the fresh-resolve blind spot.
+	activeEmbedder := ""
+	identityLocked := false
+	if s.engine != nil {
+		activeEmbedder = s.engine.ActiveIdentity()
+		identityLocked, _ = s.engine.VectorIdentityLocked()
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
 		// Existing fields, preserved for backward-compat.
@@ -115,6 +125,11 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		"started_at":     s.started.Unix(),
 		"db_path":        s.db.Path,
 		"exe":            exe,
+
+		// Vector-identity fields: what the live server embeds with, and whether
+		// search is locked due to a corpus/embedder mismatch.
+		"active_embedder":        activeEmbedder,
+		"vector_identity_locked": identityLocked,
 	})
 }
 

--- a/internal/store/meta.go
+++ b/internal/store/meta.go
@@ -49,24 +49,32 @@ func (db *DB) SetVectorIdentity(identity string) error {
 	return db.SetMeta(MetaVectorIdentity, identity)
 }
 
-// VectorModelCounts returns the count of stored vectors grouped by their
-// "model:dimensions" identity string. It reads only metadata columns (no
-// embedding blobs), so it is cheap to call at startup for reconciliation.
-func (db *DB) VectorModelCounts() (map[string]int, error) {
+// VectorModelCount is one (model, dimensions) bucket of the stored corpus.
+type VectorModelCount struct {
+	Model      string
+	Dimensions int
+	Count      int
+}
+
+// VectorModelCounts returns stored vectors grouped by (model, dimensions). It
+// reads only metadata columns (no embedding blobs), so it is cheap to call at
+// startup for reconciliation. Callers canonicalize (model, dimensions) into a
+// vector identity — kept out of the store layer because the canonicalization
+// rules (e.g. corpus-derived embedders) live in the engine.
+func (db *DB) VectorModelCounts() ([]VectorModelCount, error) {
 	rows, err := db.Query(`SELECT model, dimensions, COUNT(*) FROM mem_vectors GROUP BY model, dimensions`)
 	if err != nil {
 		return nil, fmt.Errorf("vector model counts: %w", err)
 	}
 	defer rows.Close()
 
-	counts := map[string]int{}
+	var out []VectorModelCount
 	for rows.Next() {
-		var model string
-		var dims, n int
-		if err := rows.Scan(&model, &dims, &n); err != nil {
+		var c VectorModelCount
+		if err := rows.Scan(&c.Model, &c.Dimensions, &c.Count); err != nil {
 			return nil, fmt.Errorf("scan vector model count: %w", err)
 		}
-		counts[fmt.Sprintf("%s:%d", model, dims)] = n
+		out = append(out, c)
 	}
-	return counts, rows.Err()
+	return out, rows.Err()
 }

--- a/internal/store/meta.go
+++ b/internal/store/meta.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// MetaVectorIdentity is the mem_meta key under which the corpus's declared
+// vector identity ("model:dims") is stored. The active embedder is reconciled
+// against this at startup so it cannot be silently switched by environment.
+const MetaVectorIdentity = "vector_identity"
+
+// GetMeta returns the value for a mem_meta key. ok is false when the key is
+// absent (distinct from an empty-string value).
+func (db *DB) GetMeta(key string) (value string, ok bool, err error) {
+	err = db.QueryRow(`SELECT value FROM mem_meta WHERE key = ?`, key).Scan(&value)
+	if err == sql.ErrNoRows {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("get meta %q: %w", key, err)
+	}
+	return value, true, nil
+}
+
+// SetMeta inserts or replaces a mem_meta key/value.
+func (db *DB) SetMeta(key, value string) error {
+	now := time.Now().UnixMilli()
+	_, err := db.Exec(`
+		INSERT INTO mem_meta (key, value, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(key) DO UPDATE SET value = ?, updated_at = ?
+	`, key, value, now, value, now)
+	if err != nil {
+		return fmt.Errorf("set meta %q: %w", key, err)
+	}
+	return nil
+}
+
+// VectorIdentity returns the corpus's declared vector identity, or ok=false if
+// none has been declared yet (a fresh or pre-identity corpus).
+func (db *DB) VectorIdentity() (identity string, ok bool, err error) {
+	return db.GetMeta(MetaVectorIdentity)
+}
+
+// SetVectorIdentity declares the corpus's vector identity.
+func (db *DB) SetVectorIdentity(identity string) error {
+	return db.SetMeta(MetaVectorIdentity, identity)
+}
+
+// VectorModelCounts returns the count of stored vectors grouped by their
+// "model:dimensions" identity string. It reads only metadata columns (no
+// embedding blobs), so it is cheap to call at startup for reconciliation.
+func (db *DB) VectorModelCounts() (map[string]int, error) {
+	rows, err := db.Query(`SELECT model, dimensions, COUNT(*) FROM mem_vectors GROUP BY model, dimensions`)
+	if err != nil {
+		return nil, fmt.Errorf("vector model counts: %w", err)
+	}
+	defer rows.Close()
+
+	counts := map[string]int{}
+	for rows.Next() {
+		var model string
+		var dims, n int
+		if err := rows.Scan(&model, &dims, &n); err != nil {
+			return nil, fmt.Errorf("scan vector model count: %w", err)
+		}
+		counts[fmt.Sprintf("%s:%d", model, dims)] = n
+	}
+	return counts, rows.Err()
+}

--- a/internal/store/meta_test.go
+++ b/internal/store/meta_test.go
@@ -1,0 +1,57 @@
+package store
+
+import "testing"
+
+func TestMetaGetSetUpsert(t *testing.T) {
+	db := testDB(t)
+
+	if _, ok, err := db.GetMeta("nope"); err != nil || ok {
+		t.Fatalf("absent key: ok=%v err=%v", ok, err)
+	}
+	if err := db.SetMeta("k", "v1"); err != nil {
+		t.Fatal(err)
+	}
+	if v, ok, err := db.GetMeta("k"); err != nil || !ok || v != "v1" {
+		t.Fatalf("get after set: %q ok=%v err=%v", v, ok, err)
+	}
+	if err := db.SetMeta("k", "v2"); err != nil {
+		t.Fatal(err)
+	}
+	if v, _, _ := db.GetMeta("k"); v != "v2" {
+		t.Fatalf("upsert failed: %q", v)
+	}
+}
+
+func TestVectorIdentityRoundtrip(t *testing.T) {
+	db := testDB(t)
+
+	if _, ok, _ := db.VectorIdentity(); ok {
+		t.Fatal("fresh DB should have no declared vector identity")
+	}
+	if err := db.SetVectorIdentity("tfidf:512"); err != nil {
+		t.Fatal(err)
+	}
+	if id, ok, _ := db.VectorIdentity(); !ok || id != "tfidf:512" {
+		t.Fatalf("identity roundtrip: %q ok=%v", id, ok)
+	}
+}
+
+func TestVectorModelCounts(t *testing.T) {
+	db := testDB(t)
+	n := &MemNode{URI: "mem://agent/patterns/a", NodeType: "leaf", Category: "patterns", L0Abstract: "x"}
+	if err := db.CreateNode(n); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := db.GetNodeByURI("mem://agent/patterns/a")
+	if err := db.SaveVector(got.ID, make([]float64, 768), "ollama:nomic-embed-text"); err != nil {
+		t.Fatal(err)
+	}
+
+	counts, err := db.VectorModelCounts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts["ollama:nomic-embed-text:768"] != 1 {
+		t.Fatalf("counts = %+v", counts)
+	}
+}

--- a/internal/store/meta_test.go
+++ b/internal/store/meta_test.go
@@ -51,7 +51,7 @@ func TestVectorModelCounts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if counts["ollama:nomic-embed-text:768"] != 1 {
+	if len(counts) != 1 || counts[0].Model != "ollama:nomic-embed-text" || counts[0].Dimensions != 768 || counts[0].Count != 1 {
 		t.Fatalf("counts = %+v", counts)
 	}
 }

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -258,6 +258,21 @@ CREATE TABLE metrics_daily (
 );
 `,
 	},
+	{
+		Version:     11,
+		Description: "mem_meta: key/value store for corpus-level facts (vector identity)",
+		// Additive table; no user data touched. Holds the corpus's DECLARED
+		// vector identity (model:dims) so the active embedder can be reconciled
+		// against it at startup instead of being chosen by environment alone —
+		// the root cause of the silent re-embed migration. See engine/identity.go.
+		SQL: `
+CREATE TABLE mem_meta (
+    key        TEXT PRIMARY KEY,
+    value      TEXT NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+`,
+	},
 }
 
 // headVersion is the highest schema version this binary knows how to apply.
@@ -285,7 +300,7 @@ func HeadSchemaVersion() int {
 // Typed error so callers (e.g. a future `continuity doctor` command or a
 // recovery flow) can branch on it without parsing the message string.
 type ErrSchemaTooNew struct {
-	Found    int
+	Found     int
 	Supported int
 }
 

--- a/internal/store/snapshot.go
+++ b/internal/store/snapshot.go
@@ -159,6 +159,46 @@ func (db *DB) snapshotBeforeRiskyMigration(m migration) (string, error) {
 	return snapPath, nil
 }
 
+// SnapshotNow writes a self-contained, WAL-consistent copy of the database to
+// the snapshot dir and returns its path. It uses VACUUM INTO — the SQLite-blessed
+// atomic copy — for the same WAL-safety reasons documented on
+// snapshotBeforeRiskyMigration (a naïve file copy would drop un-checkpointed
+// writes). Used by explicit, operator-invoked repairs (e.g. doctor
+// --repair-vectors) so a destructive re-embed always has a restore point.
+// Returns ("", nil) for an in-memory DB (nothing to snapshot).
+func (db *DB) SnapshotNow(label string) (string, error) {
+	if db.Path == "" || db.Path == ":memory:" {
+		return "", nil
+	}
+	snapDir := snapshotDirForDB(db.Path)
+	if err := os.MkdirAll(snapDir, 0o700); err != nil {
+		return "", fmt.Errorf("create snapshot dir %s: %w", snapDir, err)
+	}
+
+	safe := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-':
+			return r
+		default:
+			return '-'
+		}
+	}, label)
+	if safe == "" {
+		safe = "snapshot"
+	}
+
+	timestamp := time.Now().UTC().Format("2006-01-02T15-04-05Z")
+	snapPath := filepath.Join(snapDir, fmt.Sprintf("continuity-%s-%s.db", safe, timestamp))
+
+	if _, err := db.Exec("VACUUM INTO ?", snapPath); err != nil {
+		return "", fmt.Errorf("vacuum into %s: %w", snapPath, err)
+	}
+	if err := os.Chmod(snapPath, 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not tighten permissions on snapshot %s: %v\n", snapPath, err)
+	}
+	return snapPath, nil
+}
+
 // recordSnapshotAndPruneOlder is called from migrate() AFTER a risky migration
 // has successfully committed. It does two things atomically: enrolls the new
 // snapshot in the tracking table, and removes any older snapshot records so


### PR DESCRIPTION
## Why

We went looking for a retrieval bug and found something worse: **the system was already performing a hidden corpus migration.** `EmbedMissing` (a background goroutine on every `serve` startup) silently re-embedded every leaf whose stored model differed from the active embedder. When `nomic-embed-text` became available, it silently re-embedded the entire corpus TF-IDF→nomic — no snapshot, no consent, one unread stderr line. The root cause: **"active embedder" was chosen by environment (Ollama up/down at boot), not bound to the corpus.**

This violates our doctrine — *no hidden corpus migrations; diagnose → snapshot → repair.*

## What

Bind a **vector identity** (`model:dims`, canonical) to the corpus and reconcile the active embedder against it. The embedder can no longer be silently switched, and every destructive or comparison path is identity-aware or fails closed.

**Prevent**
- Migration 11 + `mem_meta` store the corpus's declared vector identity.
- `ReconcileVectorIdentity` at startup: fresh → adopt; single stored identity → backfill; **multiple/mismatch/reconcile-error → LOCK** (fail closed).
- `EmbedMissing` downgraded to fill-truly-missing-only — never re-embeds stale.
- Writes during a lock stay **Pending** (no foreign-space vector); content-updates **clear** any stale vector so search never serves old content.
- Search **fails closed** on a locked identity and **filters scoring to the active identity** (never compares across vector spaces). Same filter applied to the retract-PII gate, the extraction similarity gate, dedup clustering, and moment eviction.

**Detect**
- `/api/health` advertises the live server's active embedder + lock state.
- `continuity doctor` compares **server-vs-stored-vs-declared** (closes the fresh-resolve blind spot), reports the distribution, stale/missing/dim counts, and a read-only self-retrieval probe.

**Recover**
- `continuity doctor --repair-vectors`: snapshot-first (`VACUUM INTO`), **dry-run by default**, embed-all-then-write-all (no half-migrated corpus), refuses to run under a live server that isn't stopped/locked/in-agreement.

**Observe**
- `continuity search --explain` prints the score decomposition (no more jq-against-prod).

## Hardening

Built by Claude, then run through a 6-round adversarial review loop with Codex in the BREAK seat. **16 findings, all fixed, each with a regression test** — convergence 7→2→4→1→1→1. The recurring theme: *every destructive/comparison path must be identity-aware or fail closed*, not just the obvious search path.

## Tests
~22 new targeted tests (reconcile state machine, no-reembed/pending/stale-clear invariants, identity filtering, mixed-corpus lock, repair dry-run/apply/refuse, ranking-mechanism golden). Full suite green.

## Deferred (separate scoped reviews)
- nomic golden tier (precomputed-vector fixtures + scheduled live-Ollama CI).
- TF-IDF degraded-mode / vocab-fingerprint pass — TF-IDF is best-effort and binds model-only here to avoid self-locking on corpus growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)