### PR TITLE
fix: run the retracted-PII gate on every write path (extraction, signal, fail-closed)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -558,6 +558,11 @@ func (e *Engine) ExtractSignal(ctx context.Context, sessionID, prompt string) er
 			case target.IsRetracted():
 				log.Printf("signal: skipping %s — merge_target %s is retracted (would resurrect)", uri, c.MergeTarget)
 				continue
+			case !target.Mergeable:
+				// Immutable target: UpsertNode won't merge, it creates a suffixed leaf
+				// with the CANDIDATE's category, so gating on target.Category would
+				// check the wrong space. Ignore merge_target; use the constructed uri.
+				log.Printf("signal: ignoring merge_target %s — target is immutable (not a merge); using %s", c.MergeTarget, uri)
 			default:
 				uri = target.URI
 				gateCat = target.Category

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -545,15 +545,22 @@ func (e *Engine) ExtractSignal(ctx context.Context, sessionID, prompt string) er
 		// => skip (merge-into-tombstone). When honored, gate on the target's REAL
 		// category.
 		if c.MergeTarget != "" && strings.HasPrefix(c.MergeTarget, "mem://") {
-			if target, err := e.DB.GetNodeByURI(c.MergeTarget); err == nil && target != nil {
-				if target.IsRetracted() {
-					log.Printf("signal: skipping %s — merge_target %s is retracted (would resurrect)", uri, c.MergeTarget)
-					continue
-				}
+			target, err := e.DB.GetNodeByURI(c.MergeTarget)
+			switch {
+			case err != nil:
+				// Can't resolve => can't prove safety. Fail closed (skip) rather than
+				// fall back to the declared category and miss a retracted node in the
+				// merge target's category.
+				log.Printf("signal: merge_target lookup failed for %s — skipping candidate (fail-closed): %v", c.MergeTarget, err)
+				continue
+			case target == nil:
+				log.Printf("signal: ignoring merge_target %s — no such node; using %s", c.MergeTarget, uri)
+			case target.IsRetracted():
+				log.Printf("signal: skipping %s — merge_target %s is retracted (would resurrect)", uri, c.MergeTarget)
+				continue
+			default:
 				uri = target.URI
 				gateCat = target.Category
-			} else {
-				log.Printf("signal: ignoring merge_target %s — no such node; using %s", c.MergeTarget, uri)
 			}
 		}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -535,23 +535,34 @@ func (e *Engine) ExtractSignal(ctx context.Context, sessionID, prompt string) er
 
 		owner := ownerForCategory(c.Category)
 		uri := fmt.Sprintf("mem://%s/%s/%s", owner, c.Category, c.URIHint)
+		gateCat := c.Category // category the content will actually land in
 
+		// Honor merge_target ONLY if it RESOLVES to an existing node (its purpose is
+		// to merge into one). A raw LLM string is never trusted as a URI: a
+		// malformed/variant or hallucinated target won't resolve, so we ignore it and
+		// keep the canonical constructed uri — the write target is always canonical,
+		// never an attacker-shaped string that dodges the gate. Resolves-to-retracted
+		// => skip (merge-into-tombstone). When honored, gate on the target's REAL
+		// category.
 		if c.MergeTarget != "" && strings.HasPrefix(c.MergeTarget, "mem://") {
-			uri = c.MergeTarget
+			if target, err := e.DB.GetNodeByURI(c.MergeTarget); err == nil && target != nil {
+				if target.IsRetracted() {
+					log.Printf("signal: skipping %s — merge_target %s is retracted (would resurrect)", uri, c.MergeTarget)
+					continue
+				}
+				uri = target.URI
+				gateCat = target.Category
+			} else {
+				log.Printf("signal: ignoring merge_target %s — no such node; using %s", c.MergeTarget, uri)
+			}
 		}
 
 		// Retraction-resurrection gate (per-candidate, fail-closed): a signal
-		// candidate matching a retracted memory must not be written. Keys on the
-		// category the content actually lands in (categoryFromURI of the resolved
-		// uri, not the declared category) so a cross-category merge_target is checked
-		// against the TARGET category. Skip only the offending candidate; on a gate
-		// error skip it too rather than write unchecked. (Locked identity is handled
-		// above; embedder is nil here only in `none` mode — gate opted out.)
+		// candidate matching a retracted memory must not be written. Keys on gateCat
+		// — the category the content actually lands in. Skip only the offending
+		// candidate; on a gate error skip it too rather than write unchecked. (Locked
+		// identity is handled above; embedder is nil here only in `none` mode.)
 		if emb := e.embedderIfUnlocked(); emb != nil && c.L0 != "" {
-			gateCat := categoryFromURI(uri)
-			if gateCat == "" {
-				gateCat = c.Category
-			}
 			matches, err := e.findRetractedMatches(ctx, c.L0, gateCat, MatchThreshold(emb))
 			if err != nil {
 				log.Printf("signal: retracted-check failed for %s — skipping candidate (fail-closed): %v", uri, err)
@@ -563,10 +574,9 @@ func (e *Engine) ExtractSignal(ctx context.Context, sessionID, prompt string) er
 			}
 		}
 
-		// Exact retracted-URI guard (mirrors Remember): a uri_hint/merge_target may
-		// point straight at a retracted node the vector gate can't catch. UpsertNode
-		// would overwrite it in place (mergeable) or duplicate it (immutable) —
-		// resurrection by exact targeting. Skip the candidate.
+		// Exact retracted-URI guard (mirrors Remember): the constructed uri_hint can
+		// still collide with a retracted canonical node the vector gate can't catch
+		// (no same-identity vector). UpsertNode also enforces this atomically.
 		if existing, err := e.DB.GetNodeByURI(uri); err == nil && existing != nil && existing.IsRetracted() {
 			log.Printf("signal: skipping %s — target URI is retracted (would resurrect)", uri)
 			continue

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -557,6 +557,15 @@ func (e *Engine) ExtractSignal(ctx context.Context, sessionID, prompt string) er
 			}
 		}
 
+		// Exact retracted-URI guard (mirrors Remember): a uri_hint/merge_target may
+		// point straight at a retracted node the vector gate can't catch. UpsertNode
+		// would overwrite it in place (mergeable) or duplicate it (immutable) —
+		// resurrection by exact targeting. Skip the candidate.
+		if existing, err := e.DB.GetNodeByURI(uri); err == nil && existing != nil && existing.IsRetracted() {
+			log.Printf("signal: skipping %s — target URI is retracted (would resurrect)", uri)
+			continue
+		}
+
 		node := &store.MemNode{
 			URI:           uri,
 			NodeType:      "leaf",

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -541,12 +541,18 @@ func (e *Engine) ExtractSignal(ctx context.Context, sessionID, prompt string) er
 		}
 
 		// Retraction-resurrection gate (per-candidate, fail-closed): a signal
