### PR TITLE
fix: stable fixed-dimension feature-hashed fallback embedder (replaces drifting TF-IDF)

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -269,12 +269,12 @@ func resolveActiveEmbedder(db *store.DB, cfg config.Config) (engine.Embedder, er
 	case "ollama":
 		return engine.NewOllamaEmbedder(ollamaURL, embeddingModel, 768), nil
 	case "tfidf":
-		return engine.NewTFIDFEmbedder(db, 512)
-	default: // auto: probe Ollama, fall back to TF-IDF
+		return engine.NewHashEmbedder(0)
+	default: // auto: probe Ollama, fall back to the hashed lexical embedder
 		if engine.ProbeOllama(ollamaURL, embeddingModel) {
 			return engine.NewOllamaEmbedder(ollamaURL, embeddingModel, 768), nil
 		}
-		return engine.NewTFIDFEmbedder(db, 512)
+		return engine.NewHashEmbedder(0)
 	}
 }
 

--- a/internal/cli/retract_e2e_test.go
+++ b/internal/cli/retract_e2e_test.go
@@ -26,10 +26,11 @@ import (
 //   - The `show <uri> --include-retracted` reveal path.
 //   - The `remember --acknowledge-retracted` bypass path.
 //
-// Why TFIDF: the test runs in a clean-room CI environment that has no Ollama.
-// Forcing CONTINUITY_EMBEDDER=tfidf removes the probe's environment dependency,
-// and exercising the TFIDF code path in CI is itself the point — we ship it as
-// a fallback and have not been testing it end-to-end.
+// Why the lexical fallback: the test runs in a clean-room CI environment that
+// has no Ollama. Forcing CONTINUITY_EMBEDDER=tfidf selects the hashed lexical
+// fallback and removes the probe's environment dependency; exercising that
+// fallback path end-to-end in CI is itself the point — we ship it and must keep
+// it honest.
 //
 // Why subprocess: in-process httptest tests share state and goroutine context
 // with the test harness, which hides exit-code semantics, stderr-vs-stdout
@@ -45,13 +46,13 @@ func TestRetract_SubprocessE2E_TFIDF(t *testing.T) {
 	workDir := t.TempDir()
 	dbPath := filepath.Join(workDir, "test.db")
 
-	// Seed the DB with enough varied text that TFIDF builds a real vocabulary
-	// covering the tokens our test queries use (operator, home, address,
-	// discussion, captured, accident). Without this, NewTFIDFEmbedder produces
-	// a 1-dim vector and every cosine similarity collapses to 0, so the
-	// dedup-against-retracted gate cannot fire and the test would silently
-	// fail to exercise its target invariant.
-	seedTFIDFCorpus(t, dbPath)
+	// Seed the DB with varied distractor memories before the test runs. The
+	// hashed embedder needs no corpus to function (fixed dimension, no
+	// vocabulary), so this is no longer required for the embedder to work — it
+	// represents the production state where the user already has a populated DB,
+	// and it proves the gate matches the SPECIFIC retracted node rather than
+	// firing on any neighbor.
+	seedDistractorCorpus(t, dbPath)
 
 	serverURL, procEnv := testharness.HermeticEnv(t, workDir, dbPath, 0)
 
@@ -174,12 +175,13 @@ func TestRetract_SubprocessE2E_TFIDF(t *testing.T) {
 		ExpectStdoutContains(t, "mem://user/events/second-attempt-similar")
 }
 
-// seedTFIDFCorpus opens the SQLite DB directly and writes enough varied L0
-// abstracts that NewTFIDFEmbedder has a real vocabulary covering the tokens
-// the retract test queries use. Seeding here (not via the CLI) is intentional:
-// it represents the production state where the user already has a populated DB
-// when they invoke retract.
-func seedTFIDFCorpus(t *testing.T, dbPath string) {
+// seedDistractorCorpus opens the SQLite DB directly and writes varied L0
+// abstracts that act as near-neighbors to the retract test's queries. Seeding
+// here (not via the CLI) is intentional: it represents the production state
+// where the user already has a populated DB when they invoke retract, and the
+// distractors prove the dedup-against-retracted gate matches the specific
+// retracted node rather than any nearby memory.
+func seedDistractorCorpus(t *testing.T, dbPath string) {
 	t.Helper()
 	db, err := store.Open(dbPath)
 	if err != nil {

--- a/internal/cli/retract_integration_test.go
+++ b/internal/cli/retract_integration_test.go
@@ -222,8 +222,8 @@ func TestRetract_PIIScenario_FullLoop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Build embedder + embed (TFIDF needs corpus to exist before construction).
-	embedder, _ := engine.NewTFIDFEmbedder(db, 512)
+	// Set the hashed embedder + embed (it needs no corpus to construct).
+	embedder, _ := engine.NewHashEmbedder(0)
 	eng.SetEmbedder(embedder)
 	n, _ := db.GetNodeByURI(uri)
 	if err := eng.EmbedNode(context.Background(), n); err != nil {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -31,12 +31,13 @@ const (
 	envServeEmbedder = "CONTINUITY_EMBEDDER" // "tfidf" | "ollama" | "none" | "" (auto)
 )
 
-// tfidfBestEffortNotice is surfaced once at startup whenever TFIDF is the active
-// embedder (forced or fallback). TFIDF is best-effort by construction — the
-// corpus IS the model — so operators should know the tradeoff they're running
-// with, plus a one-line pointer to the upgrade path. The README's "Embedding
-// backends" section spells out the two shipped paths (Ollama / TFIDF). Issue #22.
-const tfidfBestEffortNotice = "  ! tfidf: retraction-dedup recall is best-effort; install Ollama (nomic-embed-text) for stronger guarantees — see README \"Embedding backends\""
+// tfidfLexicalNotice is surfaced once at startup whenever the hashed lexical
+// fallback is the active embedder (forced or fallback). The fallback is a
+// fixed-dimension feature-hashed embedder: stable and reliable for the
+// retraction/dedup gates, but LEXICAL (keyword overlap), not semantic — so
+// operators should know to install Ollama if they need semantic recall. The
+// README's "Embedding backends" section spells out the two shipped paths.
+const tfidfLexicalNotice = "  ! tfidf: hashed lexical fallback (keyword overlap, not semantic); install Ollama (nomic-embed-text) for semantic recall — see README \"Embedding backends\""
 
 var serveCmd = &cobra.Command{
 	Use:   "serve",
@@ -111,20 +112,20 @@ func runServe(cmd *cobra.Command, args []string) error {
 			}
 			fmt.Fprintf(os.Stderr, "  embedder: ollama (%s)\n", embeddingModel)
 		case "tfidf":
-			emb, tfidfErr := engine.NewTFIDFEmbedder(db, 512)
+			emb, tfidfErr := engine.NewHashEmbedder(0)
 			if tfidfErr != nil {
 				fmt.Fprintf(os.Stderr, "warning: tfidf embedder init failed: %v\n", tfidfErr)
 			} else {
 				if eng != nil {
 					eng.SetEmbedder(emb)
 				}
-				fmt.Fprintf(os.Stderr, "  embedder: tfidf (forced)\n")
-				fmt.Fprintln(os.Stderr, tfidfBestEffortNotice)
+				fmt.Fprintf(os.Stderr, "  embedder: tfidf (hashed lexical, forced)\n")
+				fmt.Fprintln(os.Stderr, tfidfLexicalNotice)
 			}
 		case "none":
 			fmt.Fprintln(os.Stderr, "  embedder: none (forced; dedup-against-retracted gate inactive)")
 		default:
-			// auto: probe Ollama, fall back to TFIDF
+			// auto: probe Ollama, fall back to the hashed lexical embedder
 			if engine.ProbeOllama(ollamaURL, embeddingModel) {
 				emb := engine.NewOllamaEmbedder(ollamaURL, embeddingModel, 768)
 				if eng != nil {
@@ -132,15 +133,15 @@ func runServe(cmd *cobra.Command, args []string) error {
 				}
 				fmt.Fprintf(os.Stderr, "  embedder: ollama (%s)\n", embeddingModel)
 			} else {
-				emb, tfidfErr := engine.NewTFIDFEmbedder(db, 512)
+				emb, tfidfErr := engine.NewHashEmbedder(0)
 				if tfidfErr != nil {
 					fmt.Fprintf(os.Stderr, "warning: tfidf embedder init failed: %v\n", tfidfErr)
 				} else {
 					if eng != nil {
 						eng.SetEmbedder(emb)
 					}
-					fmt.Fprintf(os.Stderr, "  embedder: tfidf (fallback)\n")
-					fmt.Fprintln(os.Stderr, tfidfBestEffortNotice)
+					fmt.Fprintf(os.Stderr, "  embedder: tfidf (hashed lexical, fallback)\n")
+					fmt.Fprintln(os.Stderr, tfidfLexicalNotice)
 				}
 			}
 		}

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -373,7 +373,7 @@ func runDedup(cmd *cobra.Command, args []string) error {
 		emb = engine.NewOllamaEmbedder(ollamaURL, embeddingModel, 768)
 		fmt.Printf("Embedder: ollama (%s)\n", embeddingModel)
 	} else {
-		emb, err = engine.NewTFIDFEmbedder(db, 512)
+		emb, err = engine.NewHashEmbedder(0)
 		if err != nil {
 			return fmt.Errorf("init tfidf embedder: %w", err)
 		}

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -342,12 +342,12 @@ var (
 var dedupCmd = &cobra.Command{
 	Use:   "dedup",
 	Short: "Deduplicate semantically similar memory nodes",
-	Long:  "Finds and merges duplicate memory nodes using cosine similarity. Requires a running Ollama instance or falls back to TF-IDF.",
+	Long:  "Finds and merges duplicate memory nodes using cosine similarity. Uses Ollama if available, otherwise the hashed lexical fallback. When --threshold is not set, the default is calibrated to the active embedder (lower for the lexical fallback), matching the engine's automatic dedup.",
 	RunE:  runDedup,
 }
 
 func init() {
-	dedupCmd.Flags().Float64Var(&dedupThreshold, "threshold", 0.65, "Cosine similarity threshold (0.0-1.0)")
+	dedupCmd.Flags().Float64Var(&dedupThreshold, "threshold", 0.65, "Cosine similarity threshold (0.0-1.0); default is embedder-aware when unset")
 	dedupCmd.Flags().BoolVar(&dedupDryRun, "dry-run", false, "Show what would be removed without deleting")
 }
 
@@ -395,12 +395,22 @@ func runDedup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("dedup refused — %s", reason)
 	}
 
+	// Embedder-aware default: the lexical fallback produces lower cosines than a
+	// semantic model, so a fixed 0.65 would leave behind duplicates the engine's
+	// automatic dedup (which uses MatchThreshold) already merges. Honor an
+	// explicit --threshold; otherwise calibrate to the active embedder.
+	threshold := dedupThreshold
+	if !cmd.Flags().Changed("threshold") {
+		threshold = engine.MatchThreshold(emb)
+	}
+	fmt.Printf("Threshold: %.2f\n", threshold)
+
 	if dedupDryRun {
 		fmt.Println("\n[dry-run] Would deduplicate — rerun without --dry-run to apply")
 		return nil
 	}
 
-	removed, err := eng.Dedup(ctx, dedupThreshold)
+	removed, err := eng.Dedup(ctx, threshold)
 	if err != nil {
 		return fmt.Errorf("dedup: %w", err)
 	}

--- a/internal/engine/dedup_test.go
+++ b/internal/engine/dedup_test.go
@@ -52,7 +52,7 @@ func TestFindSimilarNode(t *testing.T) {
 	}
 
 	// Build embedder from this DB
-	embedder, err := NewTFIDFEmbedder(db, 512)
+	embedder, err := NewHashEmbedder(0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func TestFindSimilarNode(t *testing.T) {
 func TestFindSimilarNodeEmptyDB(t *testing.T) {
 	db := testDB(t)
 
-	embedder, _ := NewTFIDFEmbedder(db, 512)
+	embedder, _ := NewHashEmbedder(0)
 	ctx := context.Background()
 
 	match, sim, err := findSimilarNode(ctx, db, embedder, "test query", "profile", 0.85)
@@ -134,7 +134,7 @@ func TestExtractMemoriesSimilarityGate(t *testing.T) {
 	}
 
 	// Build embedder and embed the existing node
-	embedder, _ := NewTFIDFEmbedder(db, 512)
+	embedder, _ := NewHashEmbedder(0)
 	ctx := context.Background()
 	vec, _ := embedder.Embed(ctx, existing.L0Abstract)
 	db.SaveVector(existing.ID, vec, embedder.Model())
@@ -212,7 +212,7 @@ func TestDedup(t *testing.T) {
 	nodes := seedDuplicateNodes(t, db)
 
 	// Build embedder and embed all nodes
-	embedder, err := NewTFIDFEmbedder(db, 512)
+	embedder, err := NewHashEmbedder(0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/embedder.go
+++ b/internal/engine/embedder.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 	"unicode"
@@ -194,8 +195,18 @@ func (h *HashEmbedder) Embed(_ context.Context, text string) ([]float64, error) 
 		return vec, nil
 	}
 
-	for term, count := range tf {
-		weight := 1.0 + math.Log(float64(count)) // sublinear TF
+	// Accumulate in sorted term order so the vector is bit-for-bit deterministic.
+	// Float addition isn't associative, so randomized map iteration could vary the
+	// low bits when distinct terms collide into the same bucket — harmless for
+	// threshold comparisons, but it breaks the "same text → identical vector"
+	// invariant that cross-restart gate comparisons (and our tests) rely on.
+	terms := make([]string, 0, len(tf))
+	for term := range tf {
+		terms = append(terms, term)
+	}
+	sort.Strings(terms)
+	for _, term := range terms {
+		weight := 1.0 + math.Log(float64(tf[term])) // sublinear TF
 		vec[hashBucket(term, h.dims)] += weight
 	}
 
@@ -210,7 +221,7 @@ func (h *HashEmbedder) Embed(_ context.Context, text string) ([]float64, error) 
 func alnumLower(text string) string {
 	var b strings.Builder
 	for _, r := range strings.ToLower(text) {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
 			b.WriteRune(r)
 		}
 	}
@@ -288,7 +299,7 @@ func tokenize(text string) []string {
 	var tokens []string
 	var current strings.Builder
 	for _, r := range text {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
 			current.WriteRune(r)
 		} else {
 			if current.Len() > 1 { // skip single-char tokens

--- a/internal/engine/embedder.go
+++ b/internal/engine/embedder.go
@@ -161,17 +161,30 @@ func (h *HashEmbedder) Dimensions() int { return h.dims }
 // collisions unbiased; L2 normalization makes cosine length-independent.
 func (h *HashEmbedder) Embed(_ context.Context, text string) ([]float64, error) {
 	vec := make([]float64, h.dims)
-	tokens := tokenize(text)
-	if len(tokens) == 0 {
-		return vec, nil
-	}
 
 	tf := make(map[string]int)
-	for _, tok := range tokens {
+	for _, tok := range tokenize(text) {
 		if _, stop := lexicalStopwords[tok]; stop {
 			continue // see lexicalStopwords: static stand-in for IDF down-weighting
 		}
 		tf[tok]++
+	}
+
+	// Degenerate input: no content tokens survived — the text is token-less,
+	// single-char-only after splitting (e.g. "x-y"), or entirely stopwords
+	// (e.g. "to-be"). A silent zero vector here is a false negative: the memory
+	// could not match ITSELF in search or the retraction-resurrection gate, the
+	// exact failure this embedder exists to prevent. Fall back to one coarse
+	// token over the text's alphanumerics so any real content embeds non-zero
+	// and self-consistently; only genuinely content-free text (pure punctuation)
+	// stays the zero vector.
+	if len(tf) == 0 {
+		if norm := alnumLower(text); norm != "" {
+			bucket, sign := hashFeature(norm, h.dims)
+			vec[bucket] = sign
+			normalize(vec)
+		}
+		return vec, nil
 	}
 
 	for term, count := range tf {
@@ -182,6 +195,19 @@ func (h *HashEmbedder) Embed(_ context.Context, text string) ([]float64, error) 
 
 	normalize(vec)
 	return vec, nil
+}
+
+// alnumLower returns text lowercased with every non-alphanumeric rune removed.
+// Used only for the degenerate-input fallback in Embed, to guarantee that any
+// text with alphanumeric content yields a non-zero, self-consistent vector.
+func alnumLower(text string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(text) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // lexicalStopwords is a fixed, corpus-independent set of high-frequency English

--- a/internal/engine/embedder.go
+++ b/internal/engine/embedder.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode"
 )
 
 // Embedder generates vector embeddings for text.
@@ -126,8 +127,14 @@ func ProbeOllama(url, model string) bool {
 //   - deterministic across restarts and across machines.
 //
 // Collisions (distinct terms sharing a bucket) are the cost; they are tuned away
-// by dims. Signed hashing (a per-term ±1) keeps collisions unbiased in
-// expectation rather than always additive.
+// by dims. Buckets accumulate UNSIGNED weights: the textbook signed-hashing trick
+// (a per-term ±1) keeps collisions unbiased in expectation, but it lets two
+// colliding terms with opposite signs cancel — which can zero out the whole
+// vector for short inputs (e.g. "oh aaa"), and a zero vector cannot match itself
+// in the retraction gate. For a lexical SAFETY net the cardinal sin is a silent
+// false negative, so we accept the small additive collision bias (which only ever
+// nudges similarity UP, toward firing the gate) in exchange for the guarantee
+// that any surviving content token yields a non-zero vector.
 type HashEmbedder struct {
 	dims int
 }
@@ -157,8 +164,9 @@ func (h *HashEmbedder) Model() string   { return "hashtf" }
 func (h *HashEmbedder) Dimensions() int { return h.dims }
 
 // Embed generates a normalized hashed-TF vector for the given text. Sublinear
-// term frequency (1 + log(count)) damps repetition; signed feature hashing keeps
-// collisions unbiased; L2 normalization makes cosine length-independent.
+// term frequency (1 + log(count)) damps repetition; unsigned feature hashing
+// guarantees any content token contributes a positive weight (no cancellation to
+// zero); L2 normalization makes cosine length-independent.
 func (h *HashEmbedder) Embed(_ context.Context, text string) ([]float64, error) {
 	vec := make([]float64, h.dims)
 
@@ -180,30 +188,29 @@ func (h *HashEmbedder) Embed(_ context.Context, text string) ([]float64, error) 
 	// stays the zero vector.
 	if len(tf) == 0 {
 		if norm := alnumLower(text); norm != "" {
-			bucket, sign := hashFeature(norm, h.dims)
-			vec[bucket] = sign
+			vec[hashBucket(norm, h.dims)] = 1
 			normalize(vec)
 		}
 		return vec, nil
 	}
 
 	for term, count := range tf {
-		bucket, sign := hashFeature(term, h.dims)
 		weight := 1.0 + math.Log(float64(count)) // sublinear TF
-		vec[bucket] += sign * weight
+		vec[hashBucket(term, h.dims)] += weight
 	}
 
 	normalize(vec)
 	return vec, nil
 }
 
-// alnumLower returns text lowercased with every non-alphanumeric rune removed.
-// Used only for the degenerate-input fallback in Embed, to guarantee that any
-// text with alphanumeric content yields a non-zero, self-consistent vector.
+// alnumLower returns text lowercased with every non-alphanumeric rune removed
+// (Unicode-aware, matching tokenize). Used only for the degenerate-input fallback
+// in Embed, to guarantee that any text with alphanumeric content yields a
+// non-zero, self-consistent vector.
 func alnumLower(text string) string {
 	var b strings.Builder
 	for _, r := range strings.ToLower(text) {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
 			b.WriteRune(r)
 		}
 	}
@@ -258,22 +265,17 @@ func MatchThreshold(emb Embedder) float64 {
 	return defaultSimilarityThreshold
 }
 
-// hashFeature maps a term to its bucket in [0, dims) and a deterministic ±1 sign
-// (the signed-hashing trick). Bucket and sign come from independent regions of a
-// 64-bit FNV-1a hash: the low bits choose the bucket, the high bit the sign.
-func hashFeature(term string, dims int) (bucket int, sign float64) {
+// hashBucket maps a term to its bucket in [0, dims) via a 64-bit FNV-1a hash.
+func hashBucket(term string, dims int) int {
 	hsh := fnv.New64a()
 	_, _ = hsh.Write([]byte(term))
-	sum := hsh.Sum64()
-	bucket = int(sum % uint64(dims))
-	if sum&(1<<63) == 0 {
-		return bucket, 1.0
-	}
-	return bucket, -1.0
+	return int(hsh.Sum64() % uint64(dims))
 }
 
 // tokenize splits text into lowercase alphanumeric tokens, treating every other
-// rune — including '-' and '_' — as a separator.
+// rune — including '-' and '_' — as a separator. "Alphanumeric" is Unicode-aware
+// (unicode.IsLetter/IsDigit), so non-ASCII memories tokenize to content rather
+// than silently dropping to an all-zero, unmatchable vector.
 //
 // Splitting on '-'/'_' (rather than keeping them inside tokens) is load-bearing
 // for the retraction-resurrection gate: the same PII reformatted differently
@@ -286,7 +288,7 @@ func tokenize(text string) []string {
 	var tokens []string
 	var current strings.Builder
 	for _, r := range text {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
 			current.WriteRune(r)
 		} else {
 			if current.Len() > 1 { // skip single-char tokens

--- a/internal/engine/embedder.go
+++ b/internal/engine/embedder.go
@@ -246,13 +246,21 @@ func hashFeature(term string, dims int) (bucket int, sign float64) {
 	return bucket, -1.0
 }
 
-// tokenize splits text into lowercase tokens, stripping punctuation.
+// tokenize splits text into lowercase alphanumeric tokens, treating every other
+// rune — including '-' and '_' — as a separator.
+//
+// Splitting on '-'/'_' (rather than keeping them inside tokens) is load-bearing
+// for the retraction-resurrection gate: the same PII reformatted differently
+// must still collide. Otherwise "phone 555-123-4567" tokenizes to one opaque
+// token while "phone 555 123 4567" tokenizes to three, the two share almost no
+// buckets, and the gate misses the exact same number. As a bonus, compound terms
+// like "wal-mode" now match their spaced form "wal mode".
 func tokenize(text string) []string {
 	text = strings.ToLower(text)
 	var tokens []string
 	var current strings.Builder
 	for _, r := range text {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
 			current.WriteRune(r)
 		} else {
 			if current.Len() > 1 { // skip single-char tokens

--- a/internal/engine/embedder.go
+++ b/internal/engine/embedder.go
@@ -5,14 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"math"
 	"net/http"
-	"sort"
 	"strings"
 	"time"
-
-	"github.com/lazypower/continuity/internal/store"
 )
 
 // Embedder generates vector embeddings for text.
@@ -40,7 +38,7 @@ func NewOllamaEmbedder(url, model string, dims int) *OllamaEmbedder {
 	}
 }
 
-func (o *OllamaEmbedder) Model() string  { return "ollama:" + o.model }
+func (o *OllamaEmbedder) Model() string   { return "ollama:" + o.model }
 func (o *OllamaEmbedder) Dimensions() int { return o.dims }
 
 // Embed sends text to Ollama's embed endpoint and returns the embedding vector.
@@ -104,157 +102,148 @@ func ProbeOllama(url, model string) bool {
 	return resp.StatusCode == http.StatusOK
 }
 
-// TFIDFEmbedder generates TF-IDF bag-of-words embeddings as a fallback.
+// HashEmbedder is a fixed-dimension feature-hashed lexical embedder used as the
+// Ollama-free fallback.
 //
-// Best-effort by construction: the corpus IS the model. Every retraction or
-// new write that introduces vocabulary not yet in the IDF table shifts the
-// vector space. We minimize the most load-bearing variant of that drift —
-// retraction-induced drift — by including retracted nodes in the corpus
-// (see NewTFIDFEmbedder). Ollama users have a static pre-trained model and
-// don't have this problem; the README's "Embedding backends" section
-// recommends Ollama for any setup that needs strong dedup-against-retracted
-// recall.
-type TFIDFEmbedder struct {
-	vocab []string           // ordered vocabulary (top terms by doc frequency)
-	idf   map[string]float64 // inverse document frequency per term
-	dims  int
+// Each term is hashed to a fixed bucket (hash(term) mod dims), so the coordinate
+// system is constant forever — independent of corpus size, age, vocabulary, or
+// process restarts. That is exactly what the retraction-resurrection gate, the
+// dedup pass, and search all assume: two vectors are only comparable if they
+// share a coordinate system. The predecessor (corpus-derived TF-IDF) rebuilt its
+// vocabulary from the live corpus on every construction, so its axes drifted as
+// memories were added or retracted; a fresh embedder and the stored vectors then
+// lived in different spaces and cosine collapsed to noise (or 0 on a dimension
+// mismatch), silently defeating the PII-resurrection guard.
+//
+// This is a STABLE LEXICAL safety net, not a semantic embedder: similarity is
+// keyword overlap, not meaning. The trade is deliberate — we lower the ambition
+// (no semantic recall, no IDF term-discrimination) to buy total stability. The
+// README's "Embedding backends" section recommends Ollama for setups that need
+// semantic recall. Properties this guarantees that corpus-TF-IDF did not:
+//   - no OOV: every term hashes somewhere, so rare/new terms always contribute
+//     (corpus-TF-IDF dropped any term outside its top-N vocabulary);
+//   - works on a fresh/empty DB from the first write (no startup corpus needed);
+//   - deterministic across restarts and across machines.
+//
+// Collisions (distinct terms sharing a bucket) are the cost; they are tuned away
+// by dims. Signed hashing (a per-term ±1) keeps collisions unbiased in
+// expectation rather than always additive.
+type HashEmbedder struct {
+	dims int
 }
 
-// NewTFIDFEmbedder builds a TF-IDF embedder from existing L0 abstracts.
+// defaultHashDims is the fixed feature-hash dimension. 2048 keeps collisions
+// negligible for personal-scale corpora while keeping vectors cheap (they are
+// sparse — only buckets for terms actually present are non-zero).
+const defaultHashDims = 2048
+
+// NewHashEmbedder builds a feature-hashed lexical embedder. dims <= 0 selects
+// the default (defaultHashDims). It takes no corpus: the embedding of a given
+// text is a pure function of the text and dims, which is the whole point.
 //
-// The corpus deliberately INCLUDES retracted leaves (issue #22). Excluding
-// them would cause the IDF vocabulary to drift between process restarts that
-// straddle a retraction: previously-stored vectors were embedded against a
-// corpus that contained the now-retracted node's terms, while fresh
-// embeddings would be computed against a corpus that no longer does. Cosine
-// similarity between the two becomes incoherent, silently degrading
-// findRetractedMatches recall and defeating the PII-re-introduction guard.
-// Including retracted nodes keeps the vector space stable across retractions.
-func NewTFIDFEmbedder(db *store.DB, maxTerms int) (*TFIDFEmbedder, error) {
-	if maxTerms <= 0 {
-		maxTerms = 512
+// The error return is always nil today — construction is infallible because
+// there is no corpus to read. It exists so the fallback slots into the
+// (Embedder, error) construction factory (resolveActiveEmbedder) uniformly with
+// the other backends, and leaves room for future config validation without a
+// signature change.
+func NewHashEmbedder(dims int) (*HashEmbedder, error) {
+	if dims <= 0 {
+		dims = defaultHashDims
 	}
-
-	leaves, err := db.ListLeavesIncludingRetracted()
-	if err != nil {
-		return nil, fmt.Errorf("list leaves for tfidf: %w", err)
-	}
-
-	// Collect documents (L0 abstracts)
-	var docs []string
-	for _, n := range leaves {
-		if n.L0Abstract != "" {
-			docs = append(docs, n.L0Abstract)
-		}
-	}
-
-	// Build document frequency
-	df := make(map[string]int)
-	for _, doc := range docs {
-		seen := make(map[string]bool)
-		for _, term := range tokenize(doc) {
-			if !seen[term] {
-				df[term]++
-				seen[term] = true
-			}
-		}
-	}
-
-	// Sort terms by document frequency (descending), take top maxTerms.
-	//
-	// Tie-break alphabetically (issue #22): Go map iteration is randomized
-	// and sort.Slice isn't stable, so without an explicit tiebreaker the same
-	// corpus produces vocabularies in different orders across constructions.
-	// That puts identical terms at different vector positions, making cosine
-	// similarity between vectors from two NewTFIDFEmbedder() calls effectively
-	// random — even when the corpus didn't change. The asymmetric loss falls
-	// hardest on dedup-against-retracted, which relies on the vector space
-	// being stable across process restarts.
-	type termFreq struct {
-		term string
-		freq int
-	}
-	var terms []termFreq
-	for t, f := range df {
-		terms = append(terms, termFreq{t, f})
-	}
-	sort.Slice(terms, func(i, j int) bool {
-		if terms[i].freq != terms[j].freq {
-			return terms[i].freq > terms[j].freq
-		}
-		return terms[i].term < terms[j].term
-	})
-
-	dims := maxTerms
-	if len(terms) < dims {
-		dims = len(terms)
-	}
-	if dims == 0 {
-		dims = 1 // minimum dimension to avoid zero-length vectors
-	}
-
-	vocab := make([]string, dims)
-	idf := make(map[string]float64)
-	numDocs := float64(len(docs))
-	if numDocs == 0 {
-		numDocs = 1
-	}
-
-	for i := 0; i < dims && i < len(terms); i++ {
-		vocab[i] = terms[i].term
-		// IDF = log(N / df) + 1 (smoothed)
-		idf[vocab[i]] = math.Log(numDocs/float64(terms[i].freq)) + 1.0
-	}
-
-	return &TFIDFEmbedder{
-		vocab: vocab,
-		idf:   idf,
-		dims:  dims,
-	}, nil
+	return &HashEmbedder{dims: dims}, nil
 }
 
-func (t *TFIDFEmbedder) Model() string  { return "tfidf" }
-func (t *TFIDFEmbedder) Dimensions() int { return t.dims }
+func (h *HashEmbedder) Model() string   { return "hashtf" }
+func (h *HashEmbedder) Dimensions() int { return h.dims }
 
-// Embed generates a normalized TF-IDF vector for the given text.
-func (t *TFIDFEmbedder) Embed(_ context.Context, text string) ([]float64, error) {
+// Embed generates a normalized hashed-TF vector for the given text. Sublinear
+// term frequency (1 + log(count)) damps repetition; signed feature hashing keeps
+// collisions unbiased; L2 normalization makes cosine length-independent.
+func (h *HashEmbedder) Embed(_ context.Context, text string) ([]float64, error) {
+	vec := make([]float64, h.dims)
 	tokens := tokenize(text)
 	if len(tokens) == 0 {
-		return make([]float64, t.dims), nil
+		return vec, nil
 	}
 
-	// Count term frequencies
 	tf := make(map[string]int)
 	for _, tok := range tokens {
+		if _, stop := lexicalStopwords[tok]; stop {
+			continue // see lexicalStopwords: static stand-in for IDF down-weighting
+		}
 		tf[tok]++
 	}
 
-	// Build TF-IDF vector
-	vec := make([]float64, t.dims)
-	maxTF := 0
-	for _, c := range tf {
-		if c > maxTF {
-			maxTF = c
-		}
+	for term, count := range tf {
+		bucket, sign := hashFeature(term, h.dims)
+		weight := 1.0 + math.Log(float64(count)) // sublinear TF
+		vec[bucket] += sign * weight
 	}
 
-	for i, term := range t.vocab {
-		count := tf[term]
-		if count == 0 {
-			continue
-		}
-		// Augmented TF to prevent bias towards longer documents
-		augTF := 0.5 + 0.5*float64(count)/float64(maxTF)
-		idf := t.idf[term]
-		if idf == 0 {
-			idf = 1.0
-		}
-		vec[i] = augTF * idf
-	}
-
-	// L2 normalize
 	normalize(vec)
 	return vec, nil
+}
+
+// lexicalStopwords is a fixed, corpus-independent set of high-frequency English
+// function words dropped before hashing. The legacy TF-IDF embedder leaned on
+// IDF to down-weight ubiquitous words so that distinctive content terms drove
+// similarity; dropping IDF (for coordinate stability) removed that, which both
+// muddied paraphrase recall (the retraction gate's whole job) and let unrelated
+// texts share spurious "the/in/by" overlap. A static stopword list restores the
+// discrimination deterministically — no corpus, so no drift. It is intentionally
+// conservative: only unambiguous function words, never content words.
+var lexicalStopwords = func() map[string]struct{} {
+	words := []string{
+		"the", "a", "an", "and", "or", "but", "if", "then", "so", "as", "of",
+		"to", "in", "on", "at", "by", "for", "with", "from", "into", "onto",
+		"over", "under", "about", "after", "before", "up", "out", "down", "off",
+		"is", "are", "was", "were", "be", "been", "being", "am",
+		"do", "does", "did", "has", "have", "had", "having",
+		"will", "would", "can", "could", "should", "shall", "may", "might", "must",
+		"this", "that", "these", "those", "it", "its", "they", "them", "their",
+		"he", "she", "his", "her", "him", "we", "us", "our", "you", "your",
+		"i", "me", "my", "not", "no", "nor", "yes", "all", "any", "some", "each",
+		"there", "here", "what", "which", "who", "whom", "whose", "when", "where",
+		"why", "how", "than", "too", "very", "just", "also", "only", "more", "most",
+	}
+	m := make(map[string]struct{}, len(words))
+	for _, w := range words {
+		m[w] = struct{}{}
+	}
+	return m
+}()
+
+// lexicalMatchThreshold is the cosine bar for the hashed lexical fallback in the
+// dedup / retraction-resurrection gates. It is lower than defaultSimilarityThreshold
+// (used for semantic embedders) because keyword-overlap cosine for a genuine
+// paraphrase is inherently lower than semantic cosine — a semantic-calibrated
+// 0.65 would silently miss paraphrased retracted PII. Stopword removal keeps
+// unrelated-text cosine well below this, preserving separation.
+const lexicalMatchThreshold = 0.5
+
+// MatchThreshold returns the cosine threshold for treating two embeddings as the
+// "same" memory in the dedup and retraction-resurrection gates. The hashed
+// lexical fallback gets a lower, separately-calibrated bar; semantic and unknown
+// embedders use the default.
+func MatchThreshold(emb Embedder) float64 {
+	if emb != nil && emb.Model() == "hashtf" {
+		return lexicalMatchThreshold
+	}
+	return defaultSimilarityThreshold
+}
+
+// hashFeature maps a term to its bucket in [0, dims) and a deterministic ±1 sign
+// (the signed-hashing trick). Bucket and sign come from independent regions of a
+// 64-bit FNV-1a hash: the low bits choose the bucket, the high bit the sign.
+func hashFeature(term string, dims int) (bucket int, sign float64) {
+	hsh := fnv.New64a()
+	_, _ = hsh.Write([]byte(term))
+	sum := hsh.Sum64()
+	bucket = int(sum % uint64(dims))
+	if sum&(1<<63) == 0 {
+		return bucket, 1.0
+	}
+	return bucket, -1.0
 }
 
 // tokenize splits text into lowercase tokens, stripping punctuation.

--- a/internal/engine/embedder_test.go
+++ b/internal/engine/embedder_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"math"
 	"testing"
-
-	"github.com/lazypower/continuity/internal/store"
 )
 
 func TestTokenize(t *testing.T) {
@@ -15,7 +13,7 @@ func TestTokenize(t *testing.T) {
 	}{
 		{"Hello World", 2},
 		{"Go developer, prefers minimal dependencies.", 5},
-		{"a b c", 0},       // single chars skipped
+		{"a b c", 0}, // single chars skipped
 		{"SQLite WAL mode", 3},
 		{"", 0},
 	}
@@ -87,129 +85,99 @@ func TestCosineSimilarity(t *testing.T) {
 	}
 }
 
-func TestTFIDFEmbedder(t *testing.T) {
-	db := testDB(t)
-
-	// Seed some nodes
-	db.CreateNode(&store.MemNode{
-		URI: "mem://user/profile/go-dev", NodeType: "leaf", Category: "profile",
-		L0Abstract: "Go developer who prefers minimal dependencies",
-	})
-	db.CreateNode(&store.MemNode{
-		URI: "mem://user/profile/sqlite", NodeType: "leaf", Category: "profile",
-		L0Abstract: "Uses SQLite with WAL mode for concurrent reads",
-	})
-	db.CreateNode(&store.MemNode{
-		URI: "mem://agent/patterns/error-handling", NodeType: "leaf", Category: "patterns",
-		L0Abstract: "Pattern: graceful error handling with Go error wrapping",
-	})
-
-	embedder, err := NewTFIDFEmbedder(db, 512)
+func TestHashEmbedder(t *testing.T) {
+	emb, err := NewHashEmbedder(0)
 	if err != nil {
-		t.Fatalf("NewTFIDFEmbedder: %v", err)
+		t.Fatalf("NewHashEmbedder: %v", err)
 	}
 
-	if embedder.Model() != "tfidf" {
-		t.Errorf("model = %q, want tfidf", embedder.Model())
+	if emb.Model() != "hashtf" {
+		t.Errorf("model = %q, want hashtf", emb.Model())
+	}
+	if emb.Dimensions() != defaultHashDims {
+		t.Errorf("dims = %d, want %d", emb.Dimensions(), defaultHashDims)
 	}
 
 	ctx := context.Background()
 
-	// Embed a query related to Go
-	vec, err := embedder.Embed(ctx, "Go developer minimal dependencies")
+	vec, err := emb.Embed(ctx, "Go developer minimal dependencies")
 	if err != nil {
 		t.Fatalf("Embed: %v", err)
 	}
-	if len(vec) != embedder.Dimensions() {
-		t.Errorf("vec length = %d, want %d", len(vec), embedder.Dimensions())
+	if len(vec) != emb.Dimensions() {
+		t.Errorf("vec length = %d, want %d", len(vec), emb.Dimensions())
 	}
 
-	// Embed original node text — should have high similarity
-	nodeVec, _ := embedder.Embed(ctx, "Go developer who prefers minimal dependencies")
-	sim := CosineSimilarity(vec, nodeVec)
+	// Overlapping keywords → high cosine.
+	related, _ := emb.Embed(ctx, "Go developer who prefers minimal dependencies")
+	sim := CosineSimilarity(vec, related)
 	if sim < 0.5 {
-		t.Errorf("similar text cosine = %f, want > 0.5", sim)
+		t.Errorf("related cosine = %f, want > 0.5", sim)
 	}
 
-	// Embed unrelated text — should have lower similarity
-	unrelatedVec, _ := embedder.Embed(ctx, "Python machine learning tensorflow")
-	unrelatedSim := CosineSimilarity(vec, unrelatedVec)
-	if unrelatedSim >= sim {
-		t.Errorf("unrelated similarity %f should be less than related %f", unrelatedSim, sim)
+	// Disjoint keywords → lower cosine.
+	unrelated, _ := emb.Embed(ctx, "Python machine learning tensorflow")
+	if us := CosineSimilarity(vec, unrelated); us >= sim {
+		t.Errorf("unrelated similarity %f should be less than related %f", us, sim)
 	}
 }
 
-func TestTFIDFEmbedderEmpty(t *testing.T) {
-	db := testDB(t)
-
-	embedder, err := NewTFIDFEmbedder(db, 512)
+// TestHashEmbedderEmpty: text with no tokenizable terms embeds to an all-zero
+// vector of the fixed dimension (and must not panic).
+func TestHashEmbedderEmpty(t *testing.T) {
+	emb, err := NewHashEmbedder(0)
 	if err != nil {
-		t.Fatalf("NewTFIDFEmbedder: %v", err)
+		t.Fatalf("NewHashEmbedder: %v", err)
 	}
 
-	// Should still work with no data
-	vec, err := embedder.Embed(context.Background(), "test query")
+	vec, err := emb.Embed(context.Background(), "  ?? !! ")
 	if err != nil {
 		t.Fatalf("Embed: %v", err)
 	}
-	if len(vec) != embedder.Dimensions() {
-		t.Errorf("vec length = %d, want %d", len(vec), embedder.Dimensions())
+	if len(vec) != emb.Dimensions() {
+		t.Errorf("vec length = %d, want %d", len(vec), emb.Dimensions())
+	}
+	for i, v := range vec {
+		if v != 0 {
+			t.Fatalf("token-less text must embed to all-zero; vec[%d]=%f", i, v)
+		}
 	}
 }
 
-// TestNewTFIDFEmbedder_IncludesRetractedInCorpus pins the issue #22 fix.
-// Pre-fix: NewTFIDFEmbedder called db.ListLeaves() which excludes retracted
-// nodes, so the IDF table lost terms that lived only on the retracted node.
-// Stored vectors (computed when that node was live) then lived in a different
-// vector space than fresh embeddings, silently degrading findRetractedMatches
-// recall. The fix loads from ListLeavesIncludingRetracted; this test asserts
-// the retracted node's unique vocabulary survives in the rebuilt IDF.
-func TestNewTFIDFEmbedder_IncludesRetractedInCorpus(t *testing.T) {
-	db := testDB(t)
+// TestHashEmbedderCorpusIndependent is the core regression test for the
+// fixed-dimension feature-hashing fix. The legacy corpus-derived TF-IDF rebuilt
+// its vocabulary (and thus its coordinate system) from the live corpus, so two
+// embedders constructed at different corpus sizes embedded the SAME text into
+// DIFFERENT vector spaces — silently defeating the retraction-resurrection gate,
+// which compares a fresh candidate vector against stored vectors. The hashed
+// embedder's coordinate system is fixed, so the same text always embeds to the
+// same vector regardless of corpus, restarts, or — proven here — rare vocabulary
+// no corpus has ever seen.
+func TestHashEmbedderCorpusIndependent(t *testing.T) {
+	ctx := context.Background()
+	a, _ := NewHashEmbedder(0)
+	b, _ := NewHashEmbedder(0)
 
-	// Seed two leaves with deliberately disjoint distinctive vocabulary so we
-	// can tell whether the retracted node's terms are present in the IDF.
-	if err := db.CreateNode(&store.MemNode{
-		URI: "mem://user/events/live", NodeType: "leaf", Category: "events",
-		L0Abstract: "ordinary common shared common words appear here",
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := db.CreateNode(&store.MemNode{
-		URI: "mem://user/events/will-retract", NodeType: "leaf", Category: "events",
-		L0Abstract: "zebraqua quixotic glyphwerks distinctive unusual",
-	}); err != nil {
-		t.Fatal(err)
-	}
+	const text = "zebraqua quixotic glyphwerks distinctive unusual"
+	va, _ := a.Embed(ctx, text)
+	vb, _ := b.Embed(ctx, text)
 
-	// Retract one node. Pre-fix, "zebraqua/quixotic/glyphwerks/distinctive/unusual"
-	// would vanish from the IDF.
-	if _, err := db.RetractNode("mem://user/events/will-retract", "test", ""); err != nil {
-		t.Fatal(err)
+	if len(va) != len(vb) {
+		t.Fatalf("dimension mismatch between independent embedders: %d vs %d", len(va), len(vb))
 	}
-
-	emb, err := NewTFIDFEmbedder(db, 512)
-	if err != nil {
-		t.Fatalf("NewTFIDFEmbedder: %v", err)
-	}
-
-	for _, term := range []string{"zebraqua", "quixotic", "glyphwerks", "distinctive", "unusual"} {
-		if _, ok := emb.idf[term]; !ok {
-			t.Errorf("IDF vocab missing retracted-only term %q after rebuild — corpus drift not contained", term)
+	for i := range va {
+		if va[i] != vb[i] {
+			t.Fatalf("independent embedders disagree at bucket %d (%f vs %f) — coordinate system is not stable", i, va[i], vb[i])
 		}
 	}
 
-	// Functional check: embedding a string of retracted-only terms must yield
-	// a non-zero vector. Pre-fix this would be all-zero (every term is OOV).
-	vec, err := emb.Embed(context.Background(), "zebraqua quixotic glyphwerks")
-	if err != nil {
-		t.Fatalf("Embed: %v", err)
-	}
+	// No OOV: rare vocabulary no corpus has ever indexed must still produce a
+	// non-zero vector. Corpus-TF-IDF would drop every such term as out-of-vocab.
 	var sumSquares float64
-	for _, x := range vec {
+	for _, x := range va {
 		sumSquares += x * x
 	}
 	if sumSquares == 0 {
-		t.Error("embedding of retracted-only vocabulary is all-zero — IDF table lost the terms")
+		t.Error("rare vocabulary embedded to all-zero — feature hashing must never have OOV")
 	}
 }

--- a/internal/engine/embedder_test.go
+++ b/internal/engine/embedder_test.go
@@ -209,7 +209,9 @@ func TestHashEmbedderUnicodeContentNonZero(t *testing.T) {
 	ctx := context.Background()
 	emb, _ := NewHashEmbedder(0)
 
-	for _, in := range []string{"café résumé", "你好世界", "Москва"} {
+	// Includes non-decimal Unicode numbers (Ⅻ = Nl, ② = No) — covered by
+	// unicode.IsNumber, not unicode.IsDigit.
+	for _, in := range []string{"café résumé", "你好世界", "Москва", "Ⅻ", "②"} {
 		v, _ := emb.Embed(ctx, in)
 		var sumSq float64
 		for _, x := range v {
@@ -217,6 +219,26 @@ func TestHashEmbedderUnicodeContentNonZero(t *testing.T) {
 		}
 		if sumSq == 0 {
 			t.Errorf("unicode content %q embedded to all-zero", in)
+		}
+	}
+}
+
+// TestHashEmbedderDeterministic pins bit-for-bit determinism: the same text must
+// embed to the identical vector across repeated calls, regardless of Go's
+// randomized map iteration order (terms are accumulated in sorted order). The
+// cross-restart retraction gate relies on this.
+func TestHashEmbedderDeterministic(t *testing.T) {
+	ctx := context.Background()
+	emb, _ := NewHashEmbedder(0)
+	const text = "operator home address discussion captured during a long conversation thread with many tokens"
+
+	ref, _ := emb.Embed(ctx, text)
+	for i := 0; i < 20; i++ {
+		v, _ := emb.Embed(ctx, text)
+		for j := range ref {
+			if v[j] != ref[j] {
+				t.Fatalf("non-deterministic embedding at bucket %d on iteration %d: %v vs %v", j, i, v[j], ref[j])
+			}
 		}
 	}
 }

--- a/internal/engine/embedder_test.go
+++ b/internal/engine/embedder_test.go
@@ -16,6 +16,9 @@ func TestTokenize(t *testing.T) {
 		{"a b c", 0}, // single chars skipped
 		{"SQLite WAL mode", 3},
 		{"", 0},
+		{"wal-mode", 2},        // '-' is a separator → wal, mode
+		{"555-123-4567", 3},    // hyphenated digits split → 555, 123, 4567
+		{"snake_case_name", 3}, // '_' is a separator too
 	}
 
 	for _, tt := range tests {
@@ -141,6 +144,28 @@ func TestHashEmbedderEmpty(t *testing.T) {
 		if v != 0 {
 			t.Fatalf("token-less text must embed to all-zero; vec[%d]=%f", i, v)
 		}
+	}
+}
+
+// TestHashEmbedderReformattedDigitsCollide pins the retraction-gate normalization
+// fix (Codex finding): the same PII written with different digit-group separators
+// must still land in the same buckets, so a reformatted re-write trips the gate.
+// Before the tokenize fix, "555-123-4567" was one opaque token and "555 123 4567"
+// was three, so the two barely overlapped and the gate missed identical PII.
+func TestHashEmbedderReformattedDigitsCollide(t *testing.T) {
+	ctx := context.Background()
+	emb, _ := NewHashEmbedder(0)
+
+	hyphen, _ := emb.Embed(ctx, "phone 555-123-4567")
+	spaced, _ := emb.Embed(ctx, "phone 555 123 4567")
+	if sim := CosineSimilarity(hyphen, spaced); sim < lexicalMatchThreshold {
+		t.Errorf("reformatted phone cosine = %f, want >= gate threshold %f", sim, lexicalMatchThreshold)
+	}
+
+	ssnH, _ := emb.Embed(ctx, "ssn 123-45-6789")
+	ssnS, _ := emb.Embed(ctx, "ssn 123 45 6789")
+	if sim := CosineSimilarity(ssnH, ssnS); sim < lexicalMatchThreshold {
+		t.Errorf("reformatted ssn cosine = %f, want >= gate threshold %f", sim, lexicalMatchThreshold)
 	}
 }
 

--- a/internal/engine/embedder_test.go
+++ b/internal/engine/embedder_test.go
@@ -181,6 +181,46 @@ func TestHashEmbedderDegenerateContentNonZero(t *testing.T) {
 	}
 }
 
+// TestHashEmbedderNoCancellationToZero pins the round-3 fix: unsigned hashing
+// must never let colliding content tokens cancel to an all-zero vector. With the
+// old signed-hashing trick, "oh aaa" hashed both tokens to the same bucket with
+// opposite signs, zeroing the vector so the memory could not match itself.
+func TestHashEmbedderNoCancellationToZero(t *testing.T) {
+	ctx := context.Background()
+	emb, _ := NewHashEmbedder(0)
+
+	v, _ := emb.Embed(ctx, "oh aaa")
+	var sumSq float64
+	for _, x := range v {
+		sumSq += x * x
+	}
+	if sumSq == 0 {
+		t.Fatal("colliding content tokens cancelled to an all-zero vector")
+	}
+	if v2, _ := emb.Embed(ctx, "oh aaa"); CosineSimilarity(v, v2) < 0.999 {
+		t.Error(`"oh aaa" does not self-match`)
+	}
+}
+
+// TestHashEmbedderUnicodeContentNonZero pins the round-3 fix: non-ASCII
+// alphanumeric content must tokenize to a non-zero vector, not silently drop to
+// an all-zero (unmatchable) one.
+func TestHashEmbedderUnicodeContentNonZero(t *testing.T) {
+	ctx := context.Background()
+	emb, _ := NewHashEmbedder(0)
+
+	for _, in := range []string{"café résumé", "你好世界", "Москва"} {
+		v, _ := emb.Embed(ctx, in)
+		var sumSq float64
+		for _, x := range v {
+			sumSq += x * x
+		}
+		if sumSq == 0 {
+			t.Errorf("unicode content %q embedded to all-zero", in)
+		}
+	}
+}
+
 // TestHashEmbedderReformattedDigitsCollide pins the retraction-gate normalization
 // fix (Codex finding): the same PII written with different digit-group separators
 // must still land in the same buckets, so a reformatted re-write trips the gate.

--- a/internal/engine/embedder_test.go
+++ b/internal/engine/embedder_test.go
@@ -147,6 +147,40 @@ func TestHashEmbedderEmpty(t *testing.T) {
 	}
 }
 
+// TestHashEmbedderDegenerateContentNonZero pins the round-2 fix: text that has
+// alphanumeric content but whose tokens are all stopwords ("to-be") or all
+// single-char after splitting ("x-y") must NOT embed to an all-zero vector —
+// otherwise the memory cannot match itself in search or the retraction gate.
+// Pure-punctuation text (no alphanumerics) legitimately stays zero.
+func TestHashEmbedderDegenerateContentNonZero(t *testing.T) {
+	ctx := context.Background()
+	emb, _ := NewHashEmbedder(0)
+
+	for _, in := range []string{"to-be", "on_off", "x-y", "2-f-a"} {
+		v, _ := emb.Embed(ctx, in)
+		var sumSq float64
+		for _, x := range v {
+			sumSq += x * x
+		}
+		if sumSq == 0 {
+			t.Errorf("degenerate-but-nonempty input %q embedded to all-zero — cannot match itself", in)
+		}
+		// Self-consistency: the same text must embed identically (so a re-write of
+		// retracted degenerate content still collides with itself).
+		if v2, _ := emb.Embed(ctx, in); CosineSimilarity(v, v2) < 0.999 {
+			t.Errorf("input %q does not self-match", in)
+		}
+	}
+
+	// Genuinely content-free text stays the zero vector.
+	z, _ := emb.Embed(ctx, "  ?? -- __ ")
+	for _, x := range z {
+		if x != 0 {
+			t.Fatalf("content-free text must embed to all-zero")
+		}
+	}
+}
+
 // TestHashEmbedderReformattedDigitsCollide pins the retraction-gate normalization
 // fix (Codex finding): the same PII written with different digit-group separators
 // must still land in the same buckets, so a reformatted re-write trips the gate.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -349,7 +349,7 @@ func (e *Engine) Remember(ctx context.Context, input RememberInput) (string, boo
 	// Reasons are NOT exposed inline — agent fetches them deliberately via
 	// `continuity show <uri> --include-retracted`. See issue #12 / RFC.
 	if !input.AcknowledgeRetracted && e.Embedder != nil && c.L0 != "" {
-		matches, err := e.findRetractedMatches(ctx, c.L0, c.Category, defaultSimilarityThreshold)
+		matches, err := e.findRetractedMatches(ctx, c.L0, c.Category, MatchThreshold(e.Embedder))
 		if err != nil {
 			log.Printf("remember: retracted-match check failed: %v", err)
 		} else if len(matches) > 0 {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -546,9 +546,9 @@ func TestRememberHonorsExplicitSlug(t *testing.T) {
 	mock := &llm.MockClient{Response: &llm.Response{Content: "[]"}}
 	eng := New(db, mock)
 
-	embedder, err := NewTFIDFEmbedder(db, 512)
+	embedder, err := NewHashEmbedder(0)
 	if err != nil {
-		t.Fatalf("NewTFIDFEmbedder: %v", err)
+		t.Fatalf("NewHashEmbedder: %v", err)
 	}
 	eng.SetEmbedder(embedder)
 
@@ -611,9 +611,9 @@ func TestMomentPoolEviction(t *testing.T) {
 	mock := &llm.MockClient{Response: &llm.Response{Content: "[]"}}
 	eng := New(db, mock)
 
-	embedder, err := NewTFIDFEmbedder(db, 512)
+	embedder, err := NewHashEmbedder(0)
 	if err != nil {
-		t.Fatalf("NewTFIDFEmbedder: %v", err)
+		t.Fatalf("NewHashEmbedder: %v", err)
 	}
 	eng.SetEmbedder(embedder)
 
@@ -677,7 +677,7 @@ func TestMomentPoolNoEvictionUnderCap(t *testing.T) {
 	mock := &llm.MockClient{Response: &llm.Response{Content: "[]"}}
 	eng := New(db, mock)
 
-	embedder, _ := NewTFIDFEmbedder(db, 512)
+	embedder, _ := NewHashEmbedder(0)
 	eng.SetEmbedder(embedder)
 
 	ctx := context.Background()

--- a/internal/engine/extractor.go
+++ b/internal/engine/extractor.go
@@ -183,7 +183,7 @@ func extractMemories(db *store.DB, client llm.Client, embedder Embedder, session
 
 		// Similarity gate: check if a semantically equivalent node already exists
 		if embedder != nil && c.Category != "" {
-			match, sim, err := findSimilarNode(ctx, db, embedder, c.L0, c.Category, defaultSimilarityThreshold)
+			match, sim, err := findSimilarNode(ctx, db, embedder, c.L0, c.Category, MatchThreshold(embedder))
 			if err != nil {
 				log.Printf("extraction: similarity check failed: %v", err)
 				// Continue with normal upsert on error — don't block extraction

--- a/internal/engine/identity.go
+++ b/internal/engine/identity.go
@@ -8,19 +8,15 @@ import (
 )
 
 // canonicalIdentity maps a (model, dimensions) pair to a corpus-binding vector
-// identity. Vectors are only comparable within the same identity.
-//
-// TF-IDF is special-cased to model-only: its output dimension is corpus-derived
-// (the vocabulary size, which grows as memories are added), so binding the
-// dimension would self-lock the fallback on normal corpus growth — tfidf:1 on a
-// fresh DB, tfidf:N after a few writes. The dimension carries no identity signal
-// for a corpus-derived embedder, so it is dropped. Stable embedders (real
-// models) bind model:dims, which catches the cross-model and cross-dimension
-// switches that are the actual failure mode.
+// identity. Vectors are only comparable within the same identity, so every
+// embedder — including the hashed lexical fallback — binds model:dims. The
+// fallback's dimension is now fixed (HashEmbedder, defaultHashDims), so binding
+// it no longer self-locks on corpus growth the way the old corpus-derived TF-IDF
+// would have. This also means an existing corpus written by the legacy "tfidf"
+// embedder no longer matches the new "hashtf:N" identity: it locks on upgrade
+// and is repaired by re-embedding (`continuity doctor --repair-vectors --apply`),
+// which is the intended migration path.
 func canonicalIdentity(model string, dims int) string {
-	if model == "tfidf" {
-		return "tfidf"
-	}
 	return fmt.Sprintf("%s:%d", model, dims)
 }
 

--- a/internal/engine/identity_test.go
+++ b/internal/engine/identity_test.go
@@ -60,7 +60,7 @@ func TestEmbedderIdentity(t *testing.T) {
 func TestReconcileFreshCorpusInitializes(t *testing.T) {
 	db := memTestDB(t)
 	e := New(db, nil)
-	e.SetEmbedder(stubEmbedder{model: "tfidf", dims: 512})
+	e.SetEmbedder(stubEmbedder{model: "hashtf", dims: 2048})
 
 	st, err := e.ReconcileVectorIdentity(context.Background())
 	if err != nil {
@@ -69,39 +69,42 @@ func TestReconcileFreshCorpusInitializes(t *testing.T) {
 	if !st.Match {
 		t.Fatalf("fresh corpus should match: %+v", st)
 	}
-	if id, ok, _ := db.VectorIdentity(); !ok || id != "tfidf" {
-		t.Fatalf("identity not initialized (tfidf is canonical model-only): %q ok=%v", id, ok)
+	if id, ok, _ := db.VectorIdentity(); !ok || id != "hashtf:2048" {
+		t.Fatalf("identity not initialized to active embedder: %q ok=%v", id, ok)
 	}
 	if locked, _ := e.VectorIdentityLocked(); locked {
 		t.Fatal("fresh corpus must not lock")
 	}
 }
 
-// TestReconcileTFIDFStableAcrossDimChange pins Codex finding #1: TF-IDF's
-// corpus-derived dimension must not self-lock the fallback. Stored tfidf at one
-// dim + active tfidf at another must MATCH (canonical identity is model-only).
-func TestReconcileTFIDFStableAcrossDimChange(t *testing.T) {
+// TestReconcileLegacyTFIDFCorpusLocks pins the migration trigger for the
+// stable-dimension fix: an existing corpus written by the legacy corpus-derived
+// "tfidf" embedder must NOT silently match the new fixed-dimension hashed
+// fallback ("hashtf:N"). The identities differ, so reconciliation locks (search
+// fails closed) and the operator repairs via `doctor --repair-vectors --apply`,
+// which re-embeds the corpus — retracted nodes included — into the stable space.
+// This is the inverse of the now-removed model-only special case: a legacy tfidf
+// vector at any dimension must trip the lock, not pass it.
+func TestReconcileLegacyTFIDFCorpusLocks(t *testing.T) {
 	db := memTestDB(t)
 	id := seedLeaf(t, db, "mem://agent/patterns/a", "alpha")
+	// Legacy vector: model "tfidf", a corpus-derived dimension.
 	if err := db.SaveVector(id, make([]float64, 300), "tfidf"); err != nil {
 		t.Fatal(err)
 	}
 
 	e := New(db, nil)
-	e.SetEmbedder(stubEmbedder{model: "tfidf", dims: 400}) // different dim, same embedder
+	e.SetEmbedder(stubEmbedder{model: "hashtf", dims: 2048})
 
 	st, err := e.ReconcileVectorIdentity(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !st.Match {
-		t.Fatalf("tfidf must not self-lock on dimension change: %+v", st)
+	if st.Match {
+		t.Fatalf("legacy tfidf corpus must not match the hashed fallback: %+v", st)
 	}
-	if locked, _ := e.VectorIdentityLocked(); locked {
-		t.Fatal("tfidf dim change must not lock")
-	}
-	if got, _, _ := db.VectorIdentity(); got != "tfidf" {
-		t.Fatalf("tfidf identity must be model-only, got %q", got)
+	if locked, reason := e.VectorIdentityLocked(); !locked || reason == "" {
+		t.Fatalf("legacy tfidf corpus must lock with a reason: locked=%v", locked)
 	}
 }
 

--- a/internal/engine/no_resurrection_test.go
+++ b/internal/engine/no_resurrection_test.go
@@ -115,9 +115,9 @@ func TestNoResurrection_FindSimilarNodeDoesNotReturnRetracted(t *testing.T) {
 	if err := db.CreateNode(n); err != nil {
 		t.Fatal(err)
 	}
-	embedder, err := NewTFIDFEmbedder(db, 512)
+	embedder, err := NewHashEmbedder(0)
 	if err != nil {
-		t.Fatalf("NewTFIDFEmbedder: %v", err)
+		t.Fatalf("NewHashEmbedder: %v", err)
 	}
 	vec, err := embedder.Embed(ctx, n.L0Abstract)
 	if err != nil {
@@ -162,9 +162,9 @@ func TestNoResurrection_ExtractMemoriesDoesNotMutateRetracted(t *testing.T) {
 	if err := db.CreateNode(n); err != nil {
 		t.Fatal(err)
 	}
-	embedder, err := NewTFIDFEmbedder(db, 512)
+	embedder, err := NewHashEmbedder(0)
 	if err != nil {
-		t.Fatalf("NewTFIDFEmbedder: %v", err)
+		t.Fatalf("NewHashEmbedder: %v", err)
 	}
 	vec, err := embedder.Embed(ctx, n.L0Abstract)
 	if err != nil {
@@ -216,9 +216,9 @@ func TestNoResurrection_RememberDoesNotMutateRetracted(t *testing.T) {
 	uri := seedAndEmbed(t, eng, "preferences", "doomed-pref",
 		"original preference content for testing the no-resurrection guard",
 		"ORIGINAL body content with enough length to pass validation thresholds.")
-	embedder, err := NewTFIDFEmbedder(db, 512)
+	embedder, err := NewHashEmbedder(0)
 	if err != nil {
-		t.Fatalf("NewTFIDFEmbedder: %v", err)
+		t.Fatalf("NewHashEmbedder: %v", err)
 	}
 	eng.SetEmbedder(embedder)
 	n, err := db.GetNodeByURI(uri)

--- a/internal/engine/retract_test.go
+++ b/internal/engine/retract_test.go
@@ -31,8 +31,8 @@ func TestHashURI_StableAndOpaque(t *testing.T) {
 	}
 }
 
-// seedAndEmbed inserts a leaf node and embeds it, building the embedder from
-// the post-seed corpus so TFIDF actually has signal. Returns the URI written.
+// seedAndEmbed inserts a leaf node and embeds it with the hashed lexical
+// embedder. Returns the URI written.
 func seedAndEmbed(t *testing.T, eng *Engine, category, name, summary, body string) string {
 	t.Helper()
 	uri, _, err := eng.Remember(context.Background(), RememberInput{
@@ -60,8 +60,8 @@ func TestFindRetractedMatches_FindsRetractedSkipsLive(t *testing.T) {
 		"Captured user's full home address by mistake during a session",
 		"Retracted memory body content with enough length to pass validation.")
 
-	// Build embedder AFTER seeding so the TFIDF corpus is populated. Re-embed.
-	embedder, err := NewTFIDFEmbedder(db, 512)
+	// Set the hashed embedder and re-embed (it needs no corpus to construct).
+	embedder, err := NewHashEmbedder(0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func TestFindRetractedMatches_RespectsCategory(t *testing.T) {
 		"shared and overlapping vocabulary across categories test",
 		"Body content with enough length to pass validation thresholds.")
 
-	embedder, _ := NewTFIDFEmbedder(db, 512)
+	embedder, _ := NewHashEmbedder(0)
 	eng.SetEmbedder(embedder)
 	n, _ := db.GetNodeByURI(uri)
 	if err := eng.EmbedNode(ctx, n); err != nil {
@@ -182,8 +182,8 @@ func TestRemember_SurfacesRetractedMatchAsError(t *testing.T) {
 		"operator's mother's maiden name discussed in context",
 		"Body content with enough length to pass validation thresholds easily.")
 
-	// Build the embedder after seeding so TFIDF has corpus, then re-embed.
-	embedder, _ := NewTFIDFEmbedder(db, 512)
+	// Set the hashed embedder, then re-embed (it needs no corpus to construct).
+	embedder, _ := NewHashEmbedder(0)
 	eng.SetEmbedder(embedder)
 	n, _ := db.GetNodeByURI(retracted)
 	if err := eng.EmbedNode(ctx, n); err != nil {
@@ -234,7 +234,7 @@ func TestRemember_AcknowledgeRetractedBypassesGate(t *testing.T) {
 		"pattern shape that future writes will collide with",
 		"Body content with enough length to pass validation thresholds easily.")
 
-	embedder, _ := NewTFIDFEmbedder(db, 512)
+	embedder, _ := NewHashEmbedder(0)
 	eng.SetEmbedder(embedder)
 	n, _ := db.GetNodeByURI(retracted)
 	if err := eng.EmbedNode(ctx, n); err != nil {
@@ -285,22 +285,22 @@ func TestRetractedMatchError_NoCategoryOrTagInline(t *testing.T) {
 }
 
 // TestFindRetractedMatches_TFIDFCorpusCoherent is the asserted regression
-// test for issue #22. Reproduces the production scenario:
+// test for the retraction-resurrection gate across an embedder rebuild.
+// Reproduces the production scenario:
 //
-//  1. Process A seeds + embeds N leaves under TFIDF Embedder A.
+//  1. Process A seeds + embeds N leaves under hashed Embedder A.
 //  2. Process A retracts one leaf.
-//  3. Process B starts and builds TFIDF Embedder B from the current corpus
-//     (the realistic restart path; the in-process embedder doesn't rebuild).
-//  4. A fresh write semantically identical to the retracted memory comes in.
-//     The gate must still fire — the candidate's fresh embedding (from
-//     Embedder B) must still match the stored vector (computed under A).
+//  3. Process B starts and constructs a fresh hashed Embedder B (the realistic
+//     restart path; the in-process embedder doesn't carry over).
+//  4. A fresh write that paraphrases the retracted memory comes in. The gate
+//     must still fire — the candidate's fresh embedding (from Embedder B) must
+//     still match the stored vector (computed under A).
 //
-// Pre-fix, Embedder B's IDF table differed from Embedder A's because the
-// retracted leaf's vocabulary contributed to A but not to B — vectors lived
-// in different spaces, cosine similarity degraded, and the smoke test in
-// smoke_test.go could only `logf` rather than assert. With the fix
-// (corpus = ListLeavesIncludingRetracted), both IDFs are identical and the
-// gate fires deterministically.
+// Under the legacy corpus-derived TF-IDF this was fragile: Embedder B's
+// vocabulary (and coordinate system) differed from A's because the corpus had
+// changed, so vectors lived in different spaces and cosine degraded. The hashed
+// embedder has a fixed coordinate system independent of corpus, so A and B embed
+// identically and the gate fires deterministically.
 func TestFindRetractedMatches_TFIDFCorpusCoherent(t *testing.T) {
 	db := testDB(t)
 	mock := &llm.MockClient{Response: &llm.Response{Content: "[]"}}
@@ -315,7 +315,7 @@ func TestFindRetractedMatches_TFIDFCorpusCoherent(t *testing.T) {
 		"User captured their personal home street address by accident in chat",
 		"Body content with enough length to pass validation thresholds easily.")
 
-	embedderA, err := NewTFIDFEmbedder(db, 512)
+	embedderA, err := NewHashEmbedder(0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -338,10 +338,10 @@ func TestFindRetractedMatches_TFIDFCorpusCoherent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Step 3: simulate a process restart by building Embedder B fresh from
-	// the post-retraction corpus. Pre-fix, this used ListLeaves() and the
-	// retracted node's vocabulary dropped out, shifting IDF weights.
-	embedderB, err := NewTFIDFEmbedder(db, 512)
+	// Step 3: simulate a process restart by constructing Embedder B fresh.
+	// The hashed embedder takes no corpus, so B is identical to A regardless of
+	// the retraction — that is the property this test guards.
+	embedderB, err := NewHashEmbedder(0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/retrieval_golden_test.go
+++ b/internal/engine/retrieval_golden_test.go
@@ -94,7 +94,7 @@ func scoreByURI(res []engine.SearchResult) map[string]float64 {
 
 // TestRetrievalGolden_Nomic_TopicalQueries pins that a real semantic embedder
 // surfaces the on-topic memory first, by a margin — including the "devbox" case
-// that TF-IDF mis-ranked (devbox preference must beat go-sandbox-runtime).
+// the lexical fallback mis-ranks (devbox preference must beat go-sandbox-runtime).
 func TestRetrievalGolden_Nomic_TopicalQueries(t *testing.T) {
 	db, emb := loadGoldenDB(t)
 	ctx := context.Background()
@@ -134,12 +134,12 @@ func TestRetrievalGolden_Nomic_TopicalQueries(t *testing.T) {
 	}
 }
 
-// TestRetrievalGolden_TFIDF_SelfRetrieval exercises the REAL TF-IDF fallback path
-// hermetically (pure Go, no fixture, no Ollama): build the embedder from the
-// corpus, embed every node, and confirm each retrieves itself at rank 1. TF-IDF
-// ranking quality is weak (it's best-effort), so this asserts the path WORKS, not
+// TestRetrievalGolden_HashLexical_SelfRetrieval exercises the REAL hashed lexical
+// fallback path hermetically (pure Go, no fixture, no Ollama): embed every node,
+// then confirm each retrieves itself at rank 1. Lexical ranking quality is weak
+// by design (keyword overlap, not semantic), so this asserts the path WORKS, not
 // that it ranks topical queries well — that's the nomic tier's job.
-func TestRetrievalGolden_TFIDF_SelfRetrieval(t *testing.T) {
+func TestRetrievalGolden_HashLexical_SelfRetrieval(t *testing.T) {
 	db, err := store.OpenMemory()
 	if err != nil {
 		t.Fatalf("OpenMemory: %v", err)
@@ -153,10 +153,10 @@ func TestRetrievalGolden_TFIDF_SelfRetrieval(t *testing.T) {
 		}
 	}
 
-	// Build TF-IDF from the seeded corpus, then embed each node with it.
-	emb, err := engine.NewTFIDFEmbedder(db, 512)
+	// Construct the hashed lexical embedder (no corpus needed), embed each node.
+	emb, err := engine.NewHashEmbedder(0)
 	if err != nil {
-		t.Fatalf("NewTFIDFEmbedder: %v", err)
+		t.Fatalf("NewHashEmbedder: %v", err)
 	}
 	ctx := context.Background()
 	for _, e := range goldretrieval.Corpus() {
@@ -180,7 +180,7 @@ func TestRetrievalGolden_TFIDF_SelfRetrieval(t *testing.T) {
 			got = res[0].Node.URI
 		}
 		if got != e.URI {
-			t.Errorf("tfidf self-retrieval %s: top = %s, want self", e.URI, got)
+			t.Errorf("hash-lexical self-retrieval %s: top = %s, want self", e.URI, got)
 		}
 	}
 }

--- a/internal/engine/search_test.go
+++ b/internal/engine/search_test.go
@@ -50,9 +50,9 @@ func TestFindBasic(t *testing.T) {
 	db := testDB(t)
 	nodes := seedTestNodes(t, db)
 
-	embedder, err := NewTFIDFEmbedder(db, 512)
+	embedder, err := NewHashEmbedder(0)
 	if err != nil {
-		t.Fatalf("NewTFIDFEmbedder: %v", err)
+		t.Fatalf("NewHashEmbedder: %v", err)
 	}
 	embedTestNodes(t, db, embedder, nodes)
 
@@ -83,9 +83,9 @@ func TestFindWithCategory(t *testing.T) {
 	db := testDB(t)
 	nodes := seedTestNodes(t, db)
 
-	embedder, err := NewTFIDFEmbedder(db, 512)
+	embedder, err := NewHashEmbedder(0)
 	if err != nil {
-		t.Fatalf("NewTFIDFEmbedder: %v", err)
+		t.Fatalf("NewHashEmbedder: %v", err)
 	}
 	embedTestNodes(t, db, embedder, nodes)
 
@@ -116,7 +116,7 @@ func TestFindNoEmbedder(t *testing.T) {
 func TestFindEmptyDB(t *testing.T) {
 	db := testDB(t)
 
-	embedder, _ := NewTFIDFEmbedder(db, 512)
+	embedder, _ := NewHashEmbedder(0)
 	ctx := context.Background()
 	results, err := Find(ctx, db, embedder, "test query", SearchOpts{})
 	if err != nil {
@@ -131,7 +131,7 @@ func TestSearchWithMockLLM(t *testing.T) {
 	db := testDB(t)
 	nodes := seedTestNodes(t, db)
 
-	embedder, _ := NewTFIDFEmbedder(db, 512)
+	embedder, _ := NewHashEmbedder(0)
 	embedTestNodes(t, db, embedder, nodes)
 
 	mockLLM := &llm.MockClient{
@@ -160,7 +160,7 @@ func TestSearchFallsBackToFind(t *testing.T) {
 	db := testDB(t)
 	nodes := seedTestNodes(t, db)
 
-	embedder, _ := NewTFIDFEmbedder(db, 512)
+	embedder, _ := NewHashEmbedder(0)
 	embedTestNodes(t, db, embedder, nodes)
 
 	// nil LLM client — should fall back to Find
@@ -217,7 +217,7 @@ func TestFindMomentsBoost(t *testing.T) {
 	db.CreateNode(moment)
 	db.CreateNode(event)
 
-	embedder, _ := NewTFIDFEmbedder(db, 512)
+	embedder, _ := NewHashEmbedder(0)
 	embedTestNodes(t, db, embedder, []*store.MemNode{moment, event})
 
 	ctx := context.Background()

--- a/internal/server/invariant_test.go
+++ b/internal/server/invariant_test.go
@@ -65,7 +65,7 @@ func seedInvariantWorld(t *testing.T) *Server {
 	}
 
 	// Embed everything so dedup-against-retracted has signal to find.
-	embedder, err := engine.NewTFIDFEmbedder(db, 512)
+	embedder, err := engine.NewHashEmbedder(0)
 	if err != nil {
 		t.Fatalf("embedder: %v", err)
 	}

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -231,15 +231,15 @@ func TestRememberRouteRetractedMatchStillSequestered(t *testing.T) {
 	const l0 = "operator's mother's maiden name discussed in context"
 	uri, _, err := srv.engine.Remember(ctx, engine.RememberInput{
 		Category: "events", Name: "old-pii-event",
-		Summary: l0,
-		Body:    "Memory body content with more than enough length to pass validation thresholds.",
+		Summary:              l0,
+		Body:                 "Memory body content with more than enough length to pass validation thresholds.",
 		AcknowledgeRetracted: true,
 	})
 	if err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
-	embedder, err := engine.NewTFIDFEmbedder(srv.db, 512)
+	embedder, err := engine.NewHashEmbedder(0)
 	if err != nil {
 		t.Fatalf("embedder: %v", err)
 	}

--- a/internal/server/smoke_test.go
+++ b/internal/server/smoke_test.go
@@ -111,7 +111,7 @@ func TestSmoke_MigrationAndRetractAgainstRealDB(t *testing.T) {
 			t.Skip("victim has no L0")
 		}
 		eng := engine.New(db, nil)
-		embedder, err := engine.NewTFIDFEmbedder(db, 512)
+		embedder, err := engine.NewHashEmbedder(0)
 		if err != nil {
 			t.Fatalf("embedder: %v", err)
 		}
@@ -126,14 +126,17 @@ func TestSmoke_MigrationAndRetractAgainstRealDB(t *testing.T) {
 		if isMatch, _ := engine.IsRetractedMatch(err); isMatch {
 			return
 		}
-		// If the gate didn't fire, log it but don't fail. Issue #22 closed the
-		// retraction-induced corpus-shift component of TFIDF drift (the
-		// embedder is now built from ListLeavesIncludingRetracted, so the
-		// vector space stays coherent across retractions). But corpus growth
-		// between the prior embedding and this rebuild still produces residual
-		// drift — that's the broader TFIDF limitation we accept as best-effort
-		// rather than chase. The asserted regression test for the fix lives at
-		// internal/engine/retract_test.go::TestFindRetractedMatches_TFIDFCorpusCoherent.
-		t.Logf("dedup gate did not fire (err=%v); residual TFIDF drift on real data — install Ollama for stronger guarantees", err)
+		// If the gate didn't fire, log it but don't fail. This smoke test runs
+		// against the operator's REAL DB, whose stored victim vector may have been
+		// written by a different (pre-migration) embedder — e.g. the legacy
+		// corpus-derived "tfidf" — than the hashed lexical embedder we embed the
+		// candidate with here. findRetractedMatches deliberately skips vectors
+		// under a foreign identity, so against an un-repaired corpus the gate
+		// can't fire until `doctor --repair-vectors --apply` re-embeds it. The
+		// hashed embedder itself has a fixed coordinate system (no drift); the
+		// asserted, hermetic regression for the gate lives at
+		// internal/engine/retract_test.go::TestFindRetractedMatches_TFIDFCorpusCoherent
+		// and ::TestHashEmbedderCorpusIndependent.
+		t.Logf("dedup gate did not fire (err=%v); the real DB's vectors may predate the hashed embedder — run `continuity doctor --repair-vectors --apply`, or install Ollama", err)
 	})
 }


### PR DESCRIPTION
## What & why

The Ollama-free fallback embedder built its vocabulary — and thus its **coordinate system** — from the live corpus on every construction, so its axes drifted as memories were added or retracted. A freshly-constructed embedder and the stored vectors then lived in **different spaces**: cosine collapsed to noise (or `0` on a dimension mismatch), silently defeating the **retracted-PII-resurrection gate**, dedup, and search for Ollama-free operators. (Audit: `.notes/tfidf-audit/`.)

This replaces it with a **fixed-dimension feature-hashed lexical embedder**:

- `term → hash(term) mod 2048`, sublinear TF, **unsigned** accumulation, L2-normalized, **no IDF**.
- The coordinate system is **constant forever** — independent of corpus size/age/restarts/machine. That's exactly what the gates assume (two vectors are only comparable in the same space).
- **No OOV**, works on a **fresh empty DB** from the first write, **deterministic** (bit-for-bit) across restarts.

It's deliberately reframed as a **stable lexical safety net**, not a semantic embedder — we trade semantic recall for total stability (README still points operators at Ollama for semantic recall).

### Recovering IDF's discrimination without the drift
Dropping IDF lost the down-weighting of common words. Recovered deterministically via a **static stopword list** + an **embedder-aware match threshold** (lexical `0.5` vs semantic `0.65`, since keyword-overlap cosine for a genuine paraphrase is inherently lower). The manual `dedup` command's default is now embedder-aware too.

### Migration (doctor-driven, explicit)
Identity now binds `model:dims` for **every** embedder (the `tfidf` model-only special case is gone). The new `hashtf:2048` identity no longer matches a legacy `tfidf` corpus, so existing installs **fail closed on upgrade** and migrate via `continuity doctor --repair-vectors --apply` (snapshot-first; already re-embeds retracted nodes). Verified: the lock fires and repair is correct.

## Scope (read this)
This PR fixes the **embedder-drift vector** of the "retracted PII can resurface" threat. It does **not** claim to close that threat entirely — see Follow-up.

## Cross-model review (Codex, 5 rounds, converged)
Built with Codex in the adversarial BREAK seat. Findings fixed on the embedder surface:
- **R1** reformatted PII (`555-123-4567` vs `555 123 4567`) missed the gate → tokenize splits on `-`/`_`; embedder-aware `dedup` default.
- **R2** degenerate inputs (all-stopword / single-char) embedded to a zero vector that can't match itself → degenerate-input fallback.
- **R3** signed-hash cancellation (`oh aaa` → zero) → **unsigned hashing**; ASCII-only tokenization → **Unicode-aware**.
- **R4** non-deterministic float-add order under collisions → **sorted accumulation**; `IsDigit`→`IsNumber`.
- **R5** CLEAN.

New regression tests pin every fix (`internal/engine/embedder_test.go`). Full suite + `go vet` green.

## Follow-up (separate PR — deferred by design)
Codex surfaced **pre-existing** PII-gate *coverage* holes, independent of the embedder: `findRetractedMatches` runs **only** in `Remember`. Auto-extraction (`extractMemories`, via Stop/SessionEnd hooks) and the signal path (`ExtractSignal`) write with **no** retracted gate, and `Remember` **fails open** if the gate errors. These need their own PR (gate plumbing + fail-closed-on-error), tracked separately. They are the larger remaining slice of the audit's threat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
