### PR TITLE
fix: stop the Haiku extractor from roaming the filesystem

### DIFF
--- a/internal/cli/service_darwin.go
+++ b/internal/cli/service_darwin.go
@@ -47,6 +47,7 @@ func generatePlist() (string, error) {
 		return "", fmt.Errorf("home dir: %w", err)
 	}
 	logPath := filepath.Join(home, ".continuity", "serve.log")
+	workDir := filepath.Join(home, ".continuity")
 
 	// Bake a usable PATH into the plist so the service can find the LLM provider
 	// binaries (`claude`, `ollama`); launchd does not inherit the login PATH.
@@ -66,6 +67,8 @@ func generatePlist() (string, error) {
         <key>PATH</key>
         <string>%s</string>
     </dict>
+    <key>WorkingDirectory</key>
+    <string>%s</string>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
@@ -76,7 +79,7 @@ func generatePlist() (string, error) {
     <string>%s</string>
 </dict>
 </plist>
-`, xmlEscape(launchAgentLabel), xmlEscape(self), xmlEscape(servicePATH()), xmlEscape(logPath), xmlEscape(logPath)), nil
+`, xmlEscape(launchAgentLabel), xmlEscape(self), xmlEscape(servicePATH()), xmlEscape(workDir), xmlEscape(logPath), xmlEscape(logPath)), nil
 }
 
 func platformServiceStatus() (installed bool, status string) {

--- a/internal/cli/service_linux.go
+++ b/internal/cli/service_linux.go
@@ -33,6 +33,7 @@ func generateUnit() (string, error) {
 		return "", fmt.Errorf("home dir: %w", err)
 	}
 	logPath := filepath.Join(home, ".continuity", "serve.log")
+	workDir := filepath.Join(home, ".continuity")
 
 	// Bake a usable PATH into the unit so the service can find the LLM provider
 	// binaries (`claude`, `ollama`); systemd does not inherit the login PATH.
@@ -49,6 +50,7 @@ After=network.target
 [Service]
 Type=simple
 Environment="PATH=%s"
+WorkingDirectory=%s
 ExecStart=%s serve
 Restart=on-failure
 RestartSec=5
@@ -57,7 +59,7 @@ StandardError=append:%s
 
 [Install]
 WantedBy=default.target
-`, escapeSystemdEnvValue(servicePATH()), self, logPath, logPath), nil
+`, escapeSystemdEnvValue(servicePATH()), workDir, self, logPath, logPath), nil
 }
 
 // escapeSystemdEnvValue escapes a value for inclusion inside a double-quoted

--- a/internal/llm/claude_cli.go
+++ b/internal/llm/claude_cli.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -32,6 +33,12 @@ func (c *ClaudeCLI) Complete(ctx context.Context, prompt string) (*Response, err
 	cmd := exec.CommandContext(ctx, "claude", "-p", "--model", c.model, "--max-turns", "1")
 	cmd.Stdin = strings.NewReader(prompt)
 
+	// Pin the subprocess to a dedicated empty directory. Without this, claude -p
+	// inherits the server's cwd (which is "/" under launchd) and treats it as a
+	// project root — roaming the filesystem and tripping macOS TCC prompts for
+	// Photos, Music, etc. An empty sandbox dir gives it nothing to scan.
+	cmd.Dir = sandboxDir()
+
 	// Strip CLAUDE_* env vars to prevent recursive hook triggering
 	cmd.Env = filterEnv(os.Environ())
 
@@ -47,6 +54,21 @@ func (c *ClaudeCLI) Complete(ctx context.Context, prompt string) (*Response, err
 		Content:  strings.TrimSpace(stdout.String()),
 		Provider: "claude-cli",
 	}, nil
+}
+
+// sandboxDir returns a dedicated empty directory under the continuity home for
+// claude -p to run in, so it has no surrounding project to scan. Falls back to
+// the system temp dir if the home directory can't be resolved or created.
+func sandboxDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return os.TempDir()
+	}
+	dir := filepath.Join(home, ".continuity", "sandbox")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return os.TempDir()
+	}
+	return dir
 }
 
 // filterEnv removes CLAUDE_* environment variables to prevent recursive hooks.


### PR DESCRIPTION
## Problem

The Haiku extractor spawns `claude -p` as a subprocess. Under launchd (macOS) and systemd (Linux), the `continuity serve` process runs with cwd `/` — no `WorkingDirectory` was ever set — and the subprocess inherited it. Claude CLI treats its working directory as a project root and scans outward, so from `/` (or home) it bumps into `~/Pictures`, `~/Music`, and friends, tripping macOS TCC consent prompts. Watching continuity ask for Photos access is jarring.

## Fix

**Authoritative, platform-agnostic** — `internal/llm/claude_cli.go` sets `cmd.Dir` to a dedicated empty `~/.continuity/sandbox`. With nothing surrounding it, `claude -p` has nothing to roam into. This holds regardless of how the server was launched.

**Defense-in-depth** so the server's own cwd is never `/`:
- `service_darwin.go` — launchd plist gains `WorkingDirectory` = `~/.continuity`
- `service_linux.go` — systemd unit gains `WorkingDirectory` = `~/.continuity`

Both service generators share the same `workDir` pattern to stay in lockstep.

## Verification

- `go build ./...` + `go vet` clean (macOS)
- `GOOS=linux go build ./internal/cli/` clean
- `internal/llm` tests pass

## Deploy note

Existing installs need the new binary (the `cmd.Dir` change is what stops the roaming) and a `continuity install-service` re-run to refresh the plist/unit with `WorkingDirectory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)