-		// candidate matching a retracted memory must not be written. Skip only the
-		// offending candidate; on a gate error skip it too rather than write
-		// unchecked. (Locked identity is handled above; embedder is nil here only in
-		// `none` mode, where the operator opted out of the gate.)
+		// candidate matching a retracted memory must not be written. Keys on the
+		// category the content actually lands in (categoryFromURI of the resolved
+		// uri, not the declared category) so a cross-category merge_target is checked
+		// against the TARGET category. Skip only the offending candidate; on a gate
+		// error skip it too rather than write unchecked. (Locked identity is handled
+		// above; embedder is nil here only in `none` mode — gate opted out.)
 		if emb := e.embedderIfUnlocked(); emb != nil && c.L0 != "" {
-			matches, err := e.findRetractedMatches(ctx, c.L0, c.Category, MatchThreshold(emb))
+			gateCat := categoryFromURI(uri)
+			if gateCat == "" {
+				gateCat = c.Category
+			}
+			matches, err := e.findRetractedMatches(ctx, c.L0, gateCat, MatchThreshold(emb))
 			if err != nil {
 				log.Printf("signal: retracted-check failed for %s — skipping candidate (fail-closed): %v", uri, err)
 				continue

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -535,47 +535,18 @@ func (e *Engine) ExtractSignal(ctx context.Context, sessionID, prompt string) er
 
 		owner := ownerForCategory(c.Category)
 		uri := fmt.Sprintf("mem://%s/%s/%s", owner, c.Category, c.URIHint)
-		gateCat := c.Category // category the content will actually land in
 
-		// Honor merge_target ONLY if it RESOLVES to an existing node (its purpose is
-		// to merge into one). A raw LLM string is never trusted as a URI: a
-		// malformed/variant or hallucinated target won't resolve, so we ignore it and
-		// keep the canonical constructed uri — the write target is always canonical,
-		// never an attacker-shaped string that dodges the gate. Resolves-to-retracted
-		// => skip (merge-into-tombstone). When honored, gate on the target's REAL
-		// category.
-		if c.MergeTarget != "" && strings.HasPrefix(c.MergeTarget, "mem://") {
-			target, err := e.DB.GetNodeByURI(c.MergeTarget)
-			switch {
-			case err != nil:
-				// Can't resolve => can't prove safety. Fail closed (skip) rather than
-				// fall back to the declared category and miss a retracted node in the
-				// merge target's category.
-				log.Printf("signal: merge_target lookup failed for %s — skipping candidate (fail-closed): %v", c.MergeTarget, err)
-				continue
-			case target == nil:
-				log.Printf("signal: ignoring merge_target %s — no such node; using %s", c.MergeTarget, uri)
-			case target.IsRetracted():
-				log.Printf("signal: skipping %s — merge_target %s is retracted (would resurrect)", uri, c.MergeTarget)
-				continue
-			case !target.Mergeable:
-				// Immutable target: UpsertNode won't merge, it creates a suffixed leaf
-				// with the CANDIDATE's category, so gating on target.Category would
-				// check the wrong space. Ignore merge_target; use the constructed uri.
-				log.Printf("signal: ignoring merge_target %s — target is immutable (not a merge); using %s", c.MergeTarget, uri)
-			default:
-				uri = target.URI
-				gateCat = target.Category
-			}
-		}
+		// An LLM-supplied merge_target is intentionally NOT honored (see the matching
+		// note in extractMemories): trusting an LLM-chosen URI was a recurring gate
+		// bypass. The candidate always lands in its declared category, so the gate
+		// keys on c.Category.
 
 		// Retraction-resurrection gate (per-candidate, fail-closed): a signal
-		// candidate matching a retracted memory must not be written. Keys on gateCat
-		// — the category the content actually lands in. Skip only the offending
-		// candidate; on a gate error skip it too rather than write unchecked. (Locked
-		// identity is handled above; embedder is nil here only in `none` mode.)
+		// candidate matching a retracted memory must not be written. Skip only the
+		// offending candidate; on a gate error skip it too rather than write unchecked.
+		// (Locked identity is handled above; embedder is nil here only in `none` mode.)
 		if emb := e.embedderIfUnlocked(); emb != nil && c.L0 != "" {
-			matches, err := e.findRetractedMatches(ctx, c.L0, gateCat, MatchThreshold(emb))
+			matches, err := e.findRetractedMatches(ctx, c.L0, c.Category, MatchThreshold(emb))
 			if err != nil {
 				log.Printf("signal: retracted-check failed for %s — skipping candidate (fail-closed): %v", uri, err)
 				continue

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -351,15 +351,17 @@ func (e *Engine) Remember(ctx context.Context, input RememberInput) (string, boo
 	if !input.AcknowledgeRetracted && e.Embedder != nil && c.L0 != "" {
 		matches, err := e.findRetractedMatches(ctx, c.L0, c.Category, MatchThreshold(e.Embedder))
 		if err != nil {
-			log.Printf("remember: retracted-match check failed: %v", err)
-		} else if len(matches) > 0 {
+			// Fail CLOSED: if the gate can't complete we cannot prove the write is
+			// safe, so refuse it rather than risk re-introducing retracted content.
+			// --acknowledge-retracted still overrides (this block is gated on it).
+			return "", false, fmt.Errorf("retracted-memory check failed (failing closed; re-run with --acknowledge-retracted to bypass): %w", err)
+		}
+		if len(matches) > 0 {
 			uris := make([]string, len(matches))
-			hashes := make([]string, len(matches))
 			for i, m := range matches {
 				uris[i] = m.URI
-				hashes[i] = hashURI(m.URI)
 			}
-			log.Printf("dedup-retracted: candidate matches %d retracted node(s) hash=%s", len(matches), strings.Join(hashes, ","))
+			log.Printf("dedup-retracted: candidate matches %d retracted node(s) hash=%s", len(matches), hashMatchedURIs(matches))
 			return "", false, &RetractedMatchError{MatchedURIs: uris}
 		}
 	}
@@ -505,6 +507,14 @@ func (e *Engine) ExtractSignal(ctx context.Context, sessionID, prompt string) er
 		return fmt.Errorf("LLM not configured")
 	}
 
+	// Fail closed while the vector identity is locked: the retraction gate can't
+	// run, so a signal write could silently re-introduce retracted content. Defer
+	// rather than write unchecked; the operator repairs via `continuity doctor`.
+	if e.identityMismatch {
+		log.Printf("signal: deferring — vector identity locked; run `continuity doctor --repair-vectors`")
+		return nil
+	}
+
 	resp, err := e.LLM.Complete(ctx, llm.SignalExtractionPrompt(prompt))
 	if err != nil {
 		return fmt.Errorf("signal extraction LLM: %w", err)
@@ -528,6 +538,23 @@ func (e *Engine) ExtractSignal(ctx context.Context, sessionID, prompt string) er
 
 		if c.MergeTarget != "" && strings.HasPrefix(c.MergeTarget, "mem://") {
 			uri = c.MergeTarget
+		}
+
+		// Retraction-resurrection gate (per-candidate, fail-closed): a signal
+		// candidate matching a retracted memory must not be written. Skip only the
+		// offending candidate; on a gate error skip it too rather than write
+		// unchecked. (Locked identity is handled above; embedder is nil here only in
+		// `none` mode, where the operator opted out of the gate.)
+		if emb := e.embedderIfUnlocked(); emb != nil && c.L0 != "" {
+			matches, err := e.findRetractedMatches(ctx, c.L0, c.Category, MatchThreshold(emb))
+			if err != nil {
+				log.Printf("signal: retracted-check failed for %s — skipping candidate (fail-closed): %v", uri, err)
+				continue
+			}
+			if len(matches) > 0 {
+				log.Printf("signal: skipping %s — matches %d retracted node(s) hash=%s", uri, len(matches), hashMatchedURIs(matches))
+				continue
+			}
 		}
 
 		node := &store.MemNode{
@@ -649,9 +676,19 @@ func (e *Engine) extractSession(sessionID, transcriptPath string, force bool) er
 		return nil
 	}
 
-	// embedderIfUnlocked: while the vector identity is locked, extract still
-	// creates memory nodes but leaves them Pending (nil embedder => no vector),
-	// rather than writing into an incompatible vector space.
+	// Fail closed while the vector identity is locked: the active embedder is
+	// incompatible with the corpus, so the retraction-resurrection gate cannot
+	// run, and extraction would write new memory nodes that could silently
+	// re-introduce retracted (e.g. PII) content the gate would have caught. Defer
+	// the whole session WITHOUT marking it extracted, so the next Stop/SessionEnd
+	// re-extracts once the operator repairs (`continuity doctor --repair-vectors`).
+	if e.identityMismatch {
+		log.Printf("extraction: deferring %s — vector identity locked; run `continuity doctor --repair-vectors` (not marking extracted)", sessionID)
+		return nil
+	}
+
+	// embedderIfUnlocked: with the identity NOT locked, this is the active embedder
+	// (or nil only in `none` mode, where the operator opted out of the gate).
 	if err := extractMemories(e.DB, e.LLM, e.embedderIfUnlocked(), sessionID, transcriptPath); err != nil {
 		return fmt.Errorf("memory extraction: %w", err)
 	}

--- a/internal/engine/extractor.go
+++ b/internal/engine/extractor.go
@@ -41,6 +41,21 @@ func ownerForCategory(category string) string {
 	}
 }
 
+// categoryFromURI extracts the category segment from a mem:// URI of the form
+// mem://<owner>/<category>/<slug>. Returns "" if the URI is not in that shape, so
+// callers can fall back to a known category rather than gating on an empty one.
+func categoryFromURI(uri string) string {
+	rest := strings.TrimPrefix(uri, "mem://")
+	if rest == uri {
+		return ""
+	}
+	parts := strings.Split(rest, "/")
+	if len(parts) < 3 {
+		return ""
+	}
+	return parts[1]
+}
+
 // validCategories defines the allowed memory categories.
 var validCategories = map[string]bool{
 	"profile": true, "preferences": true, "entities": true,
@@ -181,28 +196,6 @@ func extractMemories(db *store.DB, client llm.Client, embedder Embedder, session
 			uri = c.MergeTarget
 		}
 
-		// Retraction-resurrection gate (per-candidate, fail-closed): an extracted
-		// candidate that matches a retracted memory must NOT be written — otherwise
-		// retracted (e.g. PII) content silently resurfaces as a fresh live node.
-		// findSimilarNode above deliberately skips retracted nodes (so it can never
-		// merge INTO one), which is exactly why this separate gate is required to
-		// catch the create-a-new-node resurrection path. Skip only the offending
-		// candidate — one bad candidate must not drop the rest of the batch. On a
-		// gate error we also skip (fail closed) rather than write unchecked. The
-		// embedder is nil only in `none` mode (operator opted out of the gate) — the
-		// locked case is deferred upstream in extractSession, never reaching here.
-		if embedder != nil && c.L0 != "" {
-			matches, err := findRetractedMatchesIn(ctx, db, embedder, c.L0, c.Category, MatchThreshold(embedder))
-			if err != nil {
-				log.Printf("extraction: retracted-check failed for %s — skipping candidate (fail-closed): %v", uri, err)
-				continue
-			}
-			if len(matches) > 0 {
-				log.Printf("extraction: skipping %s — matches %d retracted node(s) hash=%s", uri, len(matches), hashMatchedURIs(matches))
-				continue
-			}
-		}
-
 		// Similarity gate: check if a semantically equivalent node already exists
 		if embedder != nil && c.Category != "" {
 			match, sim, err := findSimilarNode(ctx, db, embedder, c.L0, c.Category, MatchThreshold(embedder))
@@ -215,13 +208,40 @@ func extractMemories(db *store.DB, client llm.Client, embedder Embedder, session
 			}
 		}
 
+		// Retraction-resurrection gate (per-candidate, fail-closed): a candidate
+		// that matches a retracted memory must NOT be written — otherwise retracted
+		// (e.g. PII) content silently resurfaces as a fresh live node. findSimilarNode
+		// deliberately skips retracted nodes (so it can't merge INTO one), which is
+		// why this separate semantic gate is required to catch the create-a-new-node
+		// path. It runs AFTER URI resolution and keys on the category the content
+		// actually lands in (categoryFromURI of the resolved uri, not the candidate's
+		// declared category): a cross-category merge_target must be checked against
+		// retracted nodes of the TARGET category, or the gate checks the wrong space.
+		// Skip only the offending candidate — one bad candidate must not drop the
+		// rest of the batch; on a gate error we also skip (fail closed). The embedder
+		// is nil only in `none` mode (gate opted out); the locked case is deferred
+		// upstream in extractSession.
+		if embedder != nil && c.L0 != "" {
+			gateCat := categoryFromURI(uri)
+			if gateCat == "" {
+				gateCat = c.Category
+			}
+			matches, err := findRetractedMatchesIn(ctx, db, embedder, c.L0, gateCat, MatchThreshold(embedder))
+			if err != nil {
+				log.Printf("extraction: retracted-check failed for %s — skipping candidate (fail-closed): %v", uri, err)
+				continue
+			}
+			if len(matches) > 0 {
+				log.Printf("extraction: skipping %s — matches %d retracted node(s) hash=%s", uri, len(matches), hashMatchedURIs(matches))
+				continue
+			}
+		}
+
 		// Exact retracted-URI guard (mirrors Remember): an LLM-supplied uri_hint or
 		// merge_target can point straight at a retracted node, which the vector gate
-		// won't catch if that node has no same-identity vector. UpsertNode would then
-		// overwrite a retracted mergeable row in place, or spawn a live timestamp-
-		// suffixed duplicate of retracted immutable content — resurrection by exact
-		// targeting. Skip the candidate (the similarity gate only ever redirects to
-		// LIVE nodes, so this can't be a false positive from that redirect).
+		// won't catch if that node has no same-identity vector. UpsertNode enforces
+		// this atomically too (ErrRetractedTarget), but skipping here keeps a clean
+		// per-candidate log and avoids the wasted write attempt.
 		if existing, err := db.GetNodeByURI(uri); err == nil && existing != nil && existing.IsRetracted() {
 			log.Printf("extraction: skipping %s — target URI is retracted (would resurrect)", uri)
 			continue

--- a/internal/engine/extractor.go
+++ b/internal/engine/extractor.go
@@ -18,13 +18,17 @@ import (
 const defaultSimilarityThreshold = 0.65
 
 // memoryCandidate is the JSON structure returned by the extraction LLM.
+//
+// Note: there is intentionally no merge_target field. An LLM-chosen merge URI is
+// not trusted (it was a recurring retracted-PII gate-bypass surface); dedup is
+// owned by the system via findSimilarNode. Any merge_target the LLM emits is
+// simply ignored as an unknown JSON key.
 type memoryCandidate struct {
-	Category    string `json:"category"`
-	URIHint     string `json:"uri_hint"`
-	L0          string `json:"l0"`
-	L1          string `json:"l1"`
-	L2          string `json:"l2"`
-	MergeTarget string `json:"merge_target"`
+	Category string `json:"category"`
+	URIHint  string `json:"uri_hint"`
+	L0       string `json:"l0"`
+	L1       string `json:"l1"`
+	L2       string `json:"l2"`
 }
 
 // ownerForCategory returns the URI owner for a given category.

--- a/internal/engine/extractor.go
+++ b/internal/engine/extractor.go
@@ -215,6 +215,18 @@ func extractMemories(db *store.DB, client llm.Client, embedder Embedder, session
 			}
 		}
 
+		// Exact retracted-URI guard (mirrors Remember): an LLM-supplied uri_hint or
+		// merge_target can point straight at a retracted node, which the vector gate
+		// won't catch if that node has no same-identity vector. UpsertNode would then
+		// overwrite a retracted mergeable row in place, or spawn a live timestamp-
+		// suffixed duplicate of retracted immutable content — resurrection by exact
+		// targeting. Skip the candidate (the similarity gate only ever redirects to
+		// LIVE nodes, so this can't be a false positive from that redirect).
+		if existing, err := db.GetNodeByURI(uri); err == nil && existing != nil && existing.IsRetracted() {
+			log.Printf("extraction: skipping %s — target URI is retracted (would resurrect)", uri)
+			continue
+		}
+
 		node := &store.MemNode{
 			URI:           uri,
 			NodeType:      "leaf",

--- a/internal/engine/extractor.go
+++ b/internal/engine/extractor.go
@@ -188,16 +188,24 @@ func extractMemories(db *store.DB, client llm.Client, embedder Embedder, session
 		// honored, gate on the target's REAL category (not a parsed string).
 		merged := false
 		if c.MergeTarget != "" && strings.HasPrefix(c.MergeTarget, "mem://") {
-			if target, err := db.GetNodeByURI(c.MergeTarget); err == nil && target != nil {
-				if target.IsRetracted() {
-					log.Printf("extraction: skipping %s — merge_target %s is retracted (would resurrect)", uri, c.MergeTarget)
-					continue
-				}
+			target, err := db.GetNodeByURI(c.MergeTarget)
+			switch {
+			case err != nil:
+				// Can't resolve the target => can't prove the write is safe. Fail
+				// closed (skip) rather than silently fall back to the constructed uri,
+				// which would gate on the declared category and miss a retracted node
+				// in the merge target's category.
+				log.Printf("extraction: merge_target lookup failed for %s — skipping candidate (fail-closed): %v", c.MergeTarget, err)
+				continue
+			case target == nil:
+				log.Printf("extraction: ignoring merge_target %s — no such node; using %s", c.MergeTarget, uri)
+			case target.IsRetracted():
+				log.Printf("extraction: skipping %s — merge_target %s is retracted (would resurrect)", uri, c.MergeTarget)
+				continue
+			default:
 				uri = target.URI
 				gateCat = target.Category
 				merged = true
-			} else {
-				log.Printf("extraction: ignoring merge_target %s — no such node; using %s", c.MergeTarget, uri)
 			}
 		}
 

--- a/internal/engine/extractor.go
+++ b/internal/engine/extractor.go
@@ -181,6 +181,28 @@ func extractMemories(db *store.DB, client llm.Client, embedder Embedder, session
 			uri = c.MergeTarget
 		}
 
+		// Retraction-resurrection gate (per-candidate, fail-closed): an extracted
+		// candidate that matches a retracted memory must NOT be written — otherwise
+		// retracted (e.g. PII) content silently resurfaces as a fresh live node.
+		// findSimilarNode above deliberately skips retracted nodes (so it can never
+		// merge INTO one), which is exactly why this separate gate is required to
+		// catch the create-a-new-node resurrection path. Skip only the offending
+		// candidate — one bad candidate must not drop the rest of the batch. On a
+		// gate error we also skip (fail closed) rather than write unchecked. The
+		// embedder is nil only in `none` mode (operator opted out of the gate) — the
+		// locked case is deferred upstream in extractSession, never reaching here.
+		if embedder != nil && c.L0 != "" {
+			matches, err := findRetractedMatchesIn(ctx, db, embedder, c.L0, c.Category, MatchThreshold(embedder))
+			if err != nil {
+				log.Printf("extraction: retracted-check failed for %s — skipping candidate (fail-closed): %v", uri, err)
+				continue
+			}
+			if len(matches) > 0 {
+				log.Printf("extraction: skipping %s — matches %d retracted node(s) hash=%s", uri, len(matches), hashMatchedURIs(matches))
+				continue
+			}
+		}
+
 		// Similarity gate: check if a semantically equivalent node already exists
 		if embedder != nil && c.Category != "" {
 			match, sim, err := findSimilarNode(ctx, db, embedder, c.L0, c.Category, MatchThreshold(embedder))

--- a/internal/engine/extractor.go
+++ b/internal/engine/extractor.go
@@ -41,21 +41,6 @@ func ownerForCategory(category string) string {
 	}
 }
 
-// categoryFromURI extracts the category segment from a mem:// URI of the form
-// mem://<owner>/<category>/<slug>. Returns "" if the URI is not in that shape, so
-// callers can fall back to a known category rather than gating on an empty one.
-func categoryFromURI(uri string) string {
-	rest := strings.TrimPrefix(uri, "mem://")
-	if rest == uri {
-		return ""
-	}
-	parts := strings.Split(rest, "/")
-	if len(parts) < 3 {
-		return ""
-	}
-	return parts[1]
-}
-
 // validCategories defines the allowed memory categories.
 var validCategories = map[string]bool{
 	"profile": true, "preferences": true, "entities": true,
@@ -190,14 +175,37 @@ func extractMemories(db *store.DB, client llm.Client, embedder Embedder, session
 
 		owner := ownerForCategory(c.Category)
 		uri := fmt.Sprintf("mem://%s/%s/%s", owner, c.Category, c.URIHint)
+		gateCat := c.Category // category the content will actually land in
 
-		// If merge_target is specified and valid, use it
+		// Honor merge_target ONLY if it RESOLVES to an existing node — its sole
+		// purpose is to merge into one. A raw LLM string is never trusted as a URI:
+		// a malformed/variant form (casing, ?query, #frag, trailing /) or a
+		// hallucinated target won't resolve, so we ignore it and fall back to the
+		// canonical constructed uri. This is what makes the gate robust — the write
+		// target is always a canonical URI, never an attacker-shaped string that
+		// dodges category derivation or the exact-URI lookup. If it resolves to a
+		// RETRACTED node, merging would resurrect it: skip the candidate. When
+		// honored, gate on the target's REAL category (not a parsed string).
+		merged := false
 		if c.MergeTarget != "" && strings.HasPrefix(c.MergeTarget, "mem://") {
-			uri = c.MergeTarget
+			if target, err := db.GetNodeByURI(c.MergeTarget); err == nil && target != nil {
+				if target.IsRetracted() {
+					log.Printf("extraction: skipping %s — merge_target %s is retracted (would resurrect)", uri, c.MergeTarget)
+					continue
+				}
+				uri = target.URI
+				gateCat = target.Category
+				merged = true
+			} else {
+				log.Printf("extraction: ignoring merge_target %s — no such node; using %s", c.MergeTarget, uri)
+			}
 		}
 
-		// Similarity gate: check if a semantically equivalent node already exists
-		if embedder != nil && c.Category != "" {
+		// Similarity gate: check if a semantically equivalent LIVE node already
+		// exists in the declared category. Skipped when an explicit merge_target was
+		// honored (an explicit instruction wins over the heuristic). The redirect
+		// only ever targets a live node in c.Category, so gateCat is unchanged.
+		if !merged && embedder != nil && c.Category != "" {
 			match, sim, err := findSimilarNode(ctx, db, embedder, c.L0, c.Category, MatchThreshold(embedder))
 			if err != nil {
 				log.Printf("extraction: similarity check failed: %v", err)
@@ -213,19 +221,14 @@ func extractMemories(db *store.DB, client llm.Client, embedder Embedder, session
 		// (e.g. PII) content silently resurfaces as a fresh live node. findSimilarNode
 		// deliberately skips retracted nodes (so it can't merge INTO one), which is
 		// why this separate semantic gate is required to catch the create-a-new-node
-		// path. It runs AFTER URI resolution and keys on the category the content
-		// actually lands in (categoryFromURI of the resolved uri, not the candidate's
-		// declared category): a cross-category merge_target must be checked against
-		// retracted nodes of the TARGET category, or the gate checks the wrong space.
+		// path. It keys on gateCat — the category the content actually lands in (the
+		// merge target's real category for an honored merge, else the declared one) —
+		// so a cross-category merge can't be checked against the wrong vector space.
 		// Skip only the offending candidate — one bad candidate must not drop the
 		// rest of the batch; on a gate error we also skip (fail closed). The embedder
 		// is nil only in `none` mode (gate opted out); the locked case is deferred
 		// upstream in extractSession.
 		if embedder != nil && c.L0 != "" {
-			gateCat := categoryFromURI(uri)
-			if gateCat == "" {
-				gateCat = c.Category
-			}
 			matches, err := findRetractedMatchesIn(ctx, db, embedder, c.L0, gateCat, MatchThreshold(embedder))
 			if err != nil {
 				log.Printf("extraction: retracted-check failed for %s — skipping candidate (fail-closed): %v", uri, err)
@@ -237,11 +240,10 @@ func extractMemories(db *store.DB, client llm.Client, embedder Embedder, session
 			}
 		}
 
-		// Exact retracted-URI guard (mirrors Remember): an LLM-supplied uri_hint or
-		// merge_target can point straight at a retracted node, which the vector gate
-		// won't catch if that node has no same-identity vector. UpsertNode enforces
-		// this atomically too (ErrRetractedTarget), but skipping here keeps a clean
-		// per-candidate log and avoids the wasted write attempt.
+		// Exact retracted-URI guard (mirrors Remember): the constructed uri_hint can
+		// still collide with a retracted canonical node that has no same-identity
+		// vector. UpsertNode enforces this atomically too (ErrRetractedTarget), but
+		// skipping here keeps a clean per-candidate log and avoids a wasted write.
 		if existing, err := db.GetNodeByURI(uri); err == nil && existing != nil && existing.IsRetracted() {
 			log.Printf("extraction: skipping %s — target URI is retracted (would resurrect)", uri)
 			continue

--- a/internal/engine/extractor.go
+++ b/internal/engine/extractor.go
@@ -202,6 +202,14 @@ func extractMemories(db *store.DB, client llm.Client, embedder Embedder, session
 			case target.IsRetracted():
 				log.Printf("extraction: skipping %s — merge_target %s is retracted (would resurrect)", uri, c.MergeTarget)
 				continue
+			case !target.Mergeable:
+				// Merge-into only happens for mergeable targets; for an immutable
+				// target UpsertNode IGNORES the merge and creates a new suffixed leaf
+				// carrying the CANDIDATE's category — so gating on target.Category
+				// would check the wrong space. Ignore the merge_target and fall back
+				// to the constructed uri + declared category, which is exactly where
+				// the content will actually land.
+				log.Printf("extraction: ignoring merge_target %s — target is immutable (not a merge); using %s", c.MergeTarget, uri)
 			default:
 				uri = target.URI
 				gateCat = target.Category

--- a/internal/engine/extractor.go
+++ b/internal/engine/extractor.go
@@ -175,53 +175,19 @@ func extractMemories(db *store.DB, client llm.Client, embedder Embedder, session
 
 		owner := ownerForCategory(c.Category)
 		uri := fmt.Sprintf("mem://%s/%s/%s", owner, c.Category, c.URIHint)
-		gateCat := c.Category // category the content will actually land in
 
-		// Honor merge_target ONLY if it RESOLVES to an existing node — its sole
-		// purpose is to merge into one. A raw LLM string is never trusted as a URI:
-		// a malformed/variant form (casing, ?query, #frag, trailing /) or a
-		// hallucinated target won't resolve, so we ignore it and fall back to the
-		// canonical constructed uri. This is what makes the gate robust — the write
-		// target is always a canonical URI, never an attacker-shaped string that
-		// dodges category derivation or the exact-URI lookup. If it resolves to a
-		// RETRACTED node, merging would resurrect it: skip the candidate. When
-		// honored, gate on the target's REAL category (not a parsed string).
-		merged := false
-		if c.MergeTarget != "" && strings.HasPrefix(c.MergeTarget, "mem://") {
-			target, err := db.GetNodeByURI(c.MergeTarget)
-			switch {
-			case err != nil:
-				// Can't resolve the target => can't prove the write is safe. Fail
-				// closed (skip) rather than silently fall back to the constructed uri,
-				// which would gate on the declared category and miss a retracted node
-				// in the merge target's category.
-				log.Printf("extraction: merge_target lookup failed for %s — skipping candidate (fail-closed): %v", c.MergeTarget, err)
-				continue
-			case target == nil:
-				log.Printf("extraction: ignoring merge_target %s — no such node; using %s", c.MergeTarget, uri)
-			case target.IsRetracted():
-				log.Printf("extraction: skipping %s — merge_target %s is retracted (would resurrect)", uri, c.MergeTarget)
-				continue
-			case !target.Mergeable:
-				// Merge-into only happens for mergeable targets; for an immutable
-				// target UpsertNode IGNORES the merge and creates a new suffixed leaf
-				// carrying the CANDIDATE's category — so gating on target.Category
-				// would check the wrong space. Ignore the merge_target and fall back
-				// to the constructed uri + declared category, which is exactly where
-				// the content will actually land.
-				log.Printf("extraction: ignoring merge_target %s — target is immutable (not a merge); using %s", c.MergeTarget, uri)
-			default:
-				uri = target.URI
-				gateCat = target.Category
-				merged = true
-			}
-		}
+		// An LLM-supplied merge_target is intentionally NOT honored. Dedup is owned
+		// by the system via findSimilarNode (embedding similarity) below — a path the
+		// gate can reason about — so trusting an LLM-chosen URI was pure redundancy
+		// that kept opening retracted-PII gate bypasses (content landing in a
+		// category/URI the gate hadn't checked). Ignoring it shrinks the trusted
+		// input to zero LLM-controlled URIs: a candidate always lands in its own
+		// declared category, so the gate simply keys on c.Category.
 
-		// Similarity gate: check if a semantically equivalent LIVE node already
-		// exists in the declared category. Skipped when an explicit merge_target was
-		// honored (an explicit instruction wins over the heuristic). The redirect
-		// only ever targets a live node in c.Category, so gateCat is unchanged.
-		if !merged && embedder != nil && c.Category != "" {
+		// Similarity gate: redirect to a semantically equivalent LIVE node in the
+		// same category if one exists (findSimilarNode skips retracted nodes, so it
+		// can never merge INTO a tombstone).
+		if embedder != nil && c.Category != "" {
 			match, sim, err := findSimilarNode(ctx, db, embedder, c.L0, c.Category, MatchThreshold(embedder))
 			if err != nil {
 				log.Printf("extraction: similarity check failed: %v", err)
@@ -237,15 +203,13 @@ func extractMemories(db *store.DB, client llm.Client, embedder Embedder, session
 		// (e.g. PII) content silently resurfaces as a fresh live node. findSimilarNode
 		// deliberately skips retracted nodes (so it can't merge INTO one), which is
 		// why this separate semantic gate is required to catch the create-a-new-node
-		// path. It keys on gateCat — the category the content actually lands in (the
-		// merge target's real category for an honored merge, else the declared one) —
-		// so a cross-category merge can't be checked against the wrong vector space.
-		// Skip only the offending candidate — one bad candidate must not drop the
-		// rest of the batch; on a gate error we also skip (fail closed). The embedder
-		// is nil only in `none` mode (gate opted out); the locked case is deferred
-		// upstream in extractSession.
+		// path. The candidate always lands in its declared category, so the gate keys
+		// on c.Category. Skip only the offending candidate — one bad candidate must
+		// not drop the rest of the batch; on a gate error we also skip (fail closed).
+		// The embedder is nil only in `none` mode (gate opted out); the locked case is
+		// deferred upstream in extractSession.
 		if embedder != nil && c.L0 != "" {
-			matches, err := findRetractedMatchesIn(ctx, db, embedder, c.L0, gateCat, MatchThreshold(embedder))
+			matches, err := findRetractedMatchesIn(ctx, db, embedder, c.L0, c.Category, MatchThreshold(embedder))
 			if err != nil {
 				log.Printf("extraction: retracted-check failed for %s — skipping candidate (fail-closed): %v", uri, err)
 				continue

--- a/internal/engine/gate_coverage_test.go
+++ b/internal/engine/gate_coverage_test.go
@@ -134,119 +134,37 @@ func TestSignal_SkipsExactRetractedURICollision(t *testing.T) {
 	assertNoResurrection(t, db, uri, before)
 }
 
-// TestExtraction_GatesEffectiveCategoryOnCrossCategoryMergeTarget pins the
-// merge_target category-mismatch fix: a candidate declared in one category but
-// merge_target'd into a LIVE node of another category must be gated against
-// retracted nodes of the TARGET category. Otherwise content matching a retracted
-// preference, smuggled in as an "events" candidate merged onto a live preference,
-// would overwrite that live node — a semantic resurrection bypass.
-func TestExtraction_GatesEffectiveCategoryOnCrossCategoryMergeTarget(t *testing.T) {
+// TestExtraction_IgnoresMergeTarget pins that an LLM-supplied merge_target is NOT
+// honored: dedup is owned by the system (findSimilarNode), and trusting an
+// LLM-chosen URI was a recurring retracted-PII gate-bypass surface. A candidate's
+// content lands at its own constructed canonical URI in its declared category —
+// never redirected to the merge_target — so the gate always keys on the category
+// the content actually lands in.
+func TestExtraction_IgnoresMergeTarget(t *testing.T) {
 	db := testDB(t)
 	emb, _ := NewHashEmbedder(0)
 
-	// Retracted PREFERENCE carrying the sensitive content.
-	const secret = "social security number nine eight seven six five four"
-	seedRetracted(t, db, emb, "mem://user/preferences/old-secret", "preferences", secret)
-
-	// A LIVE preference the candidate will try to merge onto.
+	// A live node in another category the candidate will (vainly) try to merge onto.
 	live := &store.MemNode{URI: "mem://user/preferences/live-pref", NodeType: "leaf", Category: "preferences",
 		L0Abstract: "favorite editor is vim", L1Overview: "Body content with enough length to pass validation thresholds easily."}
 	if err := db.CreateNode(live); err != nil {
 		t.Fatal(err)
 	}
 
-	// Candidate declares category "events" (no retracted events exist) but
-	// merge_targets the live preference, with L0 == the retracted preference's PII.
-	resp := `[{"category":"events","uri_hint":"innocuous","merge_target":"mem://user/preferences/live-pref","l0":"social security number nine eight seven six five four","l1":"Body content with enough length to pass validation thresholds easily."}]`
+	resp := `[{"category":"events","uri_hint":"deploy-note","merge_target":"mem://user/preferences/live-pref","l0":"deployed the release on friday afternoon","l1":"Body content with enough length to pass validation thresholds easily."}]`
 	mock := &llm.MockClient{Response: &llm.Response{Content: resp, Provider: "mock"}}
 
 	if err := extractMemories(db, mock, emb, "sess", makeTranscript(t)); err != nil {
 		t.Fatalf("extractMemories: %v", err)
 	}
 
-	got, _ := db.GetNodeByURI("mem://user/preferences/live-pref")
-	if got == nil || got.L0Abstract != "favorite editor is vim" {
-		t.Errorf("cross-category merge_target resurrected retracted PII into the live preference: L0=%q", func() string {
-			if got == nil {
-				return "(nil)"
-			}
-			return got.L0Abstract
-		}())
+	// The merge_target node is untouched...
+	if got, _ := db.GetNodeByURI("mem://user/preferences/live-pref"); got == nil || got.L0Abstract != "favorite editor is vim" {
+		t.Error("merge_target node was modified despite merge_target being ignored")
 	}
-}
-
-// TestExtraction_IgnoresUnresolvableMergeTarget pins the round-3 root fix: a raw
-// LLM merge_target is never trusted as a URI. A variant string (here a ?query
-// suffix; casing/#frag/trailing-slash behave the same) that doesn't resolve to a
-// real node must be IGNORED — the write falls back to the canonical constructed
-// uri, where the exact-URI guard then catches the retracted collision. Pre-fix the
-// variant was written verbatim, spawning a live node that dodged both the category
-// gate and the canonical exact-URI guard.
-func TestExtraction_IgnoresUnresolvableMergeTarget(t *testing.T) {
-	db := testDB(t)
-	emb, _ := NewHashEmbedder(0)
-
-	// Retracted MERGEABLE node with NO vector (so only the exact-URI guard can
-	// catch it — the vector gate is blind here, matching Codex's scenario).
-	const canonical = "mem://user/preferences/legacy-pref"
-	n := &store.MemNode{URI: canonical, NodeType: "leaf", Category: "preferences",
-		L0Abstract: "original retracted content", L1Overview: "Body content with enough length to pass validation thresholds easily."}
-	if err := db.CreateNode(n); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := db.RetractNode(canonical, "forget this", ""); err != nil {
-		t.Fatal(err)
-	}
-	before := snapshotNode(t, db, canonical)
-
-	const variant = canonical + "?bypass=1"
-	resp := `[{"category":"preferences","uri_hint":"legacy-pref","merge_target":"` + variant + `","l0":"RESURRECTED content","l1":"Body content with enough length to pass validation thresholds easily."}]`
-	mock := &llm.MockClient{Response: &llm.Response{Content: resp, Provider: "mock"}}
-
-	if err := extractMemories(db, mock, emb, "sess", makeTranscript(t)); err != nil {
-		t.Fatalf("extractMemories: %v", err)
-	}
-
-	if got, _ := db.GetNodeByURI(variant); got != nil {
-		t.Errorf("variant merge_target was written verbatim, spawning a live node: %s", variant)
-	}
-	// The canonical retracted node must be byte-for-byte intact (exact-URI guard).
-	assertNoResurrection(t, db, canonical, before)
-}
-
-// TestExtraction_IgnoresImmutableMergeTarget pins the round-5 fix: merge_target
-// is honored only for MERGEABLE targets. UpsertNode never merges into an immutable
-// node (it creates a suffixed leaf with the candidate's category), so gating on an
-// immutable target's category would check the wrong space. The merge_target must
-// be ignored, falling back to the candidate's category — where the gate then
-// catches a same-category retracted match.
-func TestExtraction_IgnoresImmutableMergeTarget(t *testing.T) {
-	db := testDB(t)
-	emb, _ := NewHashEmbedder(0)
-
-	// Retracted PREFERENCE (mergeable category) with a vector.
-	const pii = "secret pii content nine eight seven six"
-	seedRetracted(t, db, emb, "mem://user/preferences/old-secret", "preferences", pii)
-
-	// A LIVE IMMUTABLE events node to (ab)use as a merge_target.
-	ev := &store.MemNode{URI: "mem://user/events/some-event", NodeType: "leaf", Category: "events",
-		L0Abstract: "deployed on friday", L1Overview: "Body content with enough length to pass validation thresholds easily."}
-	if err := db.CreateNode(ev); err != nil {
-		t.Fatal(err)
-	}
-
-	// Candidate is a preferences write reproducing the retracted PII, but points
-	// merge_target at the immutable events node to dodge the preferences gate.
-	resp := `[{"category":"preferences","uri_hint":"new-pref","merge_target":"mem://user/events/some-event","l0":"secret pii content nine eight seven six","l1":"Body content with enough length to pass validation thresholds easily."}]`
-	mock := &llm.MockClient{Response: &llm.Response{Content: resp, Provider: "mock"}}
-
-	if err := extractMemories(db, mock, emb, "sess", makeTranscript(t)); err != nil {
-		t.Fatalf("extractMemories: %v", err)
-	}
-
-	// Gate ran on preferences (the real landing category) and skipped — no live node.
-	if n, _ := db.GetNodeByURI("mem://user/preferences/new-pref"); n != nil {
-		t.Errorf("immutable merge_target let a preferences candidate dodge the gate: %+v", n)
+	// ...and the candidate landed at its own constructed canonical URI.
+	if got, _ := db.GetNodeByURI("mem://user/events/deploy-note"); got == nil {
+		t.Error("candidate did not land at its constructed canonical URI; merge_target must be ignored, not redirected")
 	}
 }
 

--- a/internal/engine/gate_coverage_test.go
+++ b/internal/engine/gate_coverage_test.go
@@ -1,0 +1,190 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/lazypower/continuity/internal/llm"
+	"github.com/lazypower/continuity/internal/store"
+)
+
+// seedRetracted creates a leaf, embeds it under emb, stores the vector, and
+// retracts it — so it participates in the retraction-resurrection gate.
+func seedRetracted(t *testing.T, db *store.DB, emb Embedder, uri, category, l0 string) {
+	t.Helper()
+	n := &store.MemNode{URI: uri, NodeType: "leaf", Category: category, L0Abstract: l0,
+		L1Overview: "Body content with enough length to pass validation thresholds easily."}
+	if err := db.CreateNode(n); err != nil {
+		t.Fatalf("CreateNode %s: %v", uri, err)
+	}
+	got, err := db.GetNodeByURI(uri)
+	if err != nil || got == nil {
+		t.Fatalf("GetNodeByURI %s: %v", uri, err)
+	}
+	vec, err := emb.Embed(context.Background(), l0)
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if err := db.SaveVector(got.ID, vec, emb.Model()); err != nil {
+		t.Fatalf("SaveVector: %v", err)
+	}
+	if _, err := db.RetractNode(uri, "PII captured by accident", ""); err != nil {
+		t.Fatalf("RetractNode: %v", err)
+	}
+}
+
+// erroringEmbedder fails on Embed — used to exercise the fail-closed-on-error path.
+type erroringEmbedder struct{}
+
+func (erroringEmbedder) Embed(context.Context, string) ([]float64, error) {
+	return nil, fmt.Errorf("embed boom")
+}
+func (erroringEmbedder) Model() string   { return "errmb" }
+func (erroringEmbedder) Dimensions() int { return 8 }
+
+// TestExtraction_SkipsRetractedMatch_KeepsRest pins finding #1 + the per-candidate
+// rule: an extracted candidate matching a retracted memory must be dropped (no new
+// live node), while OTHER candidates in the same batch are still written. The
+// pre-existing path only ran findSimilarNode (which skips retracted nodes), so the
+// resurrected content was written as a brand-new node.
+func TestExtraction_SkipsRetractedMatch_KeepsRest(t *testing.T) {
+	db := testDB(t)
+	emb, _ := NewHashEmbedder(0)
+
+	const pii = "operator home address one two three main street"
+	seedRetracted(t, db, emb, "mem://agent/patterns/old-pii", "patterns", pii)
+
+	// Candidate A reproduces the retracted PII (must be skipped); candidate B is
+	// unrelated (must be written).
+	resp := `[
+		{"category":"patterns","uri_hint":"resurrect-attempt","l0":"operator home address one two three main street","l1":"Body content with enough length to pass validation thresholds easily."},
+		{"category":"patterns","uri_hint":"unrelated-note","l0":"golang cobra cli flag parsing helpers","l1":"Body content with enough length to pass validation thresholds easily."}
+	]`
+	mock := &llm.MockClient{Response: &llm.Response{Content: resp, Provider: "mock"}}
+
+	if err := extractMemories(db, mock, emb, "sess-extract", makeTranscript(t)); err != nil {
+		t.Fatalf("extractMemories: %v", err)
+	}
+
+	if n, _ := db.GetNodeByURI("mem://agent/patterns/resurrect-attempt"); n != nil {
+		t.Errorf("resurrection: extraction wrote a live node reproducing retracted PII: %+v", n)
+	}
+	if n, _ := db.GetNodeByURI("mem://agent/patterns/unrelated-note"); n == nil {
+		t.Error("per-candidate rule violated: the unrelated candidate was dropped along with the bad one")
+	}
+}
+
+// TestExtraction_DeferredWhenLocked pins finding #2: while the vector identity is
+// locked the gate cannot run, so extraction must write NOTHING (fail closed) and
+// must not mark the session extracted. Proven non-vacuous by showing the same
+// candidate IS written once the lock clears.
+func TestExtraction_DeferredWhenLocked(t *testing.T) {
+	db := testDB(t)
+	emb, _ := NewHashEmbedder(0)
+	mock := &llm.MockClient{Response: &llm.Response{Content: `[
+		{"category":"patterns","uri_hint":"locked-note","l0":"some freshly extracted pattern worth keeping","l1":"Body content with enough length to pass validation thresholds easily."}
+	]`, Provider: "mock"}}
+
+	eng := New(db, mock)
+	eng.SetEmbedder(emb)
+	eng.identityMismatch = true // locked
+
+	path := makeTranscript(t)
+	if err := eng.ExtractSessionForce("sess-locked", path); err != nil {
+		t.Fatalf("ExtractSessionForce (locked): %v", err)
+	}
+	if n, _ := db.GetNodeByURI("mem://agent/patterns/locked-note"); n != nil {
+		t.Fatalf("locked extraction wrote a node without running the gate: %+v", n)
+	}
+
+	// Clear the lock — the same candidate must now be written, proving the lock is
+	// what suppressed it (not a content-gate or parse failure).
+	eng.identityMismatch = false
+	if err := eng.ExtractSessionForce("sess-locked", path); err != nil {
+		t.Fatalf("ExtractSessionForce (unlocked): %v", err)
+	}
+	if n, _ := db.GetNodeByURI("mem://agent/patterns/locked-note"); n == nil {
+		t.Error("candidate not written after lock cleared — test would be vacuous")
+	}
+}
+
+// TestSignal_SkipsRetractedMatch pins finding #3: the signal-keyword path must run
+// the per-candidate retraction gate too.
+func TestSignal_SkipsRetractedMatch(t *testing.T) {
+	db := testDB(t)
+	emb, _ := NewHashEmbedder(0)
+
+	const pii = "user social security number nine eight seven six five"
+	seedRetracted(t, db, emb, "mem://user/events/old-ssn", "events", pii)
+
+	mock := &llm.MockClient{Response: &llm.Response{Content: `[
+		{"category":"events","uri_hint":"ssn-again","l0":"user social security number nine eight seven six five","l1":"Body content with enough length to pass validation thresholds easily."},
+		{"category":"events","uri_hint":"benign-event","l0":"deployed the release on a friday afternoon","l1":"Body content with enough length to pass validation thresholds easily."}
+	]`, Provider: "mock"}}
+
+	eng := New(db, mock)
+	eng.SetEmbedder(emb)
+
+	if err := eng.ExtractSignal(context.Background(), "sess-signal", "remember this"); err != nil {
+		t.Fatalf("ExtractSignal: %v", err)
+	}
+	if n, _ := db.GetNodeByURI("mem://user/events/ssn-again"); n != nil {
+		t.Errorf("resurrection: signal wrote a live node reproducing retracted PII: %+v", n)
+	}
+	if n, _ := db.GetNodeByURI("mem://user/events/benign-event"); n == nil {
+		t.Error("per-candidate rule violated: benign signal candidate was dropped")
+	}
+}
+
+// TestSignal_DeferredWhenLocked pins finding #2 for the signal path.
+func TestSignal_DeferredWhenLocked(t *testing.T) {
+	db := testDB(t)
+	emb, _ := NewHashEmbedder(0)
+	mock := &llm.MockClient{Response: &llm.Response{Content: `[
+		{"category":"events","uri_hint":"locked-signal","l0":"a signal the user explicitly flagged","l1":"Body content with enough length to pass validation thresholds easily."}
+	]`, Provider: "mock"}}
+
+	eng := New(db, mock)
+	eng.SetEmbedder(emb)
+	eng.identityMismatch = true // locked
+
+	if err := eng.ExtractSignal(context.Background(), "sess", "remember this"); err != nil {
+		t.Fatalf("ExtractSignal (locked): %v", err)
+	}
+	if n, _ := db.GetNodeByURI("mem://user/events/locked-signal"); n != nil {
+		t.Fatalf("locked signal wrote a node without running the gate: %+v", n)
+	}
+}
+
+// TestRemember_FailsClosedOnGateError pins finding #5: if the retraction gate
+// cannot complete (embedding error), Remember must REFUSE the write rather than
+// proceed — and --acknowledge-retracted must still bypass it.
+func TestRemember_FailsClosedOnGateError(t *testing.T) {
+	db := testDB(t)
+	eng := New(db, &llm.MockClient{Response: &llm.Response{Content: "[]"}})
+	eng.SetEmbedder(erroringEmbedder{})
+
+	const body = "a sufficiently long overview body for validation"
+	_, _, err := eng.Remember(context.Background(), RememberInput{
+		Category: "patterns", Name: "alpha", Summary: "some candidate text", Body: body,
+	})
+	if err == nil {
+		t.Fatal("gate error must fail closed (refuse the write), got nil error")
+	}
+	if !strings.Contains(err.Error(), "failing closed") {
+		t.Errorf("expected a fail-closed error, got: %v", err)
+	}
+
+	// --acknowledge-retracted bypasses the gate entirely, so the write proceeds.
+	uri, _, err := eng.Remember(context.Background(), RememberInput{
+		Category: "patterns", Name: "beta", Summary: "some candidate text", Body: body, AcknowledgeRetracted: true,
+	})
+	if err != nil {
+		t.Fatalf("acknowledged write should bypass the gate, got: %v", err)
+	}
+	if n, _ := db.GetNodeByURI(uri); n == nil {
+		t.Error("acknowledged write was not stored")
+	}
+}

--- a/internal/engine/gate_coverage_test.go
+++ b/internal/engine/gate_coverage_test.go
@@ -214,6 +214,42 @@ func TestExtraction_IgnoresUnresolvableMergeTarget(t *testing.T) {
 	assertNoResurrection(t, db, canonical, before)
 }
 
+// TestExtraction_IgnoresImmutableMergeTarget pins the round-5 fix: merge_target
+// is honored only for MERGEABLE targets. UpsertNode never merges into an immutable
+// node (it creates a suffixed leaf with the candidate's category), so gating on an
+// immutable target's category would check the wrong space. The merge_target must
+// be ignored, falling back to the candidate's category — where the gate then
+// catches a same-category retracted match.
+func TestExtraction_IgnoresImmutableMergeTarget(t *testing.T) {
+	db := testDB(t)
+	emb, _ := NewHashEmbedder(0)
+
+	// Retracted PREFERENCE (mergeable category) with a vector.
+	const pii = "secret pii content nine eight seven six"
+	seedRetracted(t, db, emb, "mem://user/preferences/old-secret", "preferences", pii)
+
+	// A LIVE IMMUTABLE events node to (ab)use as a merge_target.
+	ev := &store.MemNode{URI: "mem://user/events/some-event", NodeType: "leaf", Category: "events",
+		L0Abstract: "deployed on friday", L1Overview: "Body content with enough length to pass validation thresholds easily."}
+	if err := db.CreateNode(ev); err != nil {
+		t.Fatal(err)
+	}
+
+	// Candidate is a preferences write reproducing the retracted PII, but points
+	// merge_target at the immutable events node to dodge the preferences gate.
+	resp := `[{"category":"preferences","uri_hint":"new-pref","merge_target":"mem://user/events/some-event","l0":"secret pii content nine eight seven six","l1":"Body content with enough length to pass validation thresholds easily."}]`
+	mock := &llm.MockClient{Response: &llm.Response{Content: resp, Provider: "mock"}}
+
+	if err := extractMemories(db, mock, emb, "sess", makeTranscript(t)); err != nil {
+		t.Fatalf("extractMemories: %v", err)
+	}
+
+	// Gate ran on preferences (the real landing category) and skipped — no live node.
+	if n, _ := db.GetNodeByURI("mem://user/preferences/new-pref"); n != nil {
+		t.Errorf("immutable merge_target let a preferences candidate dodge the gate: %+v", n)
+	}
+}
+
 // TestExtraction_DeferredWhenLocked pins finding #2: while the vector identity is
 // locked the gate cannot run, so extraction must write NOTHING (fail closed) and
 // must not mark the session extracted. Proven non-vacuous by showing the same

--- a/internal/engine/gate_coverage_test.go
+++ b/internal/engine/gate_coverage_test.go
@@ -134,6 +134,47 @@ func TestSignal_SkipsExactRetractedURICollision(t *testing.T) {
 	assertNoResurrection(t, db, uri, before)
 }
 
+// TestExtraction_GatesEffectiveCategoryOnCrossCategoryMergeTarget pins the
+// merge_target category-mismatch fix: a candidate declared in one category but
+// merge_target'd into a LIVE node of another category must be gated against
+// retracted nodes of the TARGET category. Otherwise content matching a retracted
+// preference, smuggled in as an "events" candidate merged onto a live preference,
+// would overwrite that live node — a semantic resurrection bypass.
+func TestExtraction_GatesEffectiveCategoryOnCrossCategoryMergeTarget(t *testing.T) {
+	db := testDB(t)
+	emb, _ := NewHashEmbedder(0)
+
+	// Retracted PREFERENCE carrying the sensitive content.
+	const secret = "social security number nine eight seven six five four"
+	seedRetracted(t, db, emb, "mem://user/preferences/old-secret", "preferences", secret)
+
+	// A LIVE preference the candidate will try to merge onto.
+	live := &store.MemNode{URI: "mem://user/preferences/live-pref", NodeType: "leaf", Category: "preferences",
+		L0Abstract: "favorite editor is vim", L1Overview: "Body content with enough length to pass validation thresholds easily."}
+	if err := db.CreateNode(live); err != nil {
+		t.Fatal(err)
+	}
+
+	// Candidate declares category "events" (no retracted events exist) but
+	// merge_targets the live preference, with L0 == the retracted preference's PII.
+	resp := `[{"category":"events","uri_hint":"innocuous","merge_target":"mem://user/preferences/live-pref","l0":"social security number nine eight seven six five four","l1":"Body content with enough length to pass validation thresholds easily."}]`
+	mock := &llm.MockClient{Response: &llm.Response{Content: resp, Provider: "mock"}}
+
+	if err := extractMemories(db, mock, emb, "sess", makeTranscript(t)); err != nil {
+		t.Fatalf("extractMemories: %v", err)
+	}
+
+	got, _ := db.GetNodeByURI("mem://user/preferences/live-pref")
+	if got == nil || got.L0Abstract != "favorite editor is vim" {
+		t.Errorf("cross-category merge_target resurrected retracted PII into the live preference: L0=%q", func() string {
+			if got == nil {
+				return "(nil)"
+			}
+			return got.L0Abstract
+		}())
+	}
+}
+
 // TestExtraction_DeferredWhenLocked pins finding #2: while the vector identity is
 // locked the gate cannot run, so extraction must write NOTHING (fail closed) and
 // must not mark the session extracted. Proven non-vacuous by showing the same

--- a/internal/engine/gate_coverage_test.go
+++ b/internal/engine/gate_coverage_test.go
@@ -76,6 +76,64 @@ func TestExtraction_SkipsRetractedMatch_KeepsRest(t *testing.T) {
 	}
 }
 
+// TestExtraction_SkipsExactRetractedURICollision pins the exact-URI guard: an
+// LLM uri_hint that resolves to a retracted MERGEABLE node, with DIFFERENT content
+// (so the vector gate can't catch it), must not overwrite the retracted row in
+// place. No vector is stored, modelling the "no same-identity vector" case.
+func TestExtraction_SkipsExactRetractedURICollision(t *testing.T) {
+	db := testDB(t)
+	emb, _ := NewHashEmbedder(0)
+
+	const uri = "mem://user/preferences/legacy-pref"
+	n := &store.MemNode{URI: uri, NodeType: "leaf", Category: "preferences",
+		L0Abstract: "original retracted preference content",
+		L1Overview: "Body content with enough length to pass validation thresholds easily."}
+	if err := db.CreateNode(n); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.RetractNode(uri, "user asked to forget this", ""); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotNode(t, db, uri)
+
+	resp := `[{"category":"preferences","uri_hint":"legacy-pref","l0":"totally different unrelated wording here","l1":"Body content with enough length to pass validation thresholds easily."}]`
+	mock := &llm.MockClient{Response: &llm.Response{Content: resp, Provider: "mock"}}
+
+	if err := extractMemories(db, mock, emb, "sess", makeTranscript(t)); err != nil {
+		t.Fatalf("extractMemories: %v", err)
+	}
+	// Full-row equality — the retracted mergeable node must be byte-for-byte intact.
+	assertNoResurrection(t, db, uri, before)
+}
+
+// TestSignal_SkipsExactRetractedURICollision is the signal-path equivalent.
+func TestSignal_SkipsExactRetractedURICollision(t *testing.T) {
+	db := testDB(t)
+	emb, _ := NewHashEmbedder(0)
+
+	const uri = "mem://user/preferences/legacy-pref"
+	n := &store.MemNode{URI: uri, NodeType: "leaf", Category: "preferences",
+		L0Abstract: "original retracted preference content",
+		L1Overview: "Body content with enough length to pass validation thresholds easily."}
+	if err := db.CreateNode(n); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.RetractNode(uri, "user asked to forget this", ""); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotNode(t, db, uri)
+
+	resp := `[{"category":"preferences","uri_hint":"legacy-pref","l0":"totally different unrelated wording here","l1":"Body content with enough length to pass validation thresholds easily."}]`
+	mock := &llm.MockClient{Response: &llm.Response{Content: resp, Provider: "mock"}}
+
+	eng := New(db, mock)
+	eng.SetEmbedder(emb)
+	if err := eng.ExtractSignal(context.Background(), "sess", "remember this"); err != nil {
+		t.Fatalf("ExtractSignal: %v", err)
+	}
+	assertNoResurrection(t, db, uri, before)
+}
+
 // TestExtraction_DeferredWhenLocked pins finding #2: while the vector identity is
 // locked the gate cannot run, so extraction must write NOTHING (fail closed) and
 // must not mark the session extracted. Proven non-vacuous by showing the same

--- a/internal/engine/gate_coverage_test.go
+++ b/internal/engine/gate_coverage_test.go
@@ -175,6 +175,45 @@ func TestExtraction_GatesEffectiveCategoryOnCrossCategoryMergeTarget(t *testing.
 	}
 }
 
+// TestExtraction_IgnoresUnresolvableMergeTarget pins the round-3 root fix: a raw
+// LLM merge_target is never trusted as a URI. A variant string (here a ?query
+// suffix; casing/#frag/trailing-slash behave the same) that doesn't resolve to a
+// real node must be IGNORED — the write falls back to the canonical constructed
+// uri, where the exact-URI guard then catches the retracted collision. Pre-fix the
+// variant was written verbatim, spawning a live node that dodged both the category
+// gate and the canonical exact-URI guard.
+func TestExtraction_IgnoresUnresolvableMergeTarget(t *testing.T) {
+	db := testDB(t)
+	emb, _ := NewHashEmbedder(0)
+
+	// Retracted MERGEABLE node with NO vector (so only the exact-URI guard can
+	// catch it — the vector gate is blind here, matching Codex's scenario).
+	const canonical = "mem://user/preferences/legacy-pref"
+	n := &store.MemNode{URI: canonical, NodeType: "leaf", Category: "preferences",
+		L0Abstract: "original retracted content", L1Overview: "Body content with enough length to pass validation thresholds easily."}
+	if err := db.CreateNode(n); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.RetractNode(canonical, "forget this", ""); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotNode(t, db, canonical)
+
+	const variant = canonical + "?bypass=1"
+	resp := `[{"category":"preferences","uri_hint":"legacy-pref","merge_target":"` + variant + `","l0":"RESURRECTED content","l1":"Body content with enough length to pass validation thresholds easily."}]`
+	mock := &llm.MockClient{Response: &llm.Response{Content: resp, Provider: "mock"}}
+
+	if err := extractMemories(db, mock, emb, "sess", makeTranscript(t)); err != nil {
+		t.Fatalf("extractMemories: %v", err)
+	}
+
+	if got, _ := db.GetNodeByURI(variant); got != nil {
+		t.Errorf("variant merge_target was written verbatim, spawning a live node: %s", variant)
+	}
+	// The canonical retracted node must be byte-for-byte intact (exact-URI guard).
+	assertNoResurrection(t, db, canonical, before)
+}
+
 // TestExtraction_DeferredWhenLocked pins finding #2: while the vector identity is
 // locked the gate cannot run, so extraction must write NOTHING (fail closed) and
 // must not mark the session extracted. Proven non-vacuous by showing the same

--- a/internal/engine/relational.go
+++ b/internal/engine/relational.go
@@ -113,6 +113,13 @@ func extractRelational(db *store.DB, client llm.Client, sessionID, transcriptPat
 		SourceSession: sessionID,
 	}
 
+	// No retraction-resurrection gate here, by construction: relational only ever
+	// writes the single fixed relationalURI (mem://user/profile/communication),
+	// which is system-owned and un-retractable (store.systemOwnedURIs; see
+	// TestRetractNode_RefusesSystemOwnedURIs). So this write can never overwrite a
+	// tombstone — and UpsertNode now refuses retracted targets atomically anyway
+	// (ErrRetractedTarget). It also never creates arbitrary nodes, and its L0 is a
+	// constant, so there is no per-candidate content for the L0-based gate to act on.
 	if err := db.UpsertNode(profileNode); err != nil {
 		return err
 	}

--- a/internal/engine/retract.go
+++ b/internal/engine/retract.go
@@ -71,6 +71,17 @@ func hashURI(uri string) string {
 	return hex.EncodeToString(sum[:])[:16]
 }
 
+// hashMatchedURIs joins the opaque hashes of matched retracted nodes for a single
+// log line, so match events are observable without leaking the URIs (and through
+// them, the reasons) into passive log feeds. See hashURI.
+func hashMatchedURIs(nodes []store.MemNode) string {
+	hs := make([]string, len(nodes))
+	for i, n := range nodes {
+		hs[i] = hashURI(n.URI)
+	}
+	return strings.Join(hs, ",")
+}
+
 // findRetractedMatches returns retracted leaf nodes in the given category whose
 // embedding similarity to candidateText is above threshold. Returns all matches
 // (not just the best), so multi-match aggregation is possible at the caller.
@@ -84,14 +95,27 @@ func (e *Engine) findRetractedMatches(ctx context.Context, candidateText, catego
 	if e.Embedder == nil || candidateText == "" || e.identityMismatch {
 		return nil, nil
 	}
+	return findRetractedMatchesIn(ctx, e.DB, e.Embedder, candidateText, category, threshold)
+}
 
-	candidateVec, err := e.Embedder.Embed(ctx, candidateText)
+// findRetractedMatchesIn is the embedder-space comparison core of the retraction
+// gate, with no engine/lock state. Callers MUST ensure the embedder is usable
+// (non-nil and compatible with the corpus — i.e. the vector identity is not
+// locked) before calling; it compares the candidate against stored retracted
+// vectors of the same identity only. Shared by the engine method (Remember) and
+// the extraction path so both gate identically.
+func findRetractedMatchesIn(ctx context.Context, db *store.DB, embedder Embedder, candidateText, category string, threshold float64) ([]store.MemNode, error) {
+	if embedder == nil || candidateText == "" {
+		return nil, nil
+	}
+
+	candidateVec, err := embedder.Embed(ctx, candidateText)
 	if err != nil {
 		return nil, fmt.Errorf("embed candidate: %w", err)
 	}
-	activeID := EmbedderIdentity(e.Embedder)
+	activeID := EmbedderIdentity(embedder)
 
-	vectors, err := e.DB.AllVectors()
+	vectors, err := db.AllVectors()
 	if err != nil {
 		return nil, fmt.Errorf("load vectors: %w", err)
 	}
@@ -103,7 +127,7 @@ func (e *Engine) findRetractedMatches(ctx context.Context, candidateText, catego
 	for i, v := range vectors {
 		nodeIDs[i] = v.NodeID
 	}
-	nodes, err := e.DB.GetNodesByIDs(nodeIDs)
+	nodes, err := db.GetNodesByIDs(nodeIDs)
 	if err != nil {
 		return nil, fmt.Errorf("get nodes: %w", err)
 	}

--- a/internal/llm/prompts.go
+++ b/internal/llm/prompts.go
@@ -54,7 +54,6 @@ Rules:
 - l0: One sentence, MAXIMUM 200 CHARACTERS. Injected into every session — brevity is critical. Specific enough to deduplicate against.
 - l1: Structured overview, MAXIMUM 2000 CHARACTERS (~300 words). Concrete and actionable. This is the primary context injection tier — compress aggressively.
 - l2: Full content with all context, MAXIMUM 40000 CHARACTERS. Only retrieved on-demand.
-- merge_target: existing URI if this updates/refines known information
 - Return ONLY a JSON array, no other text
 
 Return a JSON array:
@@ -63,8 +62,7 @@ Return a JSON array:
   "uri_hint": "slug-name",
   "l0": "single sentence abstract",
   "l1": "structured overview (for feedback: <rule>. Why: <reason>. How to apply: <when>.)",
-  "l2": "full content",
-  "merge_target": "mem://... or empty"
+  "l2": "full content"
 }]
 
 If nothing meets the extraction bar, return: []`, InternalSentinel, condensed)
@@ -156,8 +154,7 @@ Return a JSON array:
   "uri_hint": "slug-name",
   "l0": "single sentence, max 200 chars",
   "l1": "structured overview, max 2000 chars (for feedback: <rule>. Why: <reason>. How to apply: <when>.)",
-  "l2": "full content, max 40000 chars",
-  "merge_target": "mem://... or empty"
+  "l2": "full content, max 40000 chars"
 }]`, InternalSentinel, prompt)
 }
 

--- a/internal/store/nodes.go
+++ b/internal/store/nodes.go
@@ -2,10 +2,19 @@ package store
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 )
+
+// ErrRetractedTarget is returned by UpsertNode when the target URI resolves to a
+// retracted (tombstoned) node. Upsert must never resurrect a tombstone — neither
+// by overwriting a mergeable row in place nor by spawning a live duplicate. This
+// is the atomic store-level backstop behind the callers' pre-checks: it closes
+// the check-then-write race where a concurrent retraction lands between a
+// caller's guard and the write.
+var ErrRetractedTarget = errors.New("refusing to upsert into a retracted node")
 
 // textNearIdentical returns true if two strings are >95% similar by character overlap.
 // Uses a simple normalized edit-distance-like metric: shared bigram ratio.
@@ -212,17 +221,38 @@ func (db *DB) UpsertNode(node *MemNode) error {
 		return db.CreateNode(node)
 	}
 
+	// Never resurrect a tombstone. Callers (Remember / extraction / signal)
+	// pre-check and skip, but enforce it here too so the write can't slip past a
+	// concurrent retraction.
+	if existing.IsRetracted() {
+		return ErrRetractedTarget
+	}
+
 	if existing.Mergeable {
 		// Skip if new content is near-identical to existing (avoid churn)
 		if textNearIdentical(existing.L1Overview, node.L1Overview) &&
 			textNearIdentical(existing.L0Abstract, node.L0Abstract) {
 			return nil
 		}
-		existing.L0Abstract = node.L0Abstract
-		existing.L1Overview = node.L1Overview
-		existing.L2Content = node.L2Content
-		existing.SourceSession = node.SourceSession
-		return db.UpdateNode(existing)
+		// Tombstone-guarded in-place update: if the row is retracted between the
+		// read above and this write, 0 rows change — report the refusal rather
+		// than silently overwriting (resurrecting) the tombstone. Same columns as
+		// UpdateNode, preserving merged_from.
+		now := time.Now().UnixMilli()
+		res, err := db.Exec(`
+			UPDATE mem_nodes SET l0_abstract = ?, l1_overview = ?, l2_content = ?,
+				merged_from = ?, source_session = ?, updated_at = ?
+			WHERE id = ? AND tombstoned_at IS NULL
+		`, node.L0Abstract, node.L1Overview, node.L2Content,
+			existing.MergedFrom, node.SourceSession, now, existing.ID)
+		if err != nil {
+			return fmt.Errorf("update node: %w", err)
+		}
+		if n, _ := res.RowsAffected(); n == 0 {
+			return ErrRetractedTarget // raced retraction between read and write
+		}
+		node.URI = existing.URI
+		return nil
 	}
 
 	// Immutable — create as new node with deduplicated URI

--- a/internal/store/nodes.go
+++ b/internal/store/nodes.go
@@ -255,9 +255,24 @@ func (db *DB) UpsertNode(node *MemNode) error {
 		return nil
 	}
 
-	// Immutable — create as new node with deduplicated URI
+	// Immutable — create as new node with deduplicated URI.
+	baseURI := node.URI
 	node.URI = fmt.Sprintf("%s-%d", node.URI, time.Now().UnixMilli())
-	return db.CreateNode(node)
+	if err := db.CreateNode(node); err != nil {
+		return err
+	}
+	// Close the read→insert race: an INSERT has no WHERE guard like the mergeable
+	// branch, so if the base node was retracted between the IsRetracted() check
+	// above and this insert, the suffixed node would resurrect just-retracted
+	// content. Re-check and compensate (delete + fail closed). The suffixed node is
+	// only ever visible after UpsertNode returns, so this transient insert is safe.
+	if base, err := db.GetNodeByURI(baseURI); err == nil && base != nil && base.IsRetracted() {
+		if delErr := db.DeleteNode(node.ID); delErr != nil {
+			return fmt.Errorf("rollback suffixed resurrection of %s: %w", baseURI, delErr)
+		}
+		return ErrRetractedTarget
+	}
+	return nil
 }
 
 // FindByCategory returns live leaf nodes for a given category, ordered by relevance DESC.

--- a/internal/store/nodes.go
+++ b/internal/store/nodes.go
@@ -266,9 +266,15 @@ func (db *DB) UpsertNode(node *MemNode) error {
 	// above and this insert, the suffixed node would resurrect just-retracted
 	// content. Re-check and compensate (delete + fail closed). The suffixed node is
 	// only ever visible after UpsertNode returns, so this transient insert is safe.
-	if base, err := db.GetNodeByURI(baseURI); err == nil && base != nil && base.IsRetracted() {
+	base, rerr := db.GetNodeByURI(baseURI)
+	if rerr != nil || (base != nil && base.IsRetracted()) {
+		// Either the base is retracted, OR we can't prove it isn't (re-read failed).
+		// Both fail closed: undo the insert so no unproven live node survives.
 		if delErr := db.DeleteNode(node.ID); delErr != nil {
-			return fmt.Errorf("rollback suffixed resurrection of %s: %w", baseURI, delErr)
+			return fmt.Errorf("rollback suffixed node for %s: %w", baseURI, delErr)
+		}
+		if rerr != nil {
+			return fmt.Errorf("verify base %s after insert: %w", baseURI, rerr)
 		}
 		return ErrRetractedTarget
 	}

--- a/internal/store/nodes_test.go
+++ b/internal/store/nodes_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -349,4 +350,37 @@ func testDB(t *testing.T) *DB {
 	}
 	t.Cleanup(func() { db.Close() })
 	return db
+}
+
+// TestUpsertNode_RefusesRetractedTarget pins the store-level invariant that
+// upsert never resurrects a tombstone — the atomic backstop behind the engine's
+// caller-side guards (closes the check-then-write race with a concurrent
+// retraction). Covers both mergeable (in-place overwrite) and immutable
+// (suffixed-duplicate) shapes.
+func TestUpsertNode_RefusesRetractedTarget(t *testing.T) {
+	db := testDB(t)
+
+	for _, tc := range []struct{ uri, category string }{
+		{"mem://user/preferences/merge-me", "preferences"}, // mergeable
+		{"mem://user/events/immutable-one", "events"},      // immutable
+	} {
+		seedNode(t, db, tc.uri, tc.category, "original content for "+tc.category)
+		if _, err := db.RetractNode(tc.uri, "forget this", ""); err != nil {
+			t.Fatalf("retract %s: %v", tc.uri, err)
+		}
+		before, _ := db.GetNodeByURI(tc.uri)
+
+		err := db.UpsertNode(&MemNode{
+			URI: tc.uri, NodeType: "leaf", Category: tc.category,
+			L0Abstract: "RESURRECTED content", L1Overview: "resurrected body content here.",
+		})
+		if !errors.Is(err, ErrRetractedTarget) {
+			t.Errorf("%s: UpsertNode into retracted target = %v, want ErrRetractedTarget", tc.uri, err)
+		}
+		after, _ := db.GetNodeByURI(tc.uri)
+		if after.L0Abstract != before.L0Abstract || !after.IsRetracted() {
+			t.Errorf("%s: retracted node mutated by upsert: before L0=%q retracted=%v, after L0=%q retracted=%v",
+				tc.uri, before.L0Abstract, before.IsRetracted(), after.L0Abstract, after.IsRetracted())
+		}
+	}
 }


### PR DESCRIPTION
## What & why

The retracted-PII-resurrection gate (`findRetractedMatches`) previously ran on **only one** write path — `Remember`. The paths that create *most* memories bypassed it entirely, so retracted (e.g. PII) content could silently resurface even with the stable embedder from #46:

- **Auto-extraction** (`extractMemories`, via Stop/SessionEnd hooks) ran only `findSimilarNode` — which intentionally skips retracted nodes — then wrote the candidate as a fresh live node.
- **Signal** (`ExtractSignal`, the "remember this" keyword path) wrote directly, no gate.
- **`Remember` failed *open*** if the gate errored (logged and proceeded).
- While the vector identity was **locked**, extraction wrote ungated.

This wires the gate onto every write path and makes the whole thing fail closed.

## What changed

- **Per-candidate gate on extraction + signal** — a candidate matching a retracted memory (or that errors the gate) is **skipped**, without dropping the rest of the batch (the batch is non-interactive, so one bad candidate must not lose the others).
- **Locked identity → defer the whole batch** (fail closed); extraction defers *without* marking the session extracted, so it retries after `doctor --repair-vectors`.
- **`Remember` fails closed** on gate error; `--acknowledge-retracted` still bypasses.
- **Store-level atomic backstop**: `UpsertNode` returns `ErrRetractedTarget` for a retracted target; the mergeable in-place update is tombstone-guarded (`WHERE tombstoned_at IS NULL`) and the immutable suffixed-insert compensates (delete + fail closed) — closing the check-then-write race a concurrent `retract` could open.
- **Removed `merge_target` honoring** (durability over cleverness): trusting an LLM-supplied URI was the recurring gate-bypass surface (cross-category, raw-string variants, immutable targets — findings in 3 separate rounds). Dedup is now owned entirely by the system via `findSimilarNode`; a candidate always lands at its own canonical URI in its declared category. Zero LLM-controlled URIs enter the write path.

## Out of scope (documented)
- **Category-scoped retraction** (content retracted in category A reappearing as a category-B candidate) — pre-existing; applies to `Remember` too.
- **Relational profile write** — only ever targets the system-owned, un-retractable `mem://user/profile/communication` with a constant L0; no resurrection path (commented in code).
- Durable signal-retry during the lock window (it fails closed — drops, doesn't write ungated).

## Cross-model review (Codex, 6 rounds, converged → CLEAN)
Findings shrank from "gate doesn't run on most paths" → cross-category bypass / TOCTOU → raw-URI variants → fail-open-on-error → trivial fail-closed hardening. Every fix is pinned by a regression test (`internal/engine/gate_coverage_test.go`, `internal/store/nodes_test.go`). Full suite + `go vet` green.

Builds on #46 (stable embedder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